### PR TITLE
Extend deployment for LXC containers

### DIFF
--- a/deploymentByVitam/roles/mongo_common/tasks/main.yml
+++ b/deploymentByVitam/roles/mongo_common/tasks/main.yml
@@ -94,6 +94,5 @@
         enabled: yes
         state: started
 
-  when: ( ansible_virtualization_type != "docker") and ( transparent_hugepage_dir.stat.isdir is defined and transparent_hugepage_dir.stat.isdir )
-
+  when: ( ansible_virtualization_type not in ["docker","lxc"]) and ( transparent_hugepage_dir.stat.isdir is defined and transparent_hugepage_dir.stat.isdir )
 


### PR DESCRIPTION
Exclude "systemd service unit to disable THP" tasks for deployments on LXC containers.