### PR TITLE
[TECH] Use a property for RPM REPOSITORY URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1281,7 +1281,7 @@
                                     <executable>${maven.multiModuleProjectDirectory}/tools/packaging/publish.sh</executable>
                                     <workingDirectory>target</workingDirectory>
                                     <arguments>
-                                        <argument>https://repo.vitamui.com/upload/${rpm.publication.env}/Packages</argument>
+                                        <argument>${env.SERVICE_RPM_REPOSITORY_URL}/upload/${rpm.publication.env}/Packages</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
## Description (utilisé pour la release note)

L'URL du repository RPM était mis en dur dans la configuration.
ET c'était compliqué de le surcharger sur un autre environnement autre que vitam.


## Type de changement:

* Build 

