### PR TITLE
[DLAB-4126] Fix Apache's deployment: update of remaining assets of th…

### DIFF
--- a/deployment/roles/reverse/tasks/apache.yml
+++ b/deployment/roles/reverse/tasks/apache.yml
@@ -102,17 +102,6 @@
     - "key"
   when: (vitam_reverse_external_protocol is defined) and (vitam_reverse_external_protocol == 'https')
 
-#OMA: if problem with apache2 restart due to absent pem, manually remove on reverse the above p12 file and relaunch playbook
-- name: copy certificate
-  copy:
-    src: "{{ inventory_dir }}/keystores/client-iam/keystore_reverse.p12"
-    dest: "/etc/{{ apache_service }}/certs/keystore_client_{{ vitam_site_name }}.p12"
-    owner: "root"
-    mode: 0400
-  notify:
-    - extract certificate
-    - set certificate attributes
-
 - name: Copy the CA
   copy:
     src: "{{ item }}"
@@ -120,7 +109,7 @@
     owner: "root"
     mode: 0400
   with_fileglob:
-    - "{{ inventory_dir }}/certs/client-iam/ca/*.crt"
+    - "{{ inventory_dir }}/certs/server/ca/*.crt"
 
 - name: copy httpd configuration template
   template:

--- a/deployment/roles/reverse/templates/apache/httpd_config
+++ b/deployment/roles/reverse/templates/apache/httpd_config
@@ -25,8 +25,6 @@
 
     # Enable SSL for the Reverse proxy
     SSLProxyEngine on
-    # Client certificate path
-    # SSLProxyMachineCertificateFile /etc/{{apache_service}}/certs/keystore_client_{{ vitam_site_name }}.pem
     # Client CA path
     SSLProxyCACertificatePath /etc/{{apache_service}}/ca/{{ vitam_site_name }}
     # Don't check the CN of the server's certificate


### PR DESCRIPTION
# VitamUI - Hotfix sur le déploiement reverse Apache
## Description

La pull request actuelle corrige un problème de déploiement suite à la PR #27. 
En effet, il subsistait une référence à l'ancienne PKI dans les scripts de déploiement du reverse Apache. 

## Type de changement:
* Ansiblerie

## Tests
Test de déploiement effectués avec le reverse Apache.
