### PR TITLE
Readonly mongo setting

### DIFF
--- a/deployment/README.rst
+++ b/deployment/README.rst
@@ -141,7 +141,9 @@ Fichier ``vitamui_vars.yml``
 "A la vitam", permet le paramétrage des différents composants de vitam-ui.
 
 La section ``vitamui_platform_informations`` permet de définir une première entité, ainsi que quelques comptes "administrateur".
-
+La propriété system_readonly_setting permet de définir si les éléments liés au compte système qui correspondent aux configurations de l'instance sont modifiables ou pas.
+Si le paramètre est à true, les entités correspondantes ne sont pas modifiables par API et sont affichées comme non modifiables sur les interfaces graphiques.
+Attention, cette propriété doit être surchargée pour définir le comportement souhaité.
 
 Surcharge
 ----------

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -242,3 +242,4 @@ vitamui_platform_informations:
   proof_tenant: 3
   cas_tenant: -1
   first_customer_tenant: 9
+  system_readonly_setting: false

--- a/deployment/scripts/mongod/1.0.0/01_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/01_iam_ref.js.j2
@@ -24,7 +24,7 @@ db.customers.insert({
   "description": "{{ vitamui_platform_informations.description }}",
   "companyName": "{{ vitamui_platform_informations.company_name }}",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "subrogeable": false,
   "language": "FRENCH",
   "passwordRevocationDelay": NumberInt(1),
@@ -45,7 +45,7 @@ db.owners.insert({
   "_id": "system_owner",
   "identifier" : NumberInt(1),
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "code": "000001",
   "name": "system_owner",
   "companyName": "system_company",
@@ -62,7 +62,7 @@ db.owners.insert({
   "_id": "system_owner_cas",
   "identifier" : NumberInt(2),
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "code": "000002",
   "name": "system_owner_cas",
   "companyName": "system_owner_cas",
@@ -84,7 +84,7 @@ db.providers.insert({
   "name": "system_idp",
   "internal": true,
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "patterns": [
     "admin.*@{{ vitamui_platform_informations.default_email_domain }}", "support.*@{{ vitamui_platform_informations.default_email_domain }}", "superadmin.*@{{ vitamui_platform_informations.default_email_domain }}"
   ],
@@ -147,23 +147,8 @@ db.tenants.insert({
   "name": "Tenant système",
   "proof": true,
   "enabled": true,
-  "readonly": false,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": NumberInt({{ vitamui_platform_informations.proof_tenant }}),
-  "ownerId": "system_owner",
-  "customerId": "system_customer",
-  "ingestContractHoldingIdentifier" : "IC-000001",
-  "itemIngestContractIdentifier" : "IC-000001",
-  "accessContractHoldingIdentifier" : "AC-000001",
-  "accessContractLogbookIdentifier" : "AC-000002"
-});
-
-db.tenants.insert({
-  "_id": "auto_tenant",
-  "name": "Tenant Auto Referentiel",
-  "proof": true,
-  "enabled": true,
-  "readonly": false,
-  "identifier": NumberInt(2),
   "ownerId": "system_owner",
   "customerId": "system_customer",
   "ingestContractHoldingIdentifier" : "IC-000001",
@@ -176,7 +161,7 @@ db.tenants.insert({
   "_id": "cas_tenant",
   "name": "Tenant CAS",
   "enabled": true,
-  "readonly": false,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": NumberInt({{ vitamui_platform_informations.cas_tenant }}),
   "ownerId": "system_owner_cas",
   "customerId": "system_customer"
@@ -195,7 +180,7 @@ db.profiles.insert({
   "tenantIdentifier": NumberInt({{ vitamui_platform_informations.proof_tenant }}),
   "applicationName": "USERS_APP",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "level": "",
   "customerId": "system_customer",
   "roles": [{
@@ -234,7 +219,7 @@ db.profiles.insert({
   "applicationName": "GROUPS_APP",
   "enabled": true,
   "level": "",
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [{
     "name": "ROLE_GET_GROUPS"
@@ -266,7 +251,7 @@ db.profiles.insert({
   "applicationName": "PROFILES_APP",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [{
     "name": "ROLE_GET_PROFILES"
@@ -295,7 +280,7 @@ db.profiles.insert({
   "applicationName": "CUSTOMERS_APP",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [{
     "name": "ROLE_GET_CUSTOMERS"
@@ -372,7 +357,7 @@ db.profiles.insert({
   "applicationName": "SUBROGATIONS_APP",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [{
     "name": "ROLE_GET_SUBROGATIONS"
@@ -405,7 +390,7 @@ db.profiles.insert({
   "applicationName": "ACCOUNTS_APP",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [
     {
@@ -423,7 +408,7 @@ db.profiles.insert({
   "applicationName": "HIERARCHY_PROFILE_APP",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [
     {
@@ -826,7 +811,7 @@ db.profiles.insert({
   "applicationName": "",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [{
     "name": "ROLE_GET_USERS"
@@ -870,7 +855,7 @@ db.profiles.insert({
   "applicationName": "",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": []
 });
@@ -888,7 +873,7 @@ db.profiles.insert({
   "applicationName": "ACCOUNTS_APP",
   "level": "SUPPORT",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [
     {
@@ -907,7 +892,7 @@ db.profiles.insert({
   "applicationName": "SUBROGATIONS_APP",
   "level": "SUPPORT",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "customerId": "system_customer",
   "roles": [{
     "name": "ROLE_GET_SUBROGATIONS"
@@ -940,7 +925,7 @@ db.groups.insert({
   "name": "Groupe de l'administrateur VitamUI",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "description": "Groupe de l'administrateur VitamUI",
   "profileIds": [
     "system_user_profile",
@@ -971,7 +956,7 @@ db.groups.insert({
   "name": "Groupe de l'adminstrateur de l'instance",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "description": "Groupe de l'adminstrateur de l'instance",
   "profileIds": [
     "system_customer_profile",
@@ -989,7 +974,7 @@ db.groups.insert({
   "name": "Groupe de l'utilisateur support",
   "level": "SUPPORT",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "description": "Acces à la subrogation",
   "profileIds": [
     "system_surrogate_profile_support",
@@ -1006,7 +991,7 @@ db.groups.insert({
   "name": "Groupe d'accès à IAM",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "description": "Groupe d'accès à IAM",
   "profileIds": [
     "cas_profile",
@@ -1023,7 +1008,7 @@ db.users.insert({
   "_id": "admin_user",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": "1",
   "password": "{{ vitamui_platform_informations.default_password }}",
   "email": "admin@{{ vitamui_platform_informations.default_email_domain }}",
@@ -1048,7 +1033,7 @@ db.users.insert({
   "_id": "superadmin_user",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": "2",
   "password": "{{ vitamui_platform_informations.default_password }}",
   "email": "superadmin@{{ vitamui_platform_informations.default_email_domain }}",
@@ -1075,7 +1060,7 @@ db.users.insert({
   "_id": "support_user",
   "level": "SUPPORT",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": "3",
   "password": "{{ vitamui_platform_informations.default_password }}",
   "email": "support@{{ vitamui_platform_informations.default_email_domain }}",
@@ -1102,7 +1087,7 @@ db.users.insert({
   "_id": "casuser",
   "level": "",
   "enabled": true,
-  "readonly": true,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": "4",
   "password": "{{ vitamui_platform_informations.default_password }}",
   "email": "cas@{{ vitamui_platform_informations.default_email_domain }}",

--- a/deployment/scripts/mongod/1.0.0/101_iam_client1_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_client1_demo.js
@@ -167,7 +167,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
@@ -200,7 +200,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
@@ -230,7 +230,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
@@ -248,7 +248,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
@@ -275,7 +275,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
@@ -302,7 +302,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
@@ -329,7 +329,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });

--- a/deployment/scripts/mongod/1.0.0/101_iam_client2_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_client2_demo.js
@@ -139,7 +139,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
@@ -172,7 +172,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
@@ -203,7 +203,7 @@ db.profiles.insert(
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
@@ -222,7 +222,7 @@ db.profiles.insert(
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
@@ -250,7 +250,7 @@ db.profiles.insert(
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
@@ -278,7 +278,7 @@ db.profiles.insert(
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": false,
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });

--- a/deployment/scripts/mongod/1.0.0/101_iam_system_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_system_demo.js
@@ -95,7 +95,7 @@ db.owners.insert({
 	"_id": "system_owner_externe",
 	"identifier" : NumberInt(5),
 	"enabled": true,
-	"readonly": true,
+	"readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
 	"code": "000006",
 	"name": "system_owner externe",
 	"companyName": "system_company",
@@ -149,7 +149,7 @@ db.profiles.insert({
 		}
 	],
 	"level": "",
-	"readonly": true,
+	"readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
 	"customerId": "system_customer",
 	"_class": "profiles"
 });

--- a/deployment/scripts/mongod/1.0.0/207_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/207_iam_ref.js.j2
@@ -10,7 +10,7 @@ db.tenants.insert({
   "name": "Tenant Auto Referentiel",
   "proof": true,
   "enabled": true,
-  "readonly": false,
+  "readonly": {{ vitamui_platform_informations.system_readonly_setting  | lower  }},
   "identifier": NumberInt(maxIdTenant + 1),
   "ownerId": "system_owner",
   "customerId": "system_customer",

--- a/integration-tests/src/test/resources/application-dev.yml
+++ b/integration-tests/src/test/resources/application-dev.yml
@@ -74,3 +74,4 @@ vitamui_platform_informations:
   first_customer_tenant: 9
   system_archive_tenant_identifier: 9
   client1_tenant_identifier: 102
+  system_readonly_setting: false

--- a/integration-tests/src/test/resources/application-integration.yml
+++ b/integration-tests/src/test/resources/application-integration.yml
@@ -74,4 +74,5 @@ vitamui_platform_informations:
   first_customer_tenant: 9
   system_archive_tenant_identifier: 9
   client1_tenant_identifier: 102
+  system_readonly_setting: false
 

--- a/tools/docker/mongo/mongo_vars_dev.yml
+++ b/tools/docker/mongo/mongo_vars_dev.yml
@@ -75,6 +75,7 @@ vitamui_platform_informations:
   proof_tenant: 1
   cas_tenant: -1
   first_customer_tenant: 9
+  system_readonly_setting: false
 
 # ----------------------------------------------------------------------------------------------------------------------
 # cas services cert value override


### PR DESCRIPTION
## Description
Les données Mongo correspondantes au client système et qui sont centrales dans la solution VITAM-UI étaient mises en readonly.
Ce paramètre est une protection qui a été mise en oeuvre afin d'éviter des modifications de données pouvant casser la mise en oeuvre ou l'intégrité du système.

Suite à une demande du CEA, cette propriété est désormais paramétrable et peut-être changée via le paramètre ansible 'system_readonly_setting' qui se trouve dans 'vitamui_platform_informations'.
Comme valeur par défaut nous permettrons de changer les informations systèmes.

## Type de changement:
*  Configuration : Nouvelle fonctionnalité
*  Ansiblerie

## Documentation:
[X] Quels sont les modifications existantes ?
README et documentation d'architecture technique

## Tests:
Tests via les interfaces.
Visualisation des données.

## Checklist:
[x] J'ai fait les changements correspondant dans la documentation Technique.
[x] Les tests unitaires nouveaux et existants passent avec succès localement.