### PR TITLE
[CEA/Vitam] Fix deployment and configuration

### DIFF
--- a/api/api-referential/referential-internal/src/main/config/dev-vitam/ingest-external-client.conf
+++ b/api/api-referential/referential-internal/src/main/config/dev-vitam/ingest-external-client.conf
@@ -4,8 +4,8 @@ secure: true
 sslConfiguration :
  keystore :
   - keyPath: src/main/config/dev-vitam/keystore_ihm-demo.p12
-    keyPassword: FaKzJrnQFxFe3D2d
+    keyPassword: azerty4
  truststore :
   - keyPath: src/main/config/dev-vitam/truststore_ihm-demo.jks
-    keyPassword: K8GeuGNjfbFB66JG
+    keyPassword: azerty10
 hostnameVerification: true

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -148,11 +148,6 @@ vitamui:
     secure: true
     jvm_log: false
     logging_level: "INFO"
-    theme:
-      vitamui_platform_name: VITAM-UI
-      vitamui_favicon: "{{ vitamui_defaults.folder.root_path }}/conf/assets/favicon.ico"
-      vitam_logo: "{{ vitamui_defaults.folder.root_path }}/conf/assets/logo.png"
-      vitamui_logo_large: "{{ vitamui_defaults.folder.root_path }}/conf/assets/logo-large.png"
     log:
       logback_max_file_size: "10MB"
       logback_max_history: 30
@@ -215,6 +210,11 @@ vitamui:
     secure: true
     jvm_log: false
     logging_level: "INFO"
+    theme:
+      vitamui_platform_name: VITAM-UI
+      vitamui_favicon: "{{ vitamui_defaults.folder.root_path }}/conf/assets/favicon.ico"
+      vitam_logo: "{{ vitamui_defaults.folder.root_path }}/conf/assets/logo.png"
+      vitamui_logo_large: "{{ vitamui_defaults.folder.root_path }}/conf/assets/logo-large.png"
     log:
       logback_max_file_size: "10MB"
       logback_max_history: 30

--- a/deployment/roles/vitamui/templates/referential-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-external/application.yml.j2
@@ -41,7 +41,7 @@ management:
       enabled: false
 
 server-identity:
-  identityName: {{ vitamui_env_name }}
+  identityName: {{ vitamui_site_name }}
   identityRole: {{ vitamui_struct.vitamui_component }}
   identityServerId: 1
 

--- a/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
@@ -35,7 +35,7 @@ management:
       enabled: false
 
 server-identity:
-  identityName: {{ vitamui_env_name }}
+  identityName: {{ vitamui_site_name }}
   identityRole: {{ vitamui_struct.vitamui_component }}
   identityServerId: 1
 

--- a/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
@@ -43,7 +43,7 @@ logging:
     config: {{ vitamui_folder_conf }}/logback.xml
 
 server-identity:
-  identityName: {{ vitamui_env_name }}
+  identityName: {{ vitamui_site_name }}
   identityRole: {{ vitamui_struct.vitamui_component }}
   identityServerId: 1
 

--- a/deployment/vitamui_referential.yml
+++ b/deployment/vitamui_referential.yml
@@ -11,12 +11,13 @@
     - checks
     - normalize
     - users
-
-- import_playbook: stop_vitamui.yml
-
-- import_playbook: mongo_update_scripts.yml
-
-- import_playbook: start_vitamui.yml
+# TODO VITAM : decide if referential should be always installed, if not adapt mongo database script verisonning for additional modules
+#
+#- import_playbook: stop_vitamui.yml
+#
+#- import_playbook: mongo_update_scripts.yml
+#
+#- import_playbook: start_vitamui.yml
 
 - import_playbook: app_referential.yml
 


### PR DESCRIPTION
### **Description générale**

La PR correspond à des corrections liées au déploiement sutie à l'intégration des PR #41 et PR #38  .

### **Modifications apportées**

* Ajout d'une valeur par défaut de  la variable 'theme' dans la configuration ansible du module 'cas-server' et suppression de celle du module 'referential-internal'
* Adaptation quick&dirty du script de déploiement ansible des modules 'referential'  (todo : adapter le versionning de script mongos spécifiques à des modules optionnel)
* Remplacement de vitamui_env_name par vitamui_site_name dans les scripts ansible
* Fix de la configuration par défaut vitam pour le dev du module 'referential-internal'


### **Type de changement:**

- Correctif
- Configuration Dev
- Ansiblerie

### **Tests**
Testé sur environnement smile et vitam

### **Contributeur**

Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
Programme Vitam
