### PR TITLE
Bump npm registry fetch from 4.0.4 to 4.0.7

### DIFF
--- a/ui/ui-frontend-common/package-lock.json
+++ b/ui/ui-frontend-common/package-lock.json
@@ -541,52 +541,18 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "8.3.26",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.26.tgz",
-      "integrity": "sha512-IoZbXVFGLvVi5d0ozfssWDXuzot0/pMSKbQPzWIG8K7nCo7nNMVYpsMHrEVYUikA9EQEL5LqMCGohH36/zVPcA==",
+      "version": "8.3.29",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.29.tgz",
+      "integrity": "sha512-AFJ9EK0XbcNlO5Dm9vr0OlBo1Nw6AaFXPR+DmHGBdcDDHxqEmYYLWfT+JU/8U2YFIdgrtlwvdtf6UQ3V2jdz1g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "8.3.26",
+        "@angular-devkit/core": "8.3.29",
         "rxjs": "6.4.0"
       },
       "dependencies": {
-        "@angular-devkit/core": {
-          "version": "8.3.26",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.26.tgz",
-          "integrity": "sha512-b1ng9091o33s55/cwQYh1kboiJtj8y8z8xQWATDI9kRmNIQkWYVwVa/MzgPRJ4bzbEGG3zIUHCsp52A6vuGr2A==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.10.2",
-            "fast-json-stable-stringify": "2.0.0",
-            "magic-string": "0.25.3",
-            "rxjs": "6.4.0",
-            "source-map": "0.7.3"
-          }
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "magic-string": {
-          "version": "0.25.3",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/magic-string/-/magic-string-0.25.3.tgz",
-          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
         "rxjs": {
           "version": "6.4.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/rxjs/-/rxjs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
           "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
           "dev": true,
           "requires": {
@@ -613,16 +579,16 @@
       }
     },
     "@angular/cli": {
-      "version": "8.3.26",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-8.3.26.tgz",
-      "integrity": "sha512-/dZik0ALcMSNaZdzqeG5hnFqyezrPQlWv+NXPidp1l0VTIwdEmjWmL26QpSBBvZ9bqXjY5/5SZYb+zZlGu78Kg==",
+      "version": "8.3.29",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-8.3.29.tgz",
+      "integrity": "sha512-pW+iU0eKHIae+A1b9W5g8DKefMQcehZ+drGKs4Hryh8G+XGFS00BIWkmh6c1mydWTEhdsFlhdjD/rXCem7MAQQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.803.26",
-        "@angular-devkit/core": "8.3.26",
-        "@angular-devkit/schematics": "8.3.26",
-        "@schematics/angular": "8.3.26",
-        "@schematics/update": "0.803.26",
+        "@angular-devkit/architect": "0.803.29",
+        "@angular-devkit/core": "8.3.29",
+        "@angular-devkit/schematics": "8.3.29",
+        "@schematics/angular": "8.3.29",
+        "@schematics/update": "0.803.29",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "^4.1.1",
@@ -640,101 +606,39 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "@angular-devkit/architect": {
-          "version": "0.803.26",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.26.tgz",
-          "integrity": "sha512-mCynDvhGLElmuiaK5I6hVleMuZ1Svn7o5NnMW1ItiDlVZu1v49JWOxPS1A7C/ypGmhjl9jMorVtz2IumtLgCXw==",
-          "dev": true,
-          "requires": {
-            "@angular-devkit/core": "8.3.26",
-            "rxjs": "6.4.0"
-          }
-        },
-        "@angular-devkit/core": {
-          "version": "8.3.26",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.26.tgz",
-          "integrity": "sha512-b1ng9091o33s55/cwQYh1kboiJtj8y8z8xQWATDI9kRmNIQkWYVwVa/MzgPRJ4bzbEGG3zIUHCsp52A6vuGr2A==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.10.2",
-            "fast-json-stable-stringify": "2.0.0",
-            "magic-string": "0.25.3",
-            "rxjs": "6.4.0",
-            "source-map": "0.7.3"
-          }
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-colors": {
           "version": "4.1.1",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
           "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "magic-string": {
-          "version": "0.25.3",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/magic-string/-/magic-string-0.25.3.tgz",
-          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
+            "ms": "2.1.2"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "open": {
-          "version": "6.4.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/open/-/open-6.4.0.tgz",
-          "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-          "dev": true,
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
-        },
         "rimraf": {
           "version": "3.0.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/rimraf/-/rimraf-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
           "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
-        "rxjs": {
-          "version": "6.4.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/rxjs/-/rxjs-6.4.0.tgz",
-          "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -3261,68 +3165,23 @@
       }
     },
     "@schematics/angular": {
-      "version": "8.3.26",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.26.tgz",
-      "integrity": "sha512-NJCykMxB9RKL+Tmr9xHftUevsivKGsQZQKjkub528wrSgwrCWoFCxGWV31iOXkT3TlBWmuibH6MZkrWbCLX4Sw==",
+      "version": "8.3.29",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.29.tgz",
+      "integrity": "sha512-If+UhCsQzCgnQymiiF8dQRoic34+RgJ6rV0n4k7Tm4N2xNYJOG7ajjzKM7PIeafsF50FKnFP8dqaNGxCMyq5Ew==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "8.3.26",
-        "@angular-devkit/schematics": "8.3.26"
-      },
-      "dependencies": {
-        "@angular-devkit/core": {
-          "version": "8.3.26",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.26.tgz",
-          "integrity": "sha512-b1ng9091o33s55/cwQYh1kboiJtj8y8z8xQWATDI9kRmNIQkWYVwVa/MzgPRJ4bzbEGG3zIUHCsp52A6vuGr2A==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.10.2",
-            "fast-json-stable-stringify": "2.0.0",
-            "magic-string": "0.25.3",
-            "rxjs": "6.4.0",
-            "source-map": "0.7.3"
-          }
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "magic-string": {
-          "version": "0.25.3",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/magic-string/-/magic-string-0.25.3.tgz",
-          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
-        "rxjs": {
-          "version": "6.4.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/rxjs/-/rxjs-6.4.0.tgz",
-          "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        }
+        "@angular-devkit/core": "8.3.29",
+        "@angular-devkit/schematics": "8.3.29"
       }
     },
     "@schematics/update": {
-      "version": "0.803.26",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.803.26.tgz",
-      "integrity": "sha512-r284UN3HP/UgxK80SG3MDlbF4qPS6EitEqwdSBqXizUYRlV6ovG9vHMLpNruWE0B6vfYbSAn1YvvIwW/ORL1Cw==",
+      "version": "0.803.29",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.803.29.tgz",
+      "integrity": "sha512-Syf6h6DYeu1WU9aLihMwIgVASpcHCxUYqhZyHfQABiK8NkdlZ+KAp4cOxihsZyDqIJNLWON+0/FLPAQF3BXh5Q==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "8.3.26",
-        "@angular-devkit/schematics": "8.3.26",
+        "@angular-devkit/core": "8.3.29",
+        "@angular-devkit/schematics": "8.3.29",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "1.3.5",
         "pacote": "9.5.5",
@@ -3331,43 +3190,9 @@
         "semver-intersect": "1.4.0"
       },
       "dependencies": {
-        "@angular-devkit/core": {
-          "version": "8.3.26",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.26.tgz",
-          "integrity": "sha512-b1ng9091o33s55/cwQYh1kboiJtj8y8z8xQWATDI9kRmNIQkWYVwVa/MzgPRJ4bzbEGG3zIUHCsp52A6vuGr2A==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.10.2",
-            "fast-json-stable-stringify": "2.0.0",
-            "magic-string": "0.25.3",
-            "rxjs": "6.4.0",
-            "source-map": "0.7.3"
-          }
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "magic-string": {
-          "version": "0.25.3",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/magic-string/-/magic-string-0.25.3.tgz",
-          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
         "rxjs": {
           "version": "6.4.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/rxjs/-/rxjs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
           "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
           "dev": true,
           "requires": {
@@ -3376,7 +3201,7 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -3510,7 +3335,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://nexus.teamdlab.com/repository/npm/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -6484,12 +6309,23 @@
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://nexus.teamdlab.com/repository/npm/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -7430,7 +7266,7 @@
     },
     "fs-minipass": {
       "version": "1.2.7",
-      "resolved": "https://nexus.teamdlab.com/repository/npm/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "requires": {
@@ -8682,6 +8518,12 @@
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
+    },
     "is-npm": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
@@ -9102,6 +8944,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -9902,70 +9750,6 @@
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
         "ssri": "^6.0.0"
-      },
-      "dependencies": {
-        "cacache": {
-          "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-          "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "mamacro": {
@@ -10937,9 +10721,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.4.tgz",
-      "integrity": "sha512-6jb34hX/iYNQebqWUHtU8YF6Cjb1H6ouTFPClYsyiW6lpFkljTpdeftm53rRojtja1rKAvKNIIiTS5Sjpw4wsA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
+      "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",
@@ -10953,7 +10737,7 @@
       "dependencies": {
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         }
@@ -11091,13 +10875,60 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://nexus.dev.programmevitam.fr/repository/npm-group/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "object.pick": {
@@ -11140,9 +10971,9 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://nexus.teamdlab.com/repository/npm/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
@@ -11356,45 +11187,6 @@
         "which": "^1.3.1"
       },
       "dependencies": {
-        "cacache": {
-          "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-          "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.6",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
-          }
-        },
         "npm-pick-manifest": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
@@ -12506,14 +12298,13 @@
       }
     },
     "read-package-json": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-      "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "json-parse-better-errors": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.0",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
       }
@@ -12894,7 +12685,7 @@
     },
     "retry": {
       "version": "0.10.1",
-      "resolved": "https://nexus.teamdlab.com/repository/npm/retry/-/retry-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
       "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true
     },
@@ -14043,7 +13834,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://nexus.teamdlab.com/repository/npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -14074,7 +13865,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://nexus.teamdlab.com/repository/npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -14461,7 +14252,7 @@
     },
     "tar": {
       "version": "4.4.13",
-      "resolved": "https://nexus.teamdlab.com/repository/npm/tar/-/tar-4.4.13.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
       "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "requires": {
@@ -14723,7 +14514,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://nexus.teamdlab.com/repository/npm/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
@@ -15139,30 +14930,68 @@
       }
     },
     "universal-analytics": {
-      "version": "0.4.20",
-      "resolved": "https://nexus.teamdlab.com/repository/npm/universal-analytics/-/universal-analytics-0.4.20.tgz",
-      "integrity": "sha512-gE91dtMvNkjO+kWsPstHRtSwHXz0l2axqptGYp5ceg4MsuurloM0PU3pdOfpb5zBXUvyjT4PwhWK2m39uczZuw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.23.tgz",
+      "integrity": "sha512-lgMIH7XBI6OgYn1woDEmxhGdj8yDefMKg7GkWdeATAlQZFrMrNyxSkpDzY57iY0/6fdlzTbBV03OawvvzG+q7A==",
       "dev": true,
       "requires": {
-        "debug": "^3.0.0",
-        "request": "^2.88.0",
+        "debug": "^4.1.1",
+        "request": "^2.88.2",
         "uuid": "^3.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://nexus.teamdlab.com/repository/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
         }
       }
     },
@@ -16057,7 +15886,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://nexus.teamdlab.com/repository/npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -16209,7 +16038,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://nexus.teamdlab.com/repository/npm/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }

--- a/ui/ui-frontend-common/package.json
+++ b/ui/ui-frontend-common/package.json
@@ -68,7 +68,7 @@
     "@angular-builders/custom-webpack": "^8.4.1",
     "@angular-devkit/build-angular": "^0.803.29",
     "@angular-devkit/build-ng-packagr": "^0.900.2",
-    "@angular/cli": "^8.3.26",
+    "@angular/cli": "^8.3.29",
     "@angular/compiler-cli": "8.2.14",
     "@angular/language-service": "8.0.0",
     "@types/jasmine": "~3.3.0",

--- a/ui/ui-frontend/package-lock.json
+++ b/ui/ui-frontend/package-lock.json
@@ -14805,7 +14805,7 @@
     },
     "ui-frontend-common": {
       "version": "file:../ui-frontend-common/ui-frontend-common-1.0.13.tgz",
-      "integrity": "sha512-Twn6Rd/mKxHyqmdYjtnMrvB2vfKRMIc3Oson4VZGQJzOZLBgqyT4ZXySQpwW0F0p3WjHWeHp7w7nYl0G+hl7yQ==",
+      "integrity": "sha512-8mGKmU3uaCPHChNuyZ31RRL2rUGk/zjrcZIFKbkTMBzWpnW9t8nBSLUKoVjwXq0JGLRKblg3WJXX8GzrH4teYQ==",
       "requires": {
         "@angular/animations": "8.2.14",
         "@angular/cdk": "^8.2.3",

--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -100,7 +100,7 @@
     "@angular-builders/custom-webpack": "^8.4.1",
     "@angular-devkit/build-angular": "^0.803.29",
     "@angular-devkit/build-ng-packagr": "^0.900.2",
-    "@angular/cli": "^8.3.26",
+    "@angular/cli": "^8.3.29",
     "@angular/compiler-cli": "8.2.14",
     "@angular/language-service": "8.0.0",
     "@types/jasmine": "~3.3.0",


### PR DESCRIPTION
## Description
Bumps [npm-registry-fetch](https://github.com/npm/npm-registry-fetch) from 4.0.4 to 4.0.7.

## Type de changement:

<p><em>Sourced from <a href="https://github.com/npm/npm-registry-fetch/blob/v4.0.7/CHANGELOG.md">npm-registry-fetch's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/npm/registry-fetch/compare/v4.0.6...v4.0.7">4.0.7</a> (2020-08-17)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>correct password redaction (<a href="https://github.com/npm/registry-fetch/commit/110032b">110032b</a>)</li>
</ul>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2><a href="https://github.com/npm/registry-fetch/compare/v4.0.5...v4.0.6">4.0.6</a> (2020-08-14)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>import URL from url module (<a href="https://github.com/npm/registry-fetch/commit/cd35987">cd35987</a>)</li>
</ul>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2><a href="https://github.com/npm/registry-fetch/compare/v4.0.4...v4.0.5">4.0.5</a> (2020-06-30)</h2>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
</blockquote>
</details>


## Dépendances liées:
| Package  | Version |
| ------------- | ------------- |
| @angular/cli | 8.3.29  |
| pacote  | 9.5.5 |
|npm-registry-fetch|4.0.7|

## Contributeur

Vitam Accessible en Service (VAS)