### PR TITLE
upgrade junit version from 4.13 to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,10 @@
         <jaxb.core.version>2.3.0.1</jaxb.core.version>
         <jaxb.impl.version>3.0.0-M1</jaxb.impl.version>
         <jlibs.version>2.2.3</jlibs.version>
-        <junit.version>4.13</junit.version>
-        <junit.jupiter.version>5.5.0</junit.jupiter.version>
-        <junit.jupiter.platform.version>1.5.0</junit.jupiter.platform.version>
+        <junit.version>4.13.1</junit.version>
+        <junit.jupiter.version>5.7.0</junit.jupiter.version>
+        <junit.jupiter.platform.version>1.7.0</junit.jupiter.platform.version>
+        <junit.vintage.engine.version>5.7.0</junit.vintage.engine.version>
         <jruby.complete.version>1.7.26</jruby.complete.version>
         <jsonassert.version>1.5.0</jsonassert.version>
         <logback.version>1.2.3</logback.version>
@@ -972,6 +973,13 @@
                 <version>${junit.jupiter.platform.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.vintage.engine.version}</version>
+                <scope>test</scope>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.easymock</groupId>


### PR DESCRIPTION
## Description
Upgrade Junit version from 4.13 to 4.13.1

## Type de changement:
Modification de la version de Junit pour des raisons de sécurité.

## Tests:
L'ensemble des tests unitaires passent correctement après cette montée en version.

## Dépendances liées:
La montée de version de Junit de 4.13 vers 4.13.1 nécessite aussi la monté de version de :

* **junit-jupiter** vers la version 5.7.0.
* **junit-jupiter-platform** : vers la version 1.7.0.
* Spécifier la bonne version de **junit-vintage-engine** : version 5.7.0 (par défaut on a la version 5.5.2 qui viens avec la dépendance de spring-boot-starter-test mais qui n'est pas compatible avec la nouvelle version de Junit(4.13.1)).

## Contributeur
Vitam Accessible en Service (VAS)