### PR TITLE
change nist urls

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,6 @@ pipeline {
             }
             environment {
                 PUPPETEER_DOWNLOAD_HOST="${env.SERVICE_NEXUS_URL}/repository/puppeteer-chrome/"
-                JAVA_TOOL_OPTIONS=""
             }
             steps {
                 sh 'npmrc default'

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
         <maven.asciidoctor.plugin.version>2.0.0</maven.asciidoctor.plugin.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.dependencycheck.version>5.2.2</maven.dependencycheck.version>
+        <maven.dependencycheck.version>5.3.0</maven.dependencycheck.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <maven.failsafe.plugin.version>2.21.0</maven.failsafe.plugin.version>
@@ -1106,8 +1106,10 @@
                 <version>${maven.dependencycheck.version}</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <cveUrlModified>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.0-modified.json.gz</cveUrlModified>
-                    <cveUrlBase>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.0-%d.json.gz</cveUrlBase>
+                    <!--<cveUrlModified>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.0-modified.json.gz</cveUrlModified>
+                    <cveUrlBase>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.0-%d.json.gz</cveUrlBase>-->
+                    <cveUrlModified>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</cveUrlModified>
+                    <cveUrlBase>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</cveUrlBase>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                     <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                     <failOnError>false</failOnError>


### PR DESCRIPTION
Description

Depuis le 1er janvier 2021, le mirroir nist n'est plus fonctionnel. Pour remédier au problème temporairement on utilise les urls
officiels.

Tests:

L'étape checkvulnerabilité du build vitamui se déroule correctement.

Contributeur

OPS 