### PR TITLE
[VAS] Ascii doctor vulnerability fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <apache.commons.codec.version>1.14</apache.commons.codec.version>
         <apache.pdfbox.version>2.0.16</apache.pdfbox.version>
         <apache.pdfbox.xmpbox.version>2.0.16</apache.pdfbox.xmpbox.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <assertj.version>3.15.0</assertj.version>
         <bouncycastle.version>1.65</bouncycastle.version>
         <cas.version>6.1.6</cas.version>


### PR DESCRIPTION
## Description
Bumps [asciidoctor-maven-plugin](https://mvnrepository.com/artifact/org.asciidoctor/asciidoctor-maven-plugin) from 1.5.0-alpha.16 to 1.5.3.

## Contributeur

Vitam Accessible en Service (VAS)