### PR TITLE
[VAS] Item 7389 Fix Maven Check Vulnerabilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
             }
             environment {
                 PUPPETEER_DOWNLOAD_HOST="${env.SERVICE_NEXUS_URL}/repository/puppeteer-chrome/"
+                JAVA_TOOL_OPTIONS=""
             }
             steps {
                 sh 'npmrc default'

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
         <maven.asciidoctor.plugin.version>2.0.0</maven.asciidoctor.plugin.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.dependencycheck.version>5.3.0</maven.dependencycheck.version>
+        <maven.dependencycheck.version>6.1.1</maven.dependencycheck.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <maven.directory.plugin.version>0.1</maven.directory.plugin.version>
@@ -1157,10 +1157,8 @@
                 <version>${maven.dependencycheck.version}</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <!--<cveUrlModified>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.0-modified.json.gz</cveUrlModified>
-                    <cveUrlBase>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.0-%d.json.gz</cveUrlBase>-->
-                    <cveUrlModified>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                    <cveUrlBase>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</cveUrlBase>
+                    <cveUrlModified>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.1-modified.json.gz</cveUrlModified>
+                    <cveUrlBase>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.1-%d.json.gz</cveUrlBase>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                     <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                     <failOnError>false</failOnError>


### PR DESCRIPTION
## Description
Bump and Fix maven check dependency [maven-check-dependency](https://github.com/jeremylong/DependencyCheck) from 5.3.0 to 6.1.1.
## Type de changement:
- Update library
- Update [feeds](https://nvd.nist.gov/vuln/data-feeds) from nvdcve-1.0 to [nvdcve-1.1](https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz)
- Jenkins file configuration

## Contributeur

Vitam Accessible en Service (VAS)