### PR TITLE
[VAS] item 7547 Téléchargement du binaire de l'UA - Changement du nom

### DIFF
--- a/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/config/ArchiveSearchInternalServerConfig.java
+++ b/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/config/ArchiveSearchInternalServerConfig.java
@@ -49,7 +49,7 @@ import org.springframework.context.annotation.Import;
 @Import({RestExceptionHandler.class, SwaggerConfiguration.class,
     fr.gouv.vitamui.archive.internal.server.security.WebSecurityConfig.class,
     VitamAccessConfig.class, VitamAdministrationConfig.class, ConverterConfig.class})
-public class ArchiveInternalServerConfig extends AbstractContextConfiguration {
+public class ArchiveSearchInternalServerConfig extends AbstractContextConfiguration {
 
     @Bean
     @ConfigurationProperties(prefix = "clients.iam-internal")

--- a/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/rest/ArchiveSearchInternalController.java
+++ b/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/rest/ArchiveSearchInternalController.java
@@ -34,7 +34,7 @@ import fr.gouv.vitam.common.database.builder.request.exception.InvalidCreateOper
 import fr.gouv.vitam.common.database.builder.request.multiple.SelectMultiQuery;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
-import fr.gouv.vitamui.archive.internal.server.service.ArchiveInternalService;
+import fr.gouv.vitamui.archive.internal.server.service.ArchiveSearchInternalService;
 import fr.gouv.vitamui.archives.search.common.dto.ArchiveUnitsDto;
 import fr.gouv.vitamui.archives.search.common.dto.SearchCriteriaDto;
 import fr.gouv.vitamui.archives.search.common.rest.RestApi;
@@ -74,15 +74,15 @@ import static fr.gouv.vitam.common.database.builder.query.VitamFieldsHelper.unit
 @Getter
 @Setter
 @Api(tags = "archives search", value = "Archives units search")
-public class ArchiveInternalController {
+public class ArchiveSearchInternalController {
 
     private static final VitamUILogger LOGGER =
-        VitamUILoggerFactory.getInstance(ArchiveInternalController.class);
+        VitamUILoggerFactory.getInstance(ArchiveSearchInternalController.class);
 
     private static final String[] FILING_PLAN_PROJECTION =
         new String[] {"#id", "Title", "Title_", "DescriptionLevel", "#unitType", "#unitups", "#allunitups"};
 
-    private ArchiveInternalService archiveInternalService;
+    private ArchiveSearchInternalService archiveInternalService;
 
     private InternalSecurityService securityService;
 
@@ -90,7 +90,7 @@ public class ArchiveInternalController {
     private ObjectMapper objectMapper;
 
     @Autowired
-    public ArchiveInternalController(final ArchiveInternalService archiveInternalService,
+    public ArchiveSearchInternalController(final ArchiveSearchInternalService archiveInternalService,
         final InternalSecurityService securityService) {
         this.archiveInternalService = archiveInternalService;
         this.securityService = securityService;

--- a/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/service/ArchiveSearchInternalService.java
+++ b/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/service/ArchiveSearchInternalService.java
@@ -72,9 +72,9 @@ import java.util.stream.Collectors;
  * Archive-Search Internal service communication with VITAM.
  */
 @Service
-public class ArchiveInternalService {
+public class ArchiveSearchInternalService {
     private static final VitamUILogger LOGGER =
-        VitamUILoggerFactory.getInstance(ArchiveInternalService.class);
+        VitamUILoggerFactory.getInstance(ArchiveSearchInternalService.class);
     public static final String INGEST_ARCHIVE_TYPE = "INGEST";
     public static final String ORIGINATING_AGENCY_LABEL_FIELD = "originating_agency_label";
     public static final String ORIGINATING_AGENCY_ID_FIELD = "#originating_agency";
@@ -90,7 +90,7 @@ public class ArchiveInternalService {
     final private AgencyService agencyService;
 
     @Autowired
-    public ArchiveInternalService(final ObjectMapper objectMapper, final UnitService unitService,
+    public ArchiveSearchInternalService(final ObjectMapper objectMapper, final UnitService unitService,
         final AgencyService agencyService) {
         this.unitService = unitService;
         this.objectMapper = objectMapper;

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/config/ApiArchiveSearchInternalServerConfigTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/config/ApiArchiveSearchInternalServerConfigTest.java
@@ -24,31 +24,28 @@
  * accept its terms.
  */
 
-package fr.gouv.vitamui.archive.internal.server.rest;
+package fr.gouv.vitamui.archive.internal.server.config;
 
 import fr.gouv.vitam.access.external.client.AccessExternalClient;
 import fr.gouv.vitam.access.external.client.AdminExternalClient;
 import fr.gouv.vitam.ingest.external.client.IngestExternalClient;
-import fr.gouv.vitamui.archive.internal.server.service.ArchiveInternalService;
-import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
-import fr.gouv.vitamui.commons.test.utils.ServerIdentityConfigurationBuilder;
-import fr.gouv.vitamui.iam.security.provider.InternalApiAuthenticationProvider;
-import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
-import org.junit.BeforeClass;
+import fr.gouv.vitamui.archive.internal.server.service.ArchiveSearchInternalService;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@WebMvcTest(controllers = {ArchiveInternalControllerTest.class})
-@ActiveProfiles("test")
-public class ArchiveInternalControllerTest {
 
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@TestPropertySource(properties = {"spring.config.name=archive-search-internal-application"})
+@ActiveProfiles("test")
+public class ApiArchiveSearchInternalServerConfigTest {
 
     @MockBean(name = "adminExternalClient")
     private AdminExternalClient adminExternalClient;
@@ -59,25 +56,11 @@ public class ArchiveInternalControllerTest {
     @MockBean(name = "ingestExternalClient")
     private IngestExternalClient ingestExternalClient;
 
-    @MockBean
-    private InternalApiAuthenticationProvider internalApiAuthenticationProvider;
-
-    @Mock
-    private InternalSecurityService internalSecurityService;
-
-    @MockBean
-    private RestExceptionHandler restExceptionHandler;
-
-    @InjectMocks
-    private ArchiveInternalService archiveInternalService;
-
-    @BeforeClass
-    public static void setup() {
-        ServerIdentityConfigurationBuilder.setup("identityName", "identityRole", 1, 0);
-    }
+    @Autowired
+    private ArchiveSearchInternalService archiveSearchInternalService;
 
     @Test
-    public void testBasicArchive() {
+    public void testArchiveInternalConf() {
+        Assert.assertNotNull(archiveSearchInternalService);
     }
-
 }

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/doc/SwaggerJsonFileGenerationTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/doc/SwaggerJsonFileGenerationTest.java
@@ -30,7 +30,7 @@ package fr.gouv.vitamui.archive.internal.server.doc;
 import fr.gouv.vitam.access.external.client.AccessExternalClient;
 import fr.gouv.vitam.access.external.client.AdminExternalClient;
 import fr.gouv.vitamui.archive.internal.server.service.AccessContractTempInternalService;
-import fr.gouv.vitamui.archive.internal.server.service.ArchiveInternalService;
+import fr.gouv.vitamui.archive.internal.server.service.ArchiveSearchInternalService;
 import fr.gouv.vitamui.commons.api.identity.ServerIdentityConfiguration;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.commons.rest.configuration.SwaggerConfiguration;
@@ -72,7 +72,7 @@ public class SwaggerJsonFileGenerationTest extends AbstractSwaggerJsonFileGenera
     private AuthenticationProvider authenticationProvider;
 
     @MockBean
-    private ArchiveInternalService archiveInternalService;
+    private ArchiveSearchInternalService archiveSearchInternalService;
 
     @MockBean
     private AccessContractTempInternalService accessContractTempInternalService;

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/rest/ArchiveSearchInternalControllerTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/rest/ArchiveSearchInternalControllerTest.java
@@ -24,28 +24,31 @@
  * accept its terms.
  */
 
-package fr.gouv.vitamui.archive.internal.server.config;
+package fr.gouv.vitamui.archive.internal.server.rest;
 
 import fr.gouv.vitam.access.external.client.AccessExternalClient;
 import fr.gouv.vitam.access.external.client.AdminExternalClient;
 import fr.gouv.vitam.ingest.external.client.IngestExternalClient;
-import fr.gouv.vitamui.archive.internal.server.service.ArchiveInternalService;
-import org.junit.Assert;
+import fr.gouv.vitamui.archive.internal.server.service.ArchiveSearchInternalService;
+import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
+import fr.gouv.vitamui.commons.test.utils.ServerIdentityConfigurationBuilder;
+import fr.gouv.vitamui.iam.security.provider.InternalApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@TestPropertySource(properties = {"spring.config.name=archive-search-internal-application"})
+@WebMvcTest(controllers = {ArchiveSearchInternalControllerTest.class})
 @ActiveProfiles("test")
-public class ApiArchiveInternalServerConfigTest {
+public class ArchiveSearchInternalControllerTest {
+
 
     @MockBean(name = "adminExternalClient")
     private AdminExternalClient adminExternalClient;
@@ -56,11 +59,25 @@ public class ApiArchiveInternalServerConfigTest {
     @MockBean(name = "ingestExternalClient")
     private IngestExternalClient ingestExternalClient;
 
-    @Autowired
-    private ArchiveInternalService archiveInternalService;
+    @MockBean
+    private InternalApiAuthenticationProvider internalApiAuthenticationProvider;
+
+    @Mock
+    private InternalSecurityService internalSecurityService;
+
+    @MockBean
+    private RestExceptionHandler restExceptionHandler;
+
+    @InjectMocks
+    private ArchiveSearchInternalService archiveSearchInternalService;
+
+    @BeforeClass
+    public static void setup() {
+        ServerIdentityConfigurationBuilder.setup("identityName", "identityRole", 1, 0);
+    }
 
     @Test
-    public void testArchiveInternalConf() {
-        Assert.assertNotNull(archiveInternalService);
+    public void testBasicArchive() {
     }
+
 }

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/service/ArchiveSearchInternalServiceTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/service/ArchiveSearchInternalServiceTest.java
@@ -64,10 +64,10 @@ import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
-public class ArchiveInternalServiceTest {
+public class ArchiveSearchInternalServiceTest {
 
     private static final VitamUILogger LOGGER =
-        VitamUILoggerFactory.getInstance(ArchiveInternalServiceTest.class);
+        VitamUILoggerFactory.getInstance(ArchiveSearchInternalServiceTest.class);
 
     @MockBean(name = "objectMapper")
     private ObjectMapper objectMapper;
@@ -79,14 +79,14 @@ public class ArchiveInternalServiceTest {
     private AgencyService agencyService;
 
     @InjectMocks
-    private ArchiveInternalService archiveInternalService;
+    private ArchiveSearchInternalService archiveSearchInternalService;
 
     public final String FILING_HOLDING_SCHEME_RESULTS = "data/vitam_filing_holding_units_response.json";
 
     @Before
     public void setUp() {
         ServerIdentityConfigurationBuilder.setup("identityName", "identityRole", 1, 0);
-        archiveInternalService = new ArchiveInternalService(objectMapper, unitService, agencyService);
+        archiveSearchInternalService = new ArchiveSearchInternalService(objectMapper, unitService, agencyService);
     }
 
     @Test(expected = InvalidParseOperationException.class)
@@ -105,7 +105,7 @@ public class ArchiveInternalServiceTest {
         when(unitService.searchUnits(any(), any()))
             .thenReturn(buildUnitMetadataResponse(FILING_HOLDING_SCHEME_RESULTS));
         // When
-        JsonNode jsonNode = archiveInternalService.searchUnits(any(), any());
+        JsonNode jsonNode = archiveSearchInternalService.searchUnits(any(), any());
 
         // Configure the mapper
         ObjectMapper objectMapper = new ObjectMapper();
@@ -123,7 +123,7 @@ public class ArchiveInternalServiceTest {
         throws IOException, InvalidParseOperationException {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        InputStream inputStream = ArchiveInternalServiceTest.class.getClassLoader()
+        InputStream inputStream = ArchiveSearchInternalServiceTest.class.getClassLoader()
             .getResourceAsStream(filename);
         return RequestResponseOK
             .getFromJsonNode(objectMapper.readValue(ByteStreams.toByteArray(inputStream), JsonNode.class));

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.html
@@ -105,7 +105,7 @@
           <div class="col-12">
             <button class="btn secondary download-btn" [disabled]="archiveUnit['#object'] == null"
                     (click)="onDownloadObjectFromUnit(archiveUnit)">
-              <i class="vitamui-icon vitamui-icon-download"></i> <span>{{'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.DOWNLOAD_DOC' | translate}}</span>
+              <i class="vitamui-icon vitamui-icon-deposit"></i> <span>{{'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.DOWNLOAD_DOC' | translate}}</span>
             </button>
           </div>
         </div>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.scss
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.scss
@@ -1,13 +1,9 @@
 
 .download-btn{
-    width: 218px;
-    height: 50px;
-    background: #702382;
     border-radius: 100px;
     color: white;
     font-size: 14px;
     font-weight: bold;
-    letter-spacing: 0.1px;
-    text-decoration-line: underline;
     margin: 20px;
+    margin-left: 120px;
 }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.ts
@@ -30,7 +30,6 @@ export class ArchivePreviewComponent  implements OnInit {
 
   }
 
-
   ngOnInit() {
 
     }
@@ -40,7 +39,7 @@ export class ArchivePreviewComponent  implements OnInit {
     let headers = new HttpHeaders().append('Content-Type', 'application/json');
     headers = headers.append('X-Access-Contract-Id', this.accessContract);
 
-   return  this.archiveService.downloadObjectFromUnit(archiveUnit['#id'], headers);
+   return  this.archiveService.downloadObjectFromUnit(archiveUnit['#id'], archiveUnit.Title, headers);
   }
 
   emitClose() {

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
@@ -153,7 +153,7 @@ export class ArchiveService extends SearchService<any> {
     return pagedResult;
   }
 
-  downloadObjectFromUnit(id : string , headers?: HttpHeaders) {
+  downloadObjectFromUnit(id : string , name : string,  headers?: HttpHeaders) {
 
     return this.archiveApiService.downloadObjectFromUnit(id, headers).subscribe(
 
@@ -161,7 +161,7 @@ export class ArchiveService extends SearchService<any> {
 
         const element = document.createElement('a');
         element.href = window.URL.createObjectURL(file);
-        element.download ='item-'+id;
+        element.download =name;
         element.style.visibility = 'hidden';
         document.body.appendChild(element);
         element.click();


### PR DESCRIPTION
## Description
L'objectif du l'US est de changer le nom du binaire  téléchargé et qu'il s'affiche sous le nom "Title " (Intitulé) sur le poste de l'utilisateur.
Modification/renommage des classes au niveau de la partie archivesearch-internal (de archive vers archiveSearch).

## Type de changement:
* Nouveau Code.
* Correction.

## Documentation:

## Tests:
TU.

## Migration:
Pas de modification DB, pas de nouvelle APP, pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.
[X] Toutes les dépendances ont été mergées en priorité.

## Contributeur
Vitam Accessible en Service (VAS)