### PR TITLE
Update iteritems() function to items() to be fully compatible with Python 2 & 3

### DIFF
--- a/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
@@ -102,7 +102,7 @@ ui-archive-search:
     archive-search: "{{ url_prefix }}/archive-search"
 {% endif %}
   portal-categories:
-{% for id, category in vitamui_defaults.portal_categories.iteritems() %}
+{% for id, category in vitamui_defaults.portal_categories.items() %}
     {{ id }}:
       title: "{{ category.title }}"
       displayTitle: {{ category.displayTitle }}

--- a/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
@@ -83,7 +83,7 @@ ui-identity:
     vitamui-header-footer: "{{ vitamui_platform_informations.theme.theme_colors.vitamui_header_footer }}"
     vitamui-background: "{{ vitamui_platform_informations.theme.theme_colors.vitamui_background }}"
   portal-categories:
-{% for id, category in vitamui_defaults.portal_categories.iteritems() %}
+{% for id, category in vitamui_defaults.portal_categories.items() %}
     {{ id }}:
       title: "{{ category.title }}"
       displayTitle: {{ category.displayTitle }}

--- a/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
@@ -65,7 +65,7 @@ ui-identity:
     vitamui-header-footer: "{{ vitamui_platform_informations.theme.theme_colors.vitamui_header_footer }}"
     vitamui-background: "{{ vitamui_platform_informations.theme.theme_colors.vitamui_background }}"
   portal-categories:
-{% for id, category in vitamui_defaults.portal_categories.iteritems() %}
+{% for id, category in vitamui_defaults.portal_categories.items() %}
     {{ id }}:
       title: "{{ category.title }}"
       displayTitle: {{ category.displayTitle }}

--- a/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
@@ -104,7 +104,7 @@ ui-ingest:
     ingest: "{{ url_prefix }}/ingest"
 {% endif %}
   portal-categories:
-{% for id, category in vitamui_defaults.portal_categories.iteritems() %}
+{% for id, category in vitamui_defaults.portal_categories.items() %}
     {{ id }}:
       title: "{{ category.title }}"
       displayTitle: {{ category.displayTitle }}

--- a/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
@@ -76,7 +76,7 @@ ui-portal:
     vitamui-header-footer: "{{ vitamui_platform_informations.theme.theme_colors.vitamui_header_footer }}"
     vitamui-background: "{{ vitamui_platform_informations.theme.theme_colors.vitamui_background }}"
   portal-categories:
-{% for id, category in vitamui_defaults.portal_categories.iteritems() %}
+{% for id, category in vitamui_defaults.portal_categories.items() %}
     {{ id }}:
       title: "{{ category.title }}"
       displayTitle: {{ category.displayTitle }}

--- a/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
@@ -109,7 +109,7 @@ ui-referential:
     referential: "{{ url_prefix }}/referential"
 {% endif %}
   portal-categories:
-{% for id, category in vitamui_defaults.portal_categories.iteritems() %}
+{% for id, category in vitamui_defaults.portal_categories.items() %}
     {{ id }}:
       title: "{{ category.title }}"
       displayTitle: {{ category.displayTitle }}


### PR DESCRIPTION
Actuellement, il n'est pas possible de déployer entièrement Vitam-UI à l'aide d'une version Python3 associée à Ansible.

Ce correctif permet d'utiliser la fonction items() compatible avec Python2 & Python3 au lieu de iteritems() qui n'est compatible qu'avec Python2.

https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems

À CP sur R16.

Merci