### PR TITLE
[XEL] Add distributed tracing jaeger

### DIFF
--- a/api/api-iam/iam-external/pom.xml
+++ b/api/api-iam/iam-external/pom.xml
@@ -104,6 +104,10 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
 		<dependency>
 			<groupId>org.owasp.antisamy</groupId>

--- a/api/api-iam/iam-external/src/main/config/iam-external-application-dev.yml
+++ b/api/api-iam/iam-external/src/main/config/iam-external-application-dev.yml
@@ -46,6 +46,16 @@ iam-external:
     server-port: 7083
     secure: false
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui: DEBUG

--- a/api/api-iam/iam-internal/pom.xml
+++ b/api/api-iam/iam-internal/pom.xml
@@ -118,6 +118,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
 		<!-- PAC4J -->
 		<dependency>
@@ -167,6 +171,7 @@
 			<groupId>fr.gouv.vitam</groupId>
 			<artifactId>common-private</artifactId>
 		</dependency>
+
 
 		<!-- Apereo CAS Server Core Api Ticket -->
 		<dependency>

--- a/api/api-iam/iam-internal/src/main/config/iam-internal-application-dev.yml
+++ b/api/api-iam/iam-internal/src/main/config/iam-internal-application-dev.yml
@@ -64,6 +64,16 @@ vitam.tenant.init.mandatory: true
 
 customer.init.config.file: src/main/config/customer-init.yml
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui.commons.mongo.service: DEBUG

--- a/api/api-referential/referential-external/pom.xml
+++ b/api/api-referential/referential-external/pom.xml
@@ -100,8 +100,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
-		<!-- Metrics -->
+
+        <!-- Metrics -->
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>

--- a/api/api-referential/referential-external/src/main/config/referential-external-application-dev.yml
+++ b/api/api-referential/referential-external/src/main/config/referential-external-application-dev.yml
@@ -50,6 +50,16 @@ referential-external:
     server-port: 7087
     secure: false
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui: DEBUG

--- a/api/api-referential/referential-internal/pom.xml
+++ b/api/api-referential/referential-internal/pom.xml
@@ -103,8 +103,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
-		<!-- PDF generation -->
+
+        <!-- PDF generation -->
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>

--- a/api/api-referential/referential-internal/src/main/config/referential-internal-application-dev.yml
+++ b/api/api-referential/referential-internal/src/main/config/referential-internal-application-dev.yml
@@ -33,6 +33,16 @@ clients:
 swagger:
  file-path: file:../../../tools/swagger/docs/api-internal/referential-internal/swagger.json
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui.referential: DEBUG

--- a/api/api-security/security-internal/pom.xml
+++ b/api/api-security/security-internal/pom.xml
@@ -93,6 +93,10 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
         <!-- UTIL -->
         <dependency>

--- a/api/api-security/security-internal/src/main/config/security-internal-application-dev.yml
+++ b/api/api-security/security-internal/src/main/config/security-internal-application-dev.yml
@@ -25,4 +25,14 @@ management:
     ssl:
       enabled: false
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging.level.fr.gouv.vitamui: DEBUG

--- a/cas/cas-server/pom.xml
+++ b/cas/cas-server/pom.xml
@@ -277,6 +277,11 @@
             <artifactId>cas-server-support-saml-core</artifactId>
             <version>${cas.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
+
 
 
         <!-- OAuth support -->

--- a/cas/cas-server/src/main/config/cas-server-application-dev.yml
+++ b/cas/cas-server/src/main/config/cas-server-application-dev.yml
@@ -158,6 +158,16 @@ theme:
   secondary: '#241f63'
   background: '#0F0D2D'
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 debug: true
 logging:
   config: src/main/config/logback-dev.xml

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -420,3 +420,13 @@ mongo_backup_reinstall:
     collections: [ "customers","users","profiles", "groups" ]
   #- db: "admin"
   #  collections: []
+
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: false
+    log_spans: true
+    expand_exception_logs: true
+    udp_sender:
+      host: changeme
+      port: changeme

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -184,6 +184,15 @@ theme:
   secondary: '{{ vitamui_platform_informations.theme.theme_colors.vitamui_secondary }}'
   background: '{{ vitamui_platform_informations.theme.theme_colors.vitamui_background }}'
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}
+
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
   level:

--- a/deployment/roles/vitamui/templates/iam-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-external/application.yml.j2
@@ -74,3 +74,12 @@ iam-external:
 {% endif %}
 
 customer.init.config.file: {{ vitamui_folder_conf }}/customer-init.yml
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
@@ -99,3 +99,12 @@ logbook:
       delay: {{ vitamui_struct.logbook.delay }}
 
 customer.init.config.file: {{ vitamui_folder_conf }}/customer-init.yml
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/referential-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-external/application.yml.j2
@@ -93,3 +93,11 @@ referential-external:
       hostname-verification: false
 {% endif %}
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
@@ -56,3 +56,12 @@ clients:
         key-password:  {{ password_truststore }}
       hostname-verification: false
 {% endif %}
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/security-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/security-internal/application.yml.j2
@@ -42,3 +42,12 @@ management:
     port: {{ vitamui_struct.port_admin }}
     ssl:
       enabled: false
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
@@ -130,3 +130,12 @@ cas:
     trust-store-password: {{ password_truststore }}
     hostname-verification: {{ vitamui.cas_server.hostname_verification }}
 {% endif %}
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
@@ -127,3 +127,12 @@ cas:
     trust-store-password: {{ password_truststore }}
     hostname-verification: {{ vitamui.cas_server.hostname_verification }}
 {% endif %}
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
@@ -120,3 +120,12 @@ cas:
     trust-store-password: {{ password_truststore }}
     hostname-verification: {{ vitamui.cas_server.hostname_verification }}
 {% endif %}
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
@@ -153,3 +153,12 @@ list-enable-external-identifiers:
 {% endif %}
 {% endfor %}
 {% endif %}
+
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <http.core.version>4.4.13</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
         <jackson.version>2.11.0.rc1</jackson.version>
+        <jaeger.tracing.version>3.2.2</jaeger.tracing.version>
         <jakarta.xml.binding.version>2.3.2</jakarta.xml.binding.version>
         <javax.el.version.version>3.0.1-b06</javax.el.version.version>
         <javax.servlet.version>4.0.1</javax.servlet.version>
@@ -522,6 +523,11 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-tx</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+                <version>${jaeger.tracing.version}</version>
             </dependency>
 
             <!-- Security -->

--- a/tools/docker/jaeger/jaeger-docker-compose.yml
+++ b/tools/docker/jaeger/jaeger-docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.3"
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.20
+    ports:
+      - "8090:16686"
+      - "6831:6831/udp"

--- a/ui/ui-identity/pom.xml
+++ b/ui/ui-identity/pom.xml
@@ -93,6 +93,10 @@
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
 		<!-- Documentation -->
 		<dependency>

--- a/ui/ui-identity/src/main/config/ui-identity-application-dev.yml
+++ b/ui/ui-identity/src/main/config/ui-identity-application-dev.yml
@@ -98,6 +98,16 @@ cas:
     trust-store: ../../dev-deployment/environments/keystores/server/truststore_server.jks
     trust-store-password: changeme
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 # Uncomment if you want to use you specific logback config.
 #logging:
 # config: src/main/config/logback.xml

--- a/ui/ui-portal/pom.xml
+++ b/ui/ui-portal/pom.xml
@@ -88,6 +88,10 @@
         	<artifactId>spring-boot-devtools</artifactId>
         	<scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
         <!-- Documentation -->
         <dependency>

--- a/ui/ui-portal/src/main/config/ui-portal-application-dev.yml
+++ b/ui/ui-portal/src/main/config/ui-portal-application-dev.yml
@@ -98,6 +98,16 @@ cas:
     trust-store: ../../dev-deployment/environments/keystores/server/truststore_server.jks
     trust-store-password: changeme
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
     level:
         fr.gouv.vitamui: DEBUG

--- a/ui/ui-referential/pom.xml
+++ b/ui/ui-referential/pom.xml
@@ -88,6 +88,10 @@
             <artifactId>spring-boot-devtools</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
         <!-- Documentation -->
         <dependency>

--- a/ui/ui-referential/src/main/config/ui-referential-application-dev.yml
+++ b/ui/ui-referential/src/main/config/ui-referential-application-dev.yml
@@ -103,6 +103,16 @@ cas:
     trust-store: ../../dev-deployment/environments/keystores/server/truststore_server.jks
     trust-store-password: changeme
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui: DEBUG


### PR DESCRIPTION
## Description
Jaeger permet de tracer les transactions entre plusieurs services distribués. Jaeger utilise le traçage distribué pour suivre le chemin d'une requête au travers des différents microservices.

Dans une application, une requête unique peut appeler des dizaines de services différents qui interagissent les uns avec les autres.  Jaeger surveille les environnements de microservices complexes et permet d'en résoudre les problèmes.

## Type de changement
-  Configuration : Nouvelle fonctionnalité
-  Ansiblerie

## Tests

La configuration n'est activée que sur l'env de dev. Elle est testée via l'utilisation d'un docker compose intégré dans la PR.
Par défaut, Jaeger est désactivé sur les autres environnements et son déploiement est facultatif. 
Il n'a aucun impact sur l'existant.

## Contributeur

Xelians