### PR TITLE
[VAS] item 7975 : update json-Sanitizer and Bouncy Castle Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <apache.pdfbox.xmpbox.version>2.0.16</apache.pdfbox.xmpbox.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <assertj.version>3.15.0</assertj.version>
-        <bouncycastle.version>1.65</bouncycastle.version>
+        <bouncycastle.version>1.68</bouncycastle.version>
         <cas.version>6.1.6</cas.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.collections.version>3.2.2</commons.collections.version>
@@ -140,7 +140,7 @@
 		<xerces.version>2.12.0</xerces.version>
         <esapi.version>2.1.0.1</esapi.version>
         <antisamy.version>1.5.8</antisamy.version>
-        <json-sanitize.version>1.2.0</json-sanitize.version>
+        <json-sanitize.version>1.2.2</json-sanitize.version>
         <freemarker.upgraded.version>2.3.30</freemarker.upgraded.version>
 
         <!-- Web Pack -->


### PR DESCRIPTION
## Description
L'objectif de cette PR est de corriger quelque issue de sécurité remonté après l'audit de sécurité R16.
Du coup il est recommandé de s’assurer que l’ensemble des dépendances et des logiciels utilisés pour faire fonctionner le système ne présentent pas de vulnérabilités et sont à jour :
bcprov-jdk15on 1.65 -> bcprov-jdk15on 1.68 (criticité majeur)
json-sanitizer 1.2.0 -> json-sanitizer 1.2.2 (criticité majeur)

- json-sanitizer 1.2.0 -> json-sanitizer 1.2.2
le passage de 1.2.0 vers 1.2.2 ne touche pas aux fonctionnalités principales dans la classe JsonSanitizer qui sont utilisées dans le projet VitamUI.
- bcprov-jdk15on 1.65 -> bcprov-jdk15on 1.68
 Le passage de la version 1.65 vers la version 1.68 ne touche rien à part l'ajout des textes pour indiquer la version du BouncyCastleProvider utilisée. 
- Une revérification des tests unitaires au niveau du projet **commons** (modules :  `security` et `utils`) est bien effectuée avec succès.

## Documentation:
* Nouveau code

## Tests:
TU.

## Migration:
Pas de modification DB, pas de nouvelle APP, pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.
[X] Toutes les dépendances ont été mergées en priorité.

## Contributeur
Vitam Accessible en Service (VAS)