### PR TITLE
[VAS] Bug : fix start and end Date issue in ingest note

### DIFF
--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestGeneratorODTFile.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestGeneratorODTFile.java
@@ -440,6 +440,19 @@ public class IngestGeneratorODTFile {
         }
     }
 
+    private String getEndDate(List<String> listOfDate) {
+        if(listOfDate.size() > 0) {
+
+            String lastEndDate = listOfDate.stream().map(
+                endDate -> endDate.substring(0, endDate.indexOf("T")))
+                .sorted().collect(Collectors.toList())
+                .get(listOfDate.size()-1);
+
+            return transformDate(lastEndDate);
+        }
+        return "_ _ _ _";
+    }
+
     private Map<String, String> getSystemIdValues(Document document) {
 
         Map<String, String> map = new HashMap<>();
@@ -527,14 +540,12 @@ public class IngestGeneratorODTFile {
 
     private String getStartedDate(List<String> listOfDate) {
         if(listOfDate.size() > 0) {
-            return transformDate(listOfDate.get(0).split("T")[0]);
-        }
-        return "_ _ _ _";
-    }
 
-    private String getEndDate(List<String> listOfDate) {
-        if(listOfDate.size() > 0) {
-            return transformDate(listOfDate.get(listOfDate.size() - 1).split("T")[0]);
+           String firstStartDate =  listOfDate.stream().map(
+               startDate -> startDate.substring(0, startDate.indexOf("T")))
+               .sorted().findFirst().get();
+
+            return transformDate(firstStartDate);
         }
         return "_ _ _ _";
     }


### PR DESCRIPTION
## Description
L'objectif de cette PR est de corriger un problème lors de  construction du bordereau de versement à l'étape de récupération des dates extrêmes (Date de début et Date de fin) de chaque ingest uploadé.

## Documentation:
* Nouveau code
* Correction

## Tests:
TU.

## Migration:
Pas de modification DB, pas de nouvelle APP, pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.
[X] Toutes les dépendances ont été mergées en priorité.

## Contributeur
Vitam Accessible en Service (VAS)