### PR TITLE
[VAS] Bug 7095 : CSV import error message correction

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/vitamui-http-interceptor.ts
+++ b/ui/ui-frontend-common/src/app/modules/vitamui-http-interceptor.ts
@@ -58,7 +58,6 @@ const HTTP_STATUS_CODE_BAD_REQUEST = 400;
 const HTTP_STATUS_CODE_UNAUTHORIZED = 401;
 const HTTP_STATUS_CODE_FORBIDDEN = 403;
 const HTTP_STATUS_CODE_NOT_FOUND = 404;
-const HTTP_STATUS_CODE_PAYLOAD_TOO_LARGE = 413;
 const HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR = 500;
 const HTTP_STATUS_CODE_SERVICE_UNAVAILABLE = 503;
 const HTTP_STATUS_CODE_GATEWAY_TIMEOUT = 504;
@@ -180,13 +179,7 @@ export class VitamUIHttpInterceptor implements HttpInterceptor {
                 panelClass: 'vitamui-snack-bar',
                 duration: NOTIFICATION_DELAY_MS,
               });
-            } else if (response.status === HTTP_STATUS_CODE_PAYLOAD_TOO_LARGE) {
-                  this.snackBar.open('Erreur : Le seuil des résultats autorisés est dépassé, Veuillez affiner les filtres', null, {
-                    panelClass: 'vitamui-snack-bar',
-                    duration: NOTIFICATION_DELAY_MS,
-                  });
-              }
-             else if (response.status >= CLIENT_ERROR_START) {
+            } else if (response.status >= CLIENT_ERROR_START) {
               this.snackBar.open('Une erreur technique est survenue : requête invalide', null, {
                 panelClass: 'vitamui-snack-bar',
                 duration: NOTIFICATION_DELAY_MS,

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
@@ -260,7 +260,7 @@
 <div vitamuiCommonInfiniteScroll (vitamuiScroll)="loadMore()" *ngIf="submited">
   <div class="vitamui-table">
     <div class="vitamui-table-head">
-      <div class="col-8" *ngIf="totalResults > 1 || totalResults === 0 ">{{totalResults}} {{'ARCHIVE_SEARCH.RESULTS' | translate}}</div>
+      <div class="col-8" *ngIf="totalResults > 1 || totalResults === 0 ">{{totalResults}} {{'ARCHIVE_SEARCH.EXPORT_CSV.RESULTS' | translate}}</div>
       <div class="col-8" *ngIf="totalResults === 1">{{totalResults}} {{'ARCHIVE_SEARCH.RESULT' | translate}}</div>
       <div class="col-4 area-download" >
         <a class="hide-ink" (click)="exportArchiveUnitsToCsvFile()"

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -531,17 +531,14 @@ emptyForm = {
   exportArchiveUnitsToCsvFile() {
     
     if((this.searchedCriteriaList && this.searchedCriteriaList.length > 0) || (this.searchedCriteriaNodesList && this.searchedCriteriaNodesList.length > 0)) {
-      this.callVitamApiServiceToExport();
+      let sortingCriteria = { criteria: this.orderBy, sorting: this.direction }
+    let searchCriteria = { "nodes": this.searchedCriteriaNodesList, "criteriaList": this.searchedCriteriaList, "pageNumber": this.currentPage, size: PAGE_SIZE, 'sortingCriteria': sortingCriteria, 'language': this.translateService.currentLang };
+    this.archiveService.exportCsvSearchArchiveUnitsByCriteria(searchCriteria, this.accessContract);
     }
   }
 
 
 
-  private callVitamApiServiceToExport() {
-    let sortingCriteria = { criteria: this.orderBy, sorting: this.direction }
-    let searchCriteria = { "nodes": this.searchedCriteriaNodesList, "criteriaList": this.searchedCriteriaList, "pageNumber": this.currentPage, size: PAGE_SIZE, 'sortingCriteria': sortingCriteria, 'language': this.translateService.currentLang };
-    this.archiveService.exportCsvSearchArchiveUnitsByCriteria(searchCriteria, this.accessContract);
-  }
 
 
   get uaid() { return this.form.controls.uaid }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
@@ -44,6 +44,8 @@ import { FilingHoldingSchemeNode } from './models/node.interface';
 import { PagedResult, ResultFacet, SearchCriteriaDto } from './models/search.criteria';
 import { Unit } from './models/unit.interface';
 import { SearchResponse } from './models/search-response.interface';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { VitamUISnackBarComponent } from './shared/vitamui-snack-bar';
 
 
 @Injectable({
@@ -54,7 +56,8 @@ export class ArchiveService extends SearchService<any> {
   constructor(
     private archiveApiService: ArchiveApiService,
     http: HttpClient,
-    @Inject(LOCALE_ID) private locale: string
+    @Inject(LOCALE_ID) private locale: string,
+    private snackBar: MatSnackBar,
   ) {
     super(http, archiveApiService, 'ALL');
   }
@@ -136,7 +139,13 @@ export class ArchiveService extends SearchService<any> {
       },
       (errors: HttpErrorResponse) => {
         if(errors.status === 413){
-          console.log("Please update filter to reduce size of response" + errors.message)
+          console.log("Please update filter to reduce size of response" + errors.message);
+
+          this.snackBar.openFromComponent(VitamUISnackBarComponent, {
+            panelClass: 'vitamui-snack-bar',
+            data: { type: 'exportCsvLimitReached'},
+            duration: 10000
+          });
         }
       }
     );

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.html
@@ -77,9 +77,7 @@
       </div>
       <a *ngIf="filtered && !loadingHolding && nestedDataSourceFull.data.length > 0 && !linkOneToNotKeep "
          class="tree-show-link" (click)="showAllTreeNodes()"> {{'ARCHIVE_SEARCH.FILING_SHCEMA.SHOW_ENTIRE_TREE' |
-        translate}}</a>
-      <a *ngIf="!loadingHolding && nestedDataSourceFull.data.length > 0 && !linkTwoToNotKeep" class="tree-show-link"
-         (click)="showOnlyParentTreeNodes()">{{'ARCHIVE_SEARCH.FILING_SHCEMA.SHOW_TREE_PARENT' | translate}}</a>
+        translate}}</a>      
     </div>
 
     <div class="" *ngIf="loadingHolding">

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.ts
@@ -173,7 +173,6 @@ export class FilingHoldingSchemeComponent implements OnInit, OnChanges {
   }
 
   ngOnInit() {
-    this.initFilingHoldingSchemeTree();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -248,14 +247,6 @@ export class FilingHoldingSchemeComponent implements OnInit, OnChanges {
     this.filtered = false;
   }
 
-  showOnlyParentTreeNodes() {
-
-    this.initFilingHoldingSchemeTree();
-    this.linkOneToNotKeep = false;
-    this.linkTwoToNotKeep = true;
-
-  }
-
   recursiveShow(nodes: FilingHoldingSchemeNode[], show: boolean) {
     if (nodes.length === 0) { return; }
     for (const node of nodes) {
@@ -266,15 +257,19 @@ export class FilingHoldingSchemeComponent implements OnInit, OnChanges {
     }
   }
 
-  recursiveShowById(nodes: FilingHoldingSchemeNode[], checked: boolean, nodeId: string) {
-    if (nodes.length === 0) { return; }
+  recursiveShowById(nodes: FilingHoldingSchemeNode[], checked: boolean, nodeId: string): boolean {
+    let found = false; 
+    if (nodes.length !== 0){
     for (const node of nodes) {
       if (node.id === nodeId) {
         node.checked = checked;
+        found= true;
       }
-      if(node.children){
-        this.recursiveShowById(node.children, checked, nodeId);
+      if(!found && node.children){
+        found = this.recursiveShowById(node.children, checked, nodeId);
       }
+    }
+      return found;
     }
   }
 

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/shared/vitamui-snack-bar/vitamui-snack-bar.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/shared/vitamui-snack-bar/vitamui-snack-bar.component.html
@@ -7,8 +7,12 @@
       <br/>
       <span> (Merci de ne pas éteindre votre navigateur pendant le processus)</span>
     </ng-container>
+    <ng-container *ngSwitchCase="'exportCsvLimitReached'">      
+      <span> {{'ARCHIVE_SEARCH.EXPORT_CSV.EXPORT_CSV_LIMIT_REACHED' | translate}} </span>
+    </ng-container>
 
   </span>
+  
 
   <button class="close-btn" (click)="close()"><i class="material-icons">clear</i></button>
 

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/shared/vitamui-snack-bar/vitamui-snack-bar.module.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/shared/vitamui-snack-bar/vitamui-snack-bar.module.ts
@@ -37,11 +37,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import {TranslateModule} from '@ngx-translate/core';
 import { VitamUISnackBarComponent } from './vitamui-snack-bar.component';
 
 @NgModule({
   imports: [
     CommonModule,
+    TranslateModule
   ],
   declarations: [VitamUISnackBarComponent],
   exports: [VitamUISnackBarComponent],

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
@@ -72,6 +72,9 @@
       "SHOW_ENTIRE_TREE": "Show the entire tree",
       "SHOW_TREE_PARENT": "Collapse the tree"
     },
+    "EXPORT_CSV": {
+      "EXPORT_CSV_LIMIT_REACHED": "It's not possible to export more than 10 000 results, please update your filters."
+    },
     "RESULTS": "Results",
     "RESULT": "Result",
     "FOLDER": "Folder",

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
@@ -8,7 +8,6 @@
     "SEARCH_CRITERIA_OR": "OU",
     "SHOW_SEARCH_CRITERIA": "Afficher les filtres de recherche",
     "HIDE_SEARCH_CRITERIA": "Masquer les filtres de recherche",
-    "EXPORT_SEARCHS":"Exporter les résultats",
     "SHOW_MORE_RESULTS": "Afficher plus de résultats...",
     "NO_MORE_RESULTS": "Fin des résultats",
     "SEARCH_CRITERIA_FILTER": {
@@ -71,6 +70,10 @@
       "NO_TREES_NO_PLANS_FOR_ACCESS_CONTRACT": "Aucun Arbre ou Plan trouvés avec le contrat choisi",
       "SHOW_ENTIRE_TREE": "Afficher l'arborescence au complet",
       "SHOW_TREE_PARENT": "Réduire l'arborescence"
+    },
+    "EXPORT_CSV":{
+     "EXPORT_SEARCHS": "Exporter les résultats",
+     "EXPORT_CSV_LIMIT_REACHED":"Il n'est pas possible de réaliser un export csv sur plus de 10 000 résultats de recherche, veuillez restreindre votre sélection ou affiner votre recherche."
     },
     "RESULTS": "résultats",
     "RESULT": "résultat",


### PR DESCRIPTION
## Description
L'objectif de cette PR est de modifier la façon d'afficher le message d'erreur lors de l'export des résultats de recherche des unités archivistiques en CSV plus de 10000 resultats.
Enlever un double appel de recuperation de positions

Les tests unitaires vont venir après, dans une autre PR. 

## Type de changement:
* Front
* Correction

## Tests:
L'ensemble des tests unitaires coté JAVA ont été verifiés
Les nouveaux tests unitaires vont venir dans une autre PR.
Des tests manuels sont effectués sur VitamUI.

## Migration:
Pas de modification DB, pas de nouvelle APP, pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et lesméthodes difficile à comprendre.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.
[X] Toutes les dépendances ont été mergées en priorité

## Contributeur
Vitam Accessible en Service (VAS)