### PR TITLE
 [VAS] Item 8097 : Ajout de la configuration Jaeger dans les modules VAS

### DIFF
--- a/api/api-archive-search/archive-search-external/pom.xml
+++ b/api/api-archive-search/archive-search-external/pom.xml
@@ -97,7 +97,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
         <!-- Metrics -->
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/api/api-archive-search/archive-search-external/src/main/config/archive-search-external-application-dev.yml
+++ b/api/api-archive-search/archive-search-external/src/main/config/archive-search-external-application-dev.yml
@@ -54,6 +54,16 @@ archive-search-external:
     server-port: 7089
     secure: false
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui: DEBUG

--- a/api/api-archive-search/archive-search-internal/pom.xml
+++ b/api/api-archive-search/archive-search-internal/pom.xml
@@ -122,6 +122,14 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
         </dependency>
+
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
+
+
         <!-- TESTS -->
 
         <dependency>

--- a/api/api-archive-search/archive-search-internal/src/main/config/archive-search-internal-application-dev.yml
+++ b/api/api-archive-search/archive-search-internal/src/main/config/archive-search-internal-application-dev.yml
@@ -39,6 +39,16 @@ clients:
 swagger:
   file-path: file:../../../tools/swagger/docs/api-internal/archive-search-internal/swagger.json
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
+
 logging:
   level:
     fr.gouv.vitamui.archive: DEBUG

--- a/api/api-ingest/ingest-external/pom.xml
+++ b/api/api-ingest/ingest-external/pom.xml
@@ -20,6 +20,8 @@
     </properties>
 
     <dependencies>
+
+
         <!-- VITAMUI -->
         <dependency>
             <groupId>fr.gouv.vitamui.commons</groupId>
@@ -147,6 +149,12 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
+
 
         <!--TEST -->
         <dependency>

--- a/api/api-ingest/ingest-external/src/main/config/ingest-external-application-dev.yml
+++ b/api/api-ingest/ingest-external/src/main/config/ingest-external-application-dev.yml
@@ -5,7 +5,7 @@ spring:
     active: swagger
 
   cloud:
-    consul:  #disabled for dev
+    consul: #disabled for dev
       enabled: false
       discovery:
         enabled: false
@@ -52,6 +52,16 @@ ingest-external:
     server-host: localhost
     server-port: 7088
     secure: false
+
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
 
 logging:
   level:

--- a/api/api-ingest/ingest-internal/pom.xml
+++ b/api/api-ingest/ingest-internal/pom.xml
@@ -21,6 +21,7 @@
 
     <dependencies>
 
+
         <!-- VITAMUI -->
 
         <dependency>
@@ -154,6 +155,11 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
         </dependency>
 
         <!--TEST -->

--- a/api/api-ingest/ingest-internal/src/main/config/ingest-internal-application-dev.yml
+++ b/api/api-ingest/ingest-internal/src/main/config/ingest-internal-application-dev.yml
@@ -5,7 +5,7 @@ spring:
     active: swagger
 
   cloud:
-    consul:  #disabled for dev
+    consul: #disabled for dev
       enabled: false
       discovery:
         enabled: false
@@ -41,7 +41,17 @@ clients:
     server-port: 7083
 
 swagger:
- file-path: file:../../../tools/swagger/docs/api-internal/ingest-internal/swagger.json
+  file-path: file:../../../tools/swagger/docs/api-internal/ingest-internal/swagger.json
+
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831
 
 logging:
   level:

--- a/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
@@ -83,6 +83,16 @@ archive-search-external:
       hostname-verification: false
 {% endif %}
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}
+
+
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
   level:

--- a/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
@@ -52,6 +52,16 @@ clients:
       hostname-verification: false
 {% endif %}
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}
+
+
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
   level:

--- a/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
@@ -87,6 +87,16 @@ ingest-external:
       hostname-verification: false
 {% endif %}
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}
+
+
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
   level:

--- a/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
@@ -59,6 +59,16 @@ clients:
       hostname-verification: false
 {% endif %}
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}
+
+
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
   level:

--- a/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
@@ -135,3 +135,11 @@ cas:
 {% endif %}
 
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
@@ -138,3 +138,11 @@ cas:
 {% endif %}
 
 
+opentracing:
+  jaeger:
+    enabled: {{ opentracing.jaeger.enabled }}
+    logSpans: {{ opentracing.jaeger.log_spans }}
+    expandExceptionLogs: {{opentracing.jaeger.expand_exception_logs}}
+    udp-sender:
+      host: {{ opentracing.jaeger.udp_sender.host }}
+      port: {{ opentracing.jaeger.udp_sender.port }}

--- a/docs/Jaeger.md
+++ b/docs/Jaeger.md
@@ -1,0 +1,35 @@
+#Introduction
+#OpenTracing :
+Une méthode permettant de monitorer des applications dans un contexte micro-services, elle permet d'analyser les erreurs ou les problèmes de performances.
+
+#Jager : 
+est un système open source de "Open Tracing", ça inclut :
+ 1. Surveillance distribuée des transactions
+ 2. Optimisation des performances et de la latence
+ 3. Analyse des causes originelles des anomalies
+ 4. Analyse de la dépendance des services
+ 5. Propagation de contexte distribué
+ 
+#Principaux composants de Jaeger
+## Jaeger Client Libraries:
+Les clients Jaeger sont des implémentations spécifiques du langage de l'API OpenTracing.
+
+##Agent
+L'agent Jaeger est un agent réseau "daemon" qui écoute les "spans" envoyés via UDP, il les regroupe et envoie au collecteur. Il est conçu pour être déployé sur tous les hôtes en tant que composant d'infrastructure. L'agent fait abstraction du routage et de la découverte des collecteurs du client.
+
+
+##Collector
+Le collecteur Jaeger reçoit des traces des agents Jaeger et les fait passer par un processus de traitements. 
+Actuellement, les étapes sont : valider les traces, les indexer, effectuer des transformations et, enfin, les stocker. 
+Le stockage de Jaeger est un composant pluggable qui supporte actuellement en charge Cassandra, Elasticsearch et Kafka.
+
+##Query
+La requête est un service qui récupère les traces du stockage et héberge une interface utilisateur pour les afficher.
+
+##Ingester
+Ingester est un service qui lit à partir de la rubrique Kafka et écrit dans un autre backend de stockage (Cassandra, Elasticsearch).
+
+
+#Tests en local :
+Pour pouvoir tester le fonctionnement de Jaeger en local, un docker compose a été fait dans ../tools/docker/jaeger/jaeger-docker-compose.yml , puis lancer dans le navigateur : http://localhost:8090
+    

--- a/ui/ui-archive-search/pom.xml
+++ b/ui/ui-archive-search/pom.xml
@@ -58,6 +58,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
+
+
         <!-- SPRING BOOT -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/ui/ui-archive-search/src/main/config/ui-archive-search-application-dev.yml
+++ b/ui/ui-archive-search/src/main/config/ui-archive-search-application-dev.yml
@@ -113,3 +113,14 @@ management.endpoints.web.exposure.include: "*"
 # Uncomment if you want to use you specific logback config.
 #logging:
 #  config: src/main/config/logback.xml
+
+
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831

--- a/ui/ui-ingest/pom.xml
+++ b/ui/ui-ingest/pom.xml
@@ -57,6 +57,10 @@
             <type>pom</type>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
 
         <!-- SPRING BOOT -->
         <dependency>
@@ -217,7 +221,8 @@
                         <phase>process-sources</phase>
                         <configuration>
                             <skip>${skipAllFrontend}</skip>
-                            <arguments>run build -- --project=ingest --output-path=${project.basedir}/target/www --base-href=${angular.base.href} --deploy-url=${angular.base.href}
+                            <arguments>run build -- --project=ingest --output-path=${project.basedir}/target/www
+                                --base-href=${angular.base.href} --deploy-url=${angular.base.href}
                             </arguments>
                         </configuration>
                     </execution>

--- a/ui/ui-ingest/src/main/config/ui-ingest-application-dev.yml
+++ b/ui/ui-ingest/src/main/config/ui-ingest-application-dev.yml
@@ -5,7 +5,7 @@ spring:
     active: dev,swagger
 
   cloud:
-    consul:  #disable for dev
+    consul: #disable for dev
       enabled: false
       discovery:
         enabled: false
@@ -114,3 +114,12 @@ management.endpoints.web.exposure.include: "*"
 #  config: src/main/config/logback.xml
 
 
+# Jaeger
+opentracing:
+  jaeger:
+    enabled: true
+    logSpans: true
+    expandExceptionLogs: true
+    udp-sender:
+      host: localhost
+      port: 6831


### PR DESCRIPTION
## Description
L'objectif de cette PR est d'ajouter la configuration Jaeger pour les modules VAS (Archive-Search, Ingest).

Les tests unitaires vont venir après, dans une autre PR. 

## Type de changement:
* Configuration
* Ansible

## Tests:
L'ensemble des tests unitaires coté JAVA ont été verifiés
Les nouveaux tests unitaires vont venir dans une autre PR.
Des tests manuels sont effectués sur VitamUI.

## Migration:
Pas de modification DB, pas de nouvelle APP, pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et lesméthodes difficile à comprendre.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.
[X] Toutes les dépendances ont été mergées en priorité

## Contributeur
Vitam Accessible en Service (VAS)