### PR TITLE
Bug - Define specific names for vitamui services to avoid conflict with vitam services when using the same consul cluster.

### DIFF
--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -286,7 +286,7 @@ vitamui:
       vitamui_level: "DEBUG"
 
   ingest_external:
-    host: "ingest-external.service.{{ consul_domain }}"
+    host: "vitamui-ingest-external.service.{{ consul_domain }}"
     vitamui_component: "ingest-external"
     vitamui_component_type: "external"
     package_name: "vitamui-ingest-external"
@@ -305,7 +305,7 @@ vitamui:
       vitamui_level: "DEBUG"
 
   ingest_internal:
-    host: "ingest-internal.service.{{ consul_domain }}"
+    host: "vitamui-ingest-internal.service.{{ consul_domain }}"
     vitamui_component: "ingest-internal"
     vitamui_component_type: "internal"
     package_name: "vitamui-ingest-internal"

--- a/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
@@ -15,7 +15,7 @@ spring.servlet.multipart.max-request-size: -1
 
 server-identity:
   identityName: {{ vitamui_site_name }}
-  identityRole: {{ vitamui_struct.vitamui_component }}
+  identityRole: vitamui-{{ vitamui_struct.vitamui_component }}
   identityServerId: 1
 
 server:

--- a/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
@@ -17,7 +17,7 @@ spring.servlet.multipart.max-request-size: -1
 
 server-identity:
   identityName: {{ vitamui_site_name }}
-  identityRole: {{ vitamui_struct.vitamui_component }}
+  identityRole: vitamui-{{ vitamui_struct.vitamui_component }}
   identityServerId: 1
 
 server:


### PR DESCRIPTION
Lorsque l'on colocalise sur le même cluster consul que Vitam, les services ingest-external et ingest-internal existent déjà provoquant des erreurs de résolution DNS et rendant inopérationnel Vitam-UI et Vitam.

À CP sur R16 et versions supérieures.