### PR TITLE
[VAS] CP - Bug 8365 : Fix bug on importing holding and filling sheme

### DIFF
--- a/ui/ui-frontend/projects/ingest/src/app/core/common/upload.component.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/core/common/upload.component.ts
@@ -144,7 +144,7 @@ export class UploadComponent implements OnInit {
   upload() {
     if (!this.isValidSIP) { return; }
 
-    this.uploadService.uploadIngestV2(this.tenantIdentifier, this.fileToUpload, this.fileToUpload.name).subscribe(
+    this.uploadService.uploadIngestV2(this.tenantIdentifier, this.fileToUpload, this.fileToUpload.name, this.contextId).subscribe(
       () => {
         this.dialogRef.close();
         this.displaySnackBar(true);

--- a/ui/ui-frontend/projects/ingest/src/app/core/common/upload.service.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/core/common/upload.service.ts
@@ -93,10 +93,10 @@ export class UploadService {
     return this.httpClient.request(new HttpRequest('POST', this.ingestApiService.getBaseUrl() + '/ingest/upload-v2', file, options));
   }
 
-  public uploadIngestV2(tenantIdentifier: string, file: Blob, fileName: string): Observable<IngestList> {
+  public uploadIngestV2(tenantIdentifier: string, file: Blob, fileName: string, type: string): Observable<IngestList> {
     let progressPercent = 0;
     this.addNewUploadFile(fileName, new IngestInfo(fileName, file.size, 0, IngestStatus.WIP));
-    this.uploadStreaming(tenantIdentifier, 'DEFAULT_WORKFLOW', 'RESUME', file, fileName).subscribe(
+    this.uploadStreaming(tenantIdentifier, type, 'RESUME', file, fileName).subscribe(
       (data) => {
         if (data) {
           switch (data.type) {


### PR DESCRIPTION
## Description
Correction du bug #8365 : Bug critique - Les imports d'arbres et de plan de classement sont tagués à tort comme des SIP standards
## Type de changement:
* Modification du code coté Angular
## Tests:
* TU
## Checklist:
[x] Mon code suit le style de code de ce projet.
[x] Les tests unitaires nouveaux et existants passent avec succès localement.
## Contributeur
VAS
