### PR TITLE
[XELIANS] Add instance type in CRON logbook execution

### DIFF
--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/instance/InstanceConfiguration.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/instance/InstanceConfiguration.java
@@ -1,0 +1,16 @@
+package fr.gouv.vitamui.commons.api.instance;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+public class InstanceConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public InstanceService instanceService(final Environment environment) {
+        return new InstanceService(environment);
+    }
+}

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/instance/InstanceService.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/instance/InstanceService.java
@@ -1,0 +1,25 @@
+package fr.gouv.vitamui.commons.api.instance;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.env.Environment;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class InstanceService {
+
+    private final Environment environment;
+
+    private static final String PRIMARY_KEY = "instance.primary";
+
+    /**
+     * @return true is instance.primary properties is set to true or missing
+     */
+    public boolean isPrimary() {
+        var primary = environment.getProperty(PRIMARY_KEY, Boolean.class);
+        return Objects.isNull(primary) || primary;
+    }
+
+}

--- a/commons/commons-api/src/test/java/fr/gouv/vitamui/commons/api/instance/InstanceServiceTest.java
+++ b/commons/commons-api/src/test/java/fr/gouv/vitamui/commons/api/instance/InstanceServiceTest.java
@@ -1,0 +1,41 @@
+package fr.gouv.vitamui.commons.api.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceServiceTest {
+
+    @Mock
+    private Environment environment;
+
+    @InjectMocks
+    private InstanceService service;
+
+    @Test
+    void shouldBeTrue_whenPropertiesIsTrue() {
+        given(environment.getProperty(anyString(), any(Class.class))).willReturn(true);
+        assertThat(service.isPrimary()).isTrue();
+    }
+
+    @Test
+    void shouldBeTrue_whenPropertiesIsMissing() {
+        given(environment.getProperty(anyString(), any(Class.class))).willReturn(null);
+        assertThat(service.isPrimary()).isTrue();
+    }
+
+    @Test
+    void shouldBeTrue_whenPropertiesIsFalse() {
+        given(environment.getProperty(anyString(), any(Class.class))).willReturn(false);
+        assertThat(service.isPrimary()).isFalse();
+    }
+
+}

--- a/commons/commons-logbook/src/main/java/fr/gouv/vitamui/commons/logbook/config/LogbookSchedulingConfiguration.java
+++ b/commons/commons-logbook/src/main/java/fr/gouv/vitamui/commons/logbook/config/LogbookSchedulingConfiguration.java
@@ -36,20 +36,24 @@
  */
 package fr.gouv.vitamui.commons.logbook.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import fr.gouv.vitam.access.external.client.AdminExternalClient;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
+import fr.gouv.vitamui.commons.api.instance.InstanceConfiguration;
 import fr.gouv.vitamui.commons.logbook.dao.EventRepository;
 import fr.gouv.vitamui.commons.logbook.scheduler.DeleteSynchronizedEventsTasks;
 import fr.gouv.vitamui.commons.logbook.scheduler.SendEventToVitamTasks;
 
 @ConditionalOnProperty(name = "logbook.scheduling.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
+@Import(InstanceConfiguration.class)
 @EnableScheduling
 public class LogbookSchedulingConfiguration {
 
@@ -61,6 +65,7 @@ public class LogbookSchedulingConfiguration {
     }
 
     @Bean
+    @ConditionalOnExpression("#{@instanceService.isPrimary()}")
     @ConditionalOnProperty(name = "logbook.scheduling.sendEventToVitamTasks.enabled", havingValue = "true", matchIfMissing = true)
     SendEventToVitamTasks sendEventToVitamTasks(final EventRepository eventRepository,
             final AdminExternalClient adminExternalClient) {

--- a/commons/commons-logbook/src/test/java/fr/gouv/vitamui/commons/logbook/config/LogbookSchedulingConfigurationTest.java
+++ b/commons/commons-logbook/src/test/java/fr/gouv/vitamui/commons/logbook/config/LogbookSchedulingConfigurationTest.java
@@ -3,65 +3,67 @@ package fr.gouv.vitamui.commons.logbook.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import fr.gouv.vitam.access.external.client.AdminExternalClient;
 import fr.gouv.vitam.access.external.client.AdminExternalClientMock;
 import fr.gouv.vitamui.commons.logbook.dao.EventRepository;
-import fr.gouv.vitamui.commons.test.utils.ServerIdentityConfigurationBuilder;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-public class LogbookSchedulingConfigurationTest {
+@ExtendWith(SpringExtension.class)
+class LogbookSchedulingConfigurationTest {
 
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withAllowBeanDefinitionOverriding(true)
-            .withUserConfiguration(LogbookSchedulingConfiguration.class).withUserConfiguration(UserConfiguration.class);
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner().withUserConfiguration(UserConfiguration.class, LogbookSchedulingConfiguration.class);
 
-    @BeforeClass
-    public static void setup() {
-        ServerIdentityConfigurationBuilder.setup("identityName", "identityRole", 1, 0);
+    @Test
+    void shouldBeDisabled_when_propertiesIsFalse() {
+        contextRunner.withPropertyValues("instance.primary=true", "logbook.scheduling.enabled=true", "logbook.scheduling.sendEventToVitamTasks.enabled=false",
+            "logbook.scheduling.deleteSynchronizedEventsTasks.enabled=false",
+            "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *").run((context) -> {
+            assertThat(context.containsBean("sendEventToVitamTasks")).isFalse();
+            assertThat(context.containsBean("deleteSyncrhonizedEventsTasks")).isFalse();
+        });
     }
 
     @Test
-    public void schedulingDisabled() {
-        contextRunner
-                .withPropertyValues("logbook.scheduling.enabled=true",
-                        "logbook.scheduling.sendEventToVitamTasks.enabled=false",
-                        "logbook.scheduling.deleteSynchronizedEventsTasks.enabled=false",
-                        "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *")
-                .run((context) -> {
-                    assertThat(context.containsBean("sendEventToVitamTasks")).isFalse();
-                    assertThat(context.containsBean("deleteSyncrhonizedEventsTasks")).isFalse();
-                });
-
-        contextRunner
-                .withPropertyValues("logbook.scheduling.enabled=false",
-                        "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *")
-                .run((context) -> {
-                    assertThat(context.containsBean("sendEventToVitamTasks")).isFalse();
-                    assertThat(context.containsBean("deleteSyncrhonizedEventsTasks")).isFalse();
-                });
+    void shouldBeDisabled_whenIsNotPrimary() {
+        contextRunner.withPropertyValues("instance.primary=false", "logbook.scheduling.enabled=false",
+            "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *").run((context) -> {
+            assertThat(context.containsBean("sendEventToVitamTasks")).isFalse();
+            assertThat(context.containsBean("deleteSyncrhonizedEventsTasks")).isFalse();
+        });
     }
 
     @Test
-    public void schedulingEnabled() {
-        contextRunner
-                .withPropertyValues("logbook.scheduling.enabled=true",
-                        "logbook.scheduling.sendEventToVitamTasks.delay=900000",
-                        "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *")
-                .run((context) -> {
-                    assertThat(context.containsBean("sendEventToVitamTasks")).isTrue();
-                    assertThat(context.containsBean("deleteSynchronizedEventsTasks")).isTrue();
-                });
+    void shouldBeEnabled_whenIsPrimaryAndPropertiesIsTrue() {
+
+        contextRunner.withPropertyValues("instance.primary=true", "logbook.scheduling.enabled=true", "logbook.scheduling.sendEventToVitamTasks.enabled=true",
+            "logbook.scheduling.deleteSynchronizedEventsTasks.enabled=true", "logbook.scheduling.sendEventToVitamTasks.delay=900000",
+            "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *").run((context) -> {
+            assertThat(context.containsBean("sendEventToVitamTasks")).isTrue();
+            assertThat(context.containsBean("deleteSynchronizedEventsTasks")).isTrue();
+        });
     }
+
+    @Test
+    void shouldBeEnabled_whenIsPrimaryAndPropertiesIsMissing() {
+
+        contextRunner.withPropertyValues("instance.primary=true", "logbook.scheduling.enabled=true", "logbook.scheduling.sendEventToVitamTasks.delay=900000",
+            "logbook.scheduling.deleteSynchronizedEventsTasks.cronExpression=0 0,30 0-6 ? * *").run((context) -> {
+            assertThat(context.containsBean("sendEventToVitamTasks")).isTrue();
+            assertThat(context.containsBean("deleteSynchronizedEventsTasks")).isTrue();
+        });
+    }
+
 
     @Configuration
     static class UserConfiguration {
+
 
         @Bean
         EventRepository eventRepository() {


### PR DESCRIPTION
## Description

Cette PR permet de prendre en compte le type d'instance lors du lancement du CRON logbook. 
Ainsi le CRON ne se lance que sur l'instance primaire et le traitement en double des éventements logbook sera corrigé.
Ce mécanisme doit être implémenté sur tous les futurs CRON de Vitamui.

## Type de changement
-  Code et/ou Configuration : Nouvelle fonctionnalité

## Checklist

 [ * ] Mon code suit le style de code de ce projet.
 [ * ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
 [ * ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
 [ * ] Les tests unitaires nouveaux et existants passent avec succès localement.
 [ * ] Toutes les dépendances ont été mergées en priorité

## Contributeur

Xelians 