### PR TITLE
[VAS] Item 8651 : fixe R16 Bugs

### DIFF
--- a/api/api-ingest/ingest-commons/src/main/java/fr/gouv/vitamui/ingest/common/rest/RestApi.java
+++ b/api/api-ingest/ingest-commons/src/main/java/fr/gouv/vitamui/ingest/common/rest/RestApi.java
@@ -28,8 +28,7 @@ package fr.gouv.vitamui.ingest.common.rest;
 
 public class RestApi {
     public static final String V1_INGEST = "/iam/v1/ingest";
-    public static final String INGEST_REPORT_DOCX = "/docxreport";
     public static final String INGEST_UPLOAD_V2 = "/upload-v2";
-    public static final String INGEST_ATR = "/atr";
-    public static final String INGEST_MANIFEST = "/manifest";
+    public static final String INGEST_REPORT_ODT = "/odtreport";
+
 }

--- a/api/api-ingest/ingest-external-client/src/main/java/fr/gouv/vitamui/ingest/external/client/IngestExternalRestClient.java
+++ b/api/api-ingest/ingest-external-client/src/main/java/fr/gouv/vitamui/ingest/external/client/IngestExternalRestClient.java
@@ -82,8 +82,8 @@ public class IngestExternalRestClient extends BasePaginatingAndSortingRestClient
         return new ParameterizedTypeReference<PaginatedValuesDto<LogbookOperationDto>>() {};
     }
 
-    public ResponseEntity<byte[]> generateDocX(ExternalHttpContext context, String id) {
-        final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl() + RestApi.INGEST_REPORT_DOCX + CommonConstants.PATH_ID );
+    public ResponseEntity<byte[]> generateODTReport(ExternalHttpContext context, String id) {
+        final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl() + RestApi.INGEST_REPORT_ODT + CommonConstants.PATH_ID );
         final HttpEntity<AuditOptions> request = new HttpEntity<>(buildHeaders(context));
         return restTemplate.exchange(uriBuilder.build(id), HttpMethod.GET, request, byte[].class);
 

--- a/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/rest/IngestExternalController.java
+++ b/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/rest/IngestExternalController.java
@@ -117,4 +117,12 @@ public class IngestExternalController {
         SanityChecker.isValidFileName(originalFileName);
         return ingestExternalService.streamingUpload(inputStream, originalFileName, contextId, action);
     }
+
+    @Secured(ServicesData.ROLE_LOGBOOKS)
+    @GetMapping(RestApi.INGEST_REPORT_ODT + CommonConstants.PATH_ID)
+    public ResponseEntity<byte[]> generateODTReport(final @PathVariable("id") String id) {
+        LOGGER.debug("export ODT report for ingest with id :{}", id);
+        ParameterChecker.checkParameter("The Identifier is a mandatory parameter :", id);
+        return ingestExternalService.generateODTReport(id);
+    }
 }

--- a/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/service/IngestExternalService.java
+++ b/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/service/IngestExternalService.java
@@ -100,8 +100,8 @@ public class IngestExternalService extends AbstractResourceClientService<Logbook
 
     }
 
-    public ResponseEntity<byte[]> generateDocX(String id) {
-        return ingestInternalRestClient.generateDocX(getInternalHttpContext(), id);
+    public ResponseEntity<byte[]> generateODTReport(String id) {
+        return ingestInternalRestClient.generateODTReport(getInternalHttpContext(), id);
     }
 
     @Override

--- a/api/api-ingest/ingest-internal-client/src/main/java/fr/gouv/vitamui/ingest/internal/client/IngestInternalRestClient.java
+++ b/api/api-ingest/ingest-internal-client/src/main/java/fr/gouv/vitamui/ingest/internal/client/IngestInternalRestClient.java
@@ -84,8 +84,8 @@ public class IngestInternalRestClient extends BasePaginatingAndSortingRestClient
         return new ParameterizedTypeReference<PaginatedValuesDto<LogbookOperationDto>>() {};
     }
 
-    public ResponseEntity<byte[]> generateDocX(InternalHttpContext context , String id) {
-        final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl() + RestApi.INGEST_REPORT_DOCX + CommonConstants.PATH_ID );
+    public ResponseEntity<byte[]> generateODTReport(InternalHttpContext context , String id) {
+        final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl() + RestApi.INGEST_REPORT_ODT + CommonConstants.PATH_ID );
         final HttpEntity<AuditOptions> request = new HttpEntity<>(buildHeaders(context));
         return restTemplate.exchange(uriBuilder.build(id), HttpMethod.GET, request, byte[].class);
     }

--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/rest/IngestInternalController.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/rest/IngestInternalController.java
@@ -102,7 +102,7 @@ public class IngestInternalController {
     }
 
 
-    @GetMapping(RestApi.INGEST_REPORT_DOCX + CommonConstants.PATH_ID)
+    @GetMapping(RestApi.INGEST_REPORT_ODT + CommonConstants.PATH_ID)
     public ResponseEntity<byte[]> generateODTReport(final @PathVariable("id") String id)
         throws IOException {
         final VitamContext vitamContext = securityService.buildVitamContext(securityService.getTenantIdentifier());

--- a/ui/ui-frontend-common/src/app/modules/components/editable-field/editable-level-input/editable-level-input.component.html
+++ b/ui/ui-frontend-common/src/app/modules/components/editable-field/editable-level-input/editable-level-input.component.html
@@ -2,9 +2,9 @@
   <div class="editable-field-wrapper" cdkOverlayOrigin #origin="cdkOverlayOrigin">
     <div class="vitamui-input editable-field" [class.edit-mode]="editMode" (click)="enterEditMode()">
       <div class="editable-field-content">
-        <label>{{label}}</label>
+        <label>{{ label }}</label>
         <span class="editable-field-text-content">
-          {{ control.value | subLevel:prefix }}
+          {{ control.value | subLevel: prefix }}
         </span>
         <div class="editable-field-control">
           <vitamui-common-level-input [formControl]="control" [prefix]="prefix" [isEditableComponent]="true"></vitamui-common-level-input>
@@ -16,10 +16,16 @@
 
   <div class="vitamui-input-errors"></div>
 
-  <ng-template cdkConnectedOverlay [cdkConnectedOverlayOpen]="editMode" [cdkConnectedOverlayOrigin]="origin"
-    [cdkConnectedOverlayPositions]="positions">
+  <ng-template
+    cdkConnectedOverlay
+    [cdkConnectedOverlayOpen]="editMode"
+    [cdkConnectedOverlayOrigin]="origin"
+    [cdkConnectedOverlayPositions]="positions"
+  >
     <div class="editable-field-actions">
-      <button type="button" class="editable-field-confirm" (click)="confirm()" [disabled]="!canConfirm"><i class="material-icons">check</i></button>
+      <button type="button" class="editable-field-confirm" (click)="confirm()" [disabled]="!canConfirm">
+        <i class="material-icons">check</i>
+      </button>
       <button type="button" class="editable-field-cancel" (click)="cancel()"><i class="material-icons">clear</i></button>
     </div>
   </ng-template>
@@ -27,7 +33,9 @@
 
 <div *ngIf="disabled" class="read-only-field">
   <div>
-    <label>{{'LEVEL-INPUT.SUBLEVEL' | translate }}</label>
-    <div> <span>{{control.value | subLevel:prefix }}</span></div>
+    <label>{{ 'LEVEL_INPUT.SUBLEVEL' | translate }}</label>
+    <div>
+      <span>{{ control.value | subLevel: prefix }}</span>
+    </div>
   </div>
 </div>

--- a/ui/ui-frontend-common/src/app/modules/components/editable-field/level-input/level-input.component.html
+++ b/ui/ui-frontend-common/src/app/modules/components/editable-field/level-input/level-input.component.html
@@ -1,14 +1,28 @@
 <div *ngIf="!isEditableComponent" class="vitamui-input" [class.disabled]="disabled">
-    <label>{{'LEVEL-INPUT.SUBLEVEL' | translate }}<span *ngIf="required" class="required-marker">*</span></label>
-    <input [disabled]="disabled" [required]="required" [(ngModel)]="subLevel" (ngModelChange)="onValueChange($event)"
-    (blur)="onBlur()" (focus)="onFocus()" maxlength="250">
+  <label>{{ 'LEVEL_INPUT.SUBLEVEL' | translate }}<span *ngIf="required" class="required-marker">*</span></label>
+  <input
+    [disabled]="disabled"
+    [required]="required"
+    [(ngModel)]="subLevel"
+    (ngModelChange)="onValueChange($event)"
+    (blur)="onBlur()"
+    (focus)="onFocus()"
+    maxlength="250"
+  />
 </div>
 
-<div *ngIf="!isEditableComponent"  class="vitamui-input-errors">
-    <ng-content></ng-content>
+<div *ngIf="!isEditableComponent" class="vitamui-input-errors">
+  <ng-content></ng-content>
 </div>
 
 <div *ngIf="isEditableComponent">
-    <input [disabled]="disabled" [required]="required" [(ngModel)]="subLevel" (ngModelChange)="onValueChange($event)"
-    (blur)="onBlur()" maxlength="250" (focus)="onFocus()">
+  <input
+    [disabled]="disabled"
+    [required]="required"
+    [(ngModel)]="subLevel"
+    (ngModelChange)="onValueChange($event)"
+    (blur)="onBlur()"
+    maxlength="250"
+    (focus)="onFocus()"
+  />
 </div>

--- a/ui/ui-frontend-common/src/app/modules/components/header/header.component.html
+++ b/ui/ui-frontend-common/src/app/modules/components/header/header.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar color="primary" class="header">
   <div class="header-logo">
-    <a class="d-flex" href="{{portalUrl}}" >
-      <img alt="header logo" [src]="headerLogoUrl">
+    <a class="d-flex" href="{{ portalUrl }}">
+      <img alt="header logo" [src]="headerLogoUrl" />
     </a>
   </div>
 
@@ -14,11 +14,12 @@
       <!-- tenant selection -->
       <vitamui-common-item-select
         *ngIf="hasTenantSelection"
-        [label]="'SELECT-TENANT.SELECT' | translate"
-        [selectedLabel]="'SELECT-TENANT.SELECTED' | translate"
+        [label]="'SELECT_TENANT.SELECT' | translate"
+        [selectedLabel]="'SELECT_TENANT.SELECTED' | translate"
         [items]="tenants"
         [selectedItem]="selectedTenant"
-        (itemSelected)="updateTenant($event)">
+        (itemSelected)="updateTenant($event)"
+      >
       </vitamui-common-item-select>
 
       <!-- customer selection -->
@@ -28,15 +29,16 @@
         [selectedLabel]="'SELECT-CUSTOMER.SELECTED' | translate"
         [items]="customers"
         [selectedItem]="selectedCustomer"
-        (itemSelected)="updateCustomer($event)">
+        (itemSelected)="updateCustomer($event)"
+      >
       </vitamui-common-item-select>
     </div>
 
     <div class="d-flex align-items-center pl-3 mr-4 account" [matMenuTriggerFor]="accountMenu">
       <vitamui-common-user-photo class="mr-2" [photo]="currentUser?.photo"></vitamui-common-user-photo>
       <div class="mx-2">
-        <div class="text caption bold">{{'HEADER.PROFILE' | translate}}</div>
-        <div class="text normal bold">{{currentUser?.firstname}} {{currentUser.lastname}}</div>
+        <div class="text caption bold">{{ 'HEADER.PROFILE' | translate }}</div>
+        <div class="text normal bold">{{ currentUser?.firstname }} {{ currentUser.lastname }}</div>
       </div>
 
       <div class="ml-3">
@@ -46,9 +48,11 @@
       <div class="account-menu">
         <mat-menu #accountMenu="matMenu" [overlapTrigger]="false" xPosition="before">
           <ng-container>
-            <button mat-menu-item [routerLink]="['/account']" *ngIf="hasAccountProfile">{{'HEADER.MY_ACCOUNT' | translate}}</button>
-            <button mat-menu-item (click)="enabledSubrogation()" *ngIf="!!!currentUser?.superUser">{{'HEADER.NAVIGATE_AS' | translate}}</button>
-            <button mat-menu-item (click)="logout()">{{'HEADER.LOGOUT' | translate}}</button>
+            <button mat-menu-item [routerLink]="['/account']" *ngIf="hasAccountProfile">{{ 'HEADER.MY_ACCOUNT' | translate }}</button>
+            <button mat-menu-item (click)="enabledSubrogation()" *ngIf="!!!currentUser?.superUser">
+              {{ 'HEADER.NAVIGATE_AS' | translate }}
+            </button>
+            <button mat-menu-item (click)="logout()">{{ 'HEADER.LOGOUT' | translate }}</button>
           </ng-container>
         </mat-menu>
       </div>
@@ -56,7 +60,11 @@
 
     <div>
       <button mat-mini-fab class="apps-button" (click)="openMenu()">
-        <i class="vitamui-icon vitamui-icon-apps-colored"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span></i>
+        <i class="vitamui-icon vitamui-icon-apps-colored"
+          ><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span
+          ><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span
+          ><span class="path9"></span
+        ></i>
       </button>
     </div>
   </div>

--- a/ui/ui-frontend-common/src/app/modules/components/header/menu/menu-application-tile/menu-application-tile.component.html
+++ b/ui/ui-frontend-common/src/app/modules/components/header/menu/menu-application-tile/menu-application-tile.component.html
@@ -1,12 +1,12 @@
 <div class="d-flex align-items-center">
-    <div class="d-flex align-items-center mandatory">
-        <i [ngClass]="application.icon" class="app-icon d-flex justify-content-center align-items-center"></i>
-        <span class="pl-2 appName" [innerHTML]="application.name | highlight: hlCriteria"></span>
-        <span class="hover-focus pl-2">-</span>
-        <span class="hover-focus pl-2 tooltip">{{application.tooltip}}</span>
-    </div>
-    <div class="ml-auto focus d-flex justify-content-end">
-        <span class="material-icons">keyboard_return</span>
-        <span class="pl-2">{{'MENU-APPLICATION-TILE.ENTER_APPLICATION' | translate}}</span>
-    </div>
+  <div class="d-flex align-items-center mandatory">
+    <i [ngClass]="application.icon" class="app-icon d-flex justify-content-center align-items-center"></i>
+    <span class="pl-2 appName" [innerHTML]="application.name | highlight: hlCriteria"></span>
+    <span class="hover-focus pl-2">-</span>
+    <span class="hover-focus pl-2 tooltip">{{ application.tooltip }}</span>
+  </div>
+  <div class="ml-auto focus d-flex justify-content-end">
+    <span class="material-icons">keyboard_return</span>
+    <span class="pl-2">{{ 'MENU_APPLICATION_TILE.ENTER_APPLICATION' | translate }}</span>
+  </div>
 </div>

--- a/ui/ui-frontend-common/src/app/modules/components/header/menu/menu.component.html
+++ b/ui/ui-frontend-common/src/app/modules/components/header/menu/menu.component.html
@@ -1,57 +1,59 @@
-<div
-    class="container p-0"
-    [@opacityAnimation]="state"
-    >
-    <div class="row header">
-        <vitamui-common-search-bar
-            class="col-5 mr-2"
-            name="category-search"
-            (searchChanged)="onSearch($event)"
-            (clear)="resetSearch()"
-            placeholder="{{'MENU.GRAB_APPLICATION' | translate}}"
-        ></vitamui-common-search-bar>
+<div class="container p-0" [@opacityAnimation]="state">
+  <div class="row header">
+    <vitamui-common-search-bar
+      class="col-5 mr-2"
+      name="category-search"
+      (searchChanged)="onSearch($event)"
+      (clear)="resetSearch()"
+      placeholder="{{ 'MENU.GRAB_APPLICATION' | translate }}"
+    ></vitamui-common-search-bar>
 
-        <vitamui-common-item-select
-            class="col-3 p-0 ml-5"
-            [label]="'SELECT-TENANT.SELECT' | translate"
-            [selectedLabel]="'SELECT-TENANT.SELECTED' | translate"
-            [items]="tenants"
-            [selectedItem]="selectedTenant"
-            (itemSelected)="updateApps($event)"
-        ></vitamui-common-item-select>
+    <vitamui-common-item-select
+      class="col-3 p-0 ml-5"
+      [label]="'SELECT_TENANT.SELECT' | translate"
+      [selectedLabel]="'SELECT_TENANT.SELECTED' | translate"
+      [items]="tenants"
+      [selectedItem]="selectedTenant"
+      (itemSelected)="updateApps($event)"
+    ></vitamui-common-item-select>
 
-        <div class="apps-container col-3 ml-auto" (click)="onClose()">
-            <span class="pr-2">{{'MENU.MY_APPLICATIONS' | translate}}</span>
-            <button mat-icon-button class="apps-button">
-                <i class="vitamui-icon vitamui-icon-apps-colored"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span></i>
-            </button>
-        </div>
+    <div class="apps-container col-3 ml-auto" (click)="onClose()">
+      <span class="pr-2">{{ 'MENU.MY_APPLICATIONS' | translate }}</span>
+      <button mat-icon-button class="apps-button">
+        <i class="vitamui-icon vitamui-icon-apps-colored"
+          ><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span
+          ><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span
+          ><span class="path9"></span
+        ></i>
+      </button>
     </div>
+  </div>
 
-    <div class="pt-4">
-        <ng-container *ngIf="filteredApplications; else displayMats">
-            <span class="px-3">{{'MENU.RESULT' | translate}}&nbsp;: </span>
-            <hr class="mb-0">
-            <mat-selection-list id="searchResults"
-                class="py-3 overflow"
-                (selectionChange)="openApplication($event.option.value)">
-                <mat-list-option [value]="app" @slideAnimation *ngFor="let app of filteredApplications">
-                    <vitamui-common-menu-application-tile [application]="app" [hlCriteria]="criteria"></vitamui-common-menu-application-tile>
-                </mat-list-option>
-            </mat-selection-list>
-        </ng-container>
-        <ng-template #displayMats>
-                <mat-tab-group animationDuration="300ms" mat-align-tabs="start" [selectedIndex]="tabSelectedIndex" (selectedTabChange)="changeTabFocus($event)">
-                    <mat-tab *ngFor="let category of appMap | keyvalue" [label]="'MENU.' + category.key.identifier | translate">
-                        <mat-selection-list
-                            class="py-3"
-                            (selectionChange)="openApplication($event.option.value);">
-                            <mat-list-option cdkTrapFocus cdkTrapFocusAutoChange [value]="app" *ngFor="let app of category.value">
-                                <vitamui-common-menu-application-tile [application]="app"></vitamui-common-menu-application-tile>
-                            </mat-list-option>
-                        </mat-selection-list>
-                    </mat-tab>
-                </mat-tab-group>
-        </ng-template>
-    </div>
+  <div class="pt-4">
+    <ng-container *ngIf="filteredApplications; else displayMats">
+      <span class="px-3">{{ 'MENU.RESULT' | translate }}&nbsp;: </span>
+      <hr class="mb-0" />
+      <mat-selection-list id="searchResults" class="py-3 overflow" (selectionChange)="openApplication($event.option.value)">
+        <mat-list-option [value]="app" @slideAnimation *ngFor="let app of filteredApplications">
+          <vitamui-common-menu-application-tile [application]="app" [hlCriteria]="criteria"></vitamui-common-menu-application-tile>
+        </mat-list-option>
+      </mat-selection-list>
+    </ng-container>
+    <ng-template #displayMats>
+      <mat-tab-group
+        animationDuration="300ms"
+        mat-align-tabs="start"
+        [selectedIndex]="tabSelectedIndex"
+        (selectedTabChange)="changeTabFocus($event)"
+      >
+        <mat-tab *ngFor="let category of appMap | keyvalue" [label]="'MENU.' + category.key.identifier | translate">
+          <mat-selection-list class="py-3" (selectionChange)="openApplication($event.option.value)">
+            <mat-list-option cdkTrapFocus cdkTrapFocusAutoChange [value]="app" *ngFor="let app of category.value">
+              <vitamui-common-menu-application-tile [application]="app"></vitamui-common-menu-application-tile>
+            </mat-list-option>
+          </mat-selection-list>
+        </mat-tab>
+      </mat-tab-group>
+    </ng-template>
+  </div>
 </div>

--- a/ui/ui-frontend-common/src/app/modules/components/header/select-tenant-dialog/select-tenant-dialog.component.html
+++ b/ui/ui-frontend-common/src/app/modules/components/header/select-tenant-dialog/select-tenant-dialog.component.html
@@ -1,16 +1,16 @@
 <div class="row dialog">
-    <h4 class="col-12 p-0 m-0">{{ 'SELECT-TENANT.DIALOG_TITLE' | translate }} {{platformName}}</h4>
-    <h5 class="col-12 p-0">{{ 'SELECT-TENANT.DIALOG_SUBTITLE' | translate }}</h5>
-    <p class="col-12 p-0 mt-5">{{ 'SELECT-TENANT.DIALOG_INSTRUCTIONS' | translate }} <span class="asterix">*</span></p>
+    <h4 class="col-12 p-0 m-0">{{ 'SELECT_TENANT.DIALOG_TITLE' | translate }} {{platformName}}</h4>
+    <h5 class="col-12 p-0">{{ 'SELECT_TENANT.DIALOG_SUBTITLE' | translate }}</h5>
+    <p class="col-12 p-0 mt-5">{{ 'SELECT_TENANT.DIALOG_INSTRUCTIONS' | translate }} <span class="asterix">*</span></p>
 
     <vitamui-common-item-select
         class="col-12 p-0 mb-5"
-        [label]="'SELECT-TENANT.SELECT' | translate"
-        [selectedLabel]="'SELECT-TENANT.SELECTED' | translate"
+        [label]="'SELECT_TENANT.SELECT' | translate"
+        [selectedLabel]="'SELECT_TENANT.SELECTED' | translate"
         (itemSelected)="selectedTenant = $event"
         [items]="tenants">
     </vitamui-common-item-select>
 
-    <button class="col-12 p-0 mt-4 btn primary" [disabled]="!selectedTenant" (click)="closeDialog()">{{ 'SELECT-TENANT.DIALOG_BUTTON_LABEL' | translate }}  {{platformName}}</button>
-    <p class="text normal mx-auto mt-4"><span class="asterix">*</span> {{ 'SELECT-TENANT.DIALOG_MESSAGE' | translate }}</p>
+    <button class="col-12 p-0 mt-4 btn primary" [disabled]="!selectedTenant" (click)="closeDialog()">{{ 'SELECT_TENANT.DIALOG_BUTTON_LABEL' | translate }}  {{platformName}}</button>
+    <p class="text normal mx-auto mt-4"><span class="asterix">*</span> {{ 'SELECT_TENANT.DIALOG_MESSAGE' | translate }}</p>
 </div>

--- a/ui/ui-frontend/package-lock.json
+++ b/ui/ui-frontend/package-lock.json
@@ -796,7 +796,7 @@
     },
     "@angular/material-moment-adapter": {
       "version": "10.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-10.2.7.tgz",
+      "resolved": "https://nexus.dev.programmevitam.fr/repository/vitam-npm/@angular/material-moment-adapter/-/material-moment-adapter-10.2.7.tgz",
       "integrity": "sha512-VaigAiBCz10AvpzgZvdR4SCGnMRxXKx8ukUdeowuoqAFONEPpRdCJmwZ+8bpi9Q/jXlrZJicCMhklj4bBQw6tg==",
       "requires": {
         "tslib": "^2.0.0"
@@ -8756,7 +8756,7 @@
     },
     "lodash-es": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "resolved": "https://nexus.dev.programmevitam.fr/repository/vitam-npm/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.clonedeep": {
@@ -9455,7 +9455,7 @@
     },
     "moment": {
       "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "resolved": "https://nexus.dev.programmevitam.fr/repository/vitam-npm/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-locales-webpack-plugin": {
@@ -9469,7 +9469,7 @@
     },
     "moment-mini": {
       "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.24.0.tgz",
+      "resolved": "https://nexus.dev.programmevitam.fr/repository/vitam-npm/moment-mini/-/moment-mini-2.24.0.tgz",
       "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
     },
     "move-concurrently": {
@@ -14870,7 +14870,7 @@
     },
     "ui-frontend-common": {
       "version": "file:../ui-frontend-common/ui-frontend-common-2.1.0.tgz",
-      "integrity": "sha512-yw/GQ3bSJUe1glzBF6PZ01cS9Af44LKPaNU1gtng+uLPK3NVu8zKYFe/97wKLHeqPWMW+dwnEl03bivRTyinHw==",
+      "integrity": "sha512-IoouyxVOYQrNlito6ecmHkojeAF+ovOl7o1SzUFEHLNM1DWotZMQ8cwHTyprkV/NtiPXXjjskHkPTg4aucZoxg==",
       "requires": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "^12.0.0",
@@ -14884,7 +14884,7 @@
       "dependencies": {
         "@ngx-translate/http-loader": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-4.0.0.tgz",
+          "resolved": "https://nexus.dev.programmevitam.fr/repository/vitam-npm/@ngx-translate/http-loader/-/http-loader-4.0.0.tgz",
           "integrity": "sha512-x8LumqydWD7eX9yQTAVeoCM9gFUIGVTUjZqbxdAUavAA3qVnk9wCQux7iHLPXpydl8vyQmLoPQR+fFU+DUDOMA==",
           "requires": {
             "tslib": "^1.9.0"
@@ -14892,7 +14892,7 @@
         },
         "tslib": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "resolved": "https://nexus.dev.programmevitam.fr/repository/vitam-npm/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }

--- a/ui/ui-frontend/projects/ingest/src/app/core/api/ingest-api.service.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/core/api/ingest-api.service.ts
@@ -1,14 +1,13 @@
-import { Inject, Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
-import { BASE_URL, BaseHttpClient, PageRequest, PaginatedResponse } from 'ui-frontend-common';
+import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { BaseHttpClient, BASE_URL, PageRequest, PaginatedResponse } from 'ui-frontend-common';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class IngestApiService extends BaseHttpClient<any> {
-
   baseUrl: string;
 
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
@@ -25,25 +24,22 @@ export class IngestApiService extends BaseHttpClient<any> {
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
-    return super.getAllByParams(params, headers).pipe(
-      tap(result => result.map(ev => ev.parsedData = (ev.data != null) ? JSON.parse(ev.data) : null))
-    );
+    return super
+      .getAllByParams(params, headers)
+      .pipe(tap((result) => result.map((ev) => (ev.parsedData = ev.data != null ? JSON.parse(ev.data) : null))));
   }
 
   getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<any>> {
-    return super.getAllPaginated(pageRequest, embedded, headers).pipe(
-      tap(result => result.values.map(ev => ev.parsedData = (ev.data != null) ? JSON.parse(ev.data) : null))
-    );
+    return super
+      .getAllPaginated(pageRequest, embedded, headers)
+      .pipe(tap((result) => result.values.map((ev) => (ev.parsedData = ev.data != null ? JSON.parse(ev.data) : null))));
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<any> {
-    return super.getOne(id, headers).pipe(
-      tap(ev => ev.parsedData = (ev.data != null) ? JSON.parse(ev.data) : null)
-    );
+    return super.getOne(id, headers).pipe(tap((ev) => (ev.parsedData = ev.data != null ? JSON.parse(ev.data) : null)));
   }
 
-  downloadDocxReport(id : string) : Observable<Blob> {
-    return this.http.get(`${this.apiUrl}/docxreport/${id}`, { responseType: 'blob' });
+  downloadODTReport(id: string): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/odtreport/${id}`, { responseType: 'blob' });
   }
-
 }

--- a/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-preview.component.html
+++ b/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-preview.component.html
@@ -1,27 +1,48 @@
 <vitamui-common-sidenav-header
-  [badge]="ingestStatus(ingest) === 'OK' ? 'green' : (ingestStatus(ingest) === 'WARNING' ? 'orange' : (ingestStatus(ingest) === 'STARTED' ? 'grey' : 'red'))"
-  [title]=" ingest?.obIdIn ? ingest?.obIdIn : ingest?.id " [icon]="'vitamui-icon-box vitamui-row-icon'"
-  [hasToolTipOnTitle]="true" [toolTipTitleText]="(ingest?.obIdIn ? ingest?.obIdIn : ingest?.id )"
+  [badge]="
+    ingestStatus(ingest) === 'OK'
+      ? 'green'
+      : ingestStatus(ingest) === 'WARNING'
+      ? 'orange'
+      : ingestStatus(ingest) === 'STARTED'
+      ? 'grey'
+      : 'red'
+  "
+  [title]="ingest?.obIdIn ? ingest?.obIdIn : ingest?.id"
+  [icon]="'vitamui-icon-box vitamui-row-icon'"
+  [hasToolTipOnTitle]="true"
+  [toolTipTitleText]="ingest?.obIdIn ? ingest?.obIdIn : ingest?.id"
   [toolTipTitleDuration]="300"
-  (onclose)="emitClose()">
+  (onclose)="emitClose()"
+>
   <vitamui-common-menu-button [overlayPos]="'end'" [icon]="'vitamui-icon-more-horiz'">
-    <button mat-menu-item i18n="@@ingestPreviewDownloadManifest" (click)="downloadManifest()"
-            [disabled]="ingestStatus(ingest) === 'KO'">{{'INGEST_DETAIL.DOWNLOAD_MANIFEST' | translate}}
+    <button
+      mat-menu-item
+      i18n="@@ingestPreviewDownloadManifest"
+      (click)="downloadManifest()"
+      [disabled]="ingestStatus(ingest) === 'KO' || ingestStatus(ingest) === 'FATAL' || ingestStatus(ingest) === 'En cours'"
+    >
+      {{ 'INGEST_DETAIL.DOWNLOAD_MANIFEST' | translate }}
     </button>
-    <button mat-menu-item i18n="@@ingestPreviewDownloadATR"
-            (click)="downloadATR()">{{'INGEST_DETAIL.DOWNLOAD_ATR' | translate}}
+    <button mat-menu-item i18n="@@ingestPreviewDownloadATR" (click)="downloadATR()" [disabled]="ingestStatus(ingest) === 'En cours'">
+      {{ 'INGEST_DETAIL.DOWNLOAD_ATR' | translate }}
     </button>
-    <button mat-menu-item i18n="@@ingestPreviewGenerateDocX" (click)="generateDocX()"
-            matTooltip="{{'INGEST_DETAIL.DOWNLOAD_DOCX' | translate}}" matTooltipClass="vitamui-tooltip"
-            [disabled]="ingestStatus(ingest) === 'KO' || ingestStatus(ingest) === 'FATAL'">
-      {{'INGEST_DETAIL.DOWNLOAD_DOCX' | translate}}
+    <button
+      mat-menu-item
+      i18n="@@ingestPreviewGenerateDocX"
+      (click)="downloadODTReport()"
+      matTooltip="{{ 'INGEST_DETAIL.DOWNLOAD_DOCX' | translate }}"
+      matTooltipClass="vitamui-tooltip"
+      [disabled]="ingestStatus(ingest) === 'KO' || ingestStatus(ingest) === 'FATAL' || ingestStatus(ingest) === 'En cours'"
+    >
+      {{ 'INGEST_DETAIL.DOWNLOAD_DOCX' | translate }}
     </button>
   </vitamui-common-menu-button>
 </vitamui-common-sidenav-header>
 
 <div class="vitamui-sidepanel-body">
   <mat-tab-group class="preview-tab-group">
-    <mat-tab label="{{'INGEST_DETAIL.DETAILS' | translate}}">
+    <mat-tab label="{{ 'INGEST_DETAIL.DETAILS' | translate }}">
       <app-ingest-information-tab [ingest]="ingest"></app-ingest-information-tab>
     </mat-tab>
   </mat-tab-group>

--- a/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-preview.component.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-preview.component.ts
@@ -41,28 +41,23 @@ import { IngestService } from '../ingest.service';
 @Component({
   selector: 'app-ingest-preview',
   templateUrl: './ingest-preview.component.html',
-  styleUrls: ['./ingest-preview.component.scss']
+  styleUrls: ['./ingest-preview.component.scss'],
 })
 export class IngestPreviewComponent implements OnInit {
-
   @Input() ingest: any; // Make a type ?
   @Output() previewClose = new EventEmitter();
- 
 
-  constructor(private logbookService: LogbookService, private ingestService : IngestService) { }
+  constructor(private logbookService: LogbookService, private ingestService: IngestService) {}
 
-  ngOnInit() {
-
-  }
+  ngOnInit() {}
 
   emitClose() {
     this.previewClose.emit();
   }
 
   filterEvents(event: any): boolean {
-    return event.outDetail && (
-      event.outDetail.includes('EXT_VITAMUI_UPDATE_INGEST') ||
-      event.outDetail.includes('EXT_VITAMUI_CREATE_INGEST')
+    return (
+      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_UPDATE_INGEST') || event.outDetail.includes('EXT_VITAMUI_CREATE_INGEST'))
     );
   }
 
@@ -81,8 +76,7 @@ export class IngestPreviewComponent implements OnInit {
     if (this.getOperationStatus(ingest) === 'En cours') {
       return 'En cours';
     } else {
-      return (ingest.events !== undefined && ingest.events.length !== 0) ?
-        ingest.events[ingest.events.length - 1].outcome : ingest.outcome;
+      return ingest.events !== undefined && ingest.events.length !== 0 ? ingest.events[ingest.events.length - 1].outcome : ingest.outcome;
     }
   }
 
@@ -94,7 +88,7 @@ export class IngestPreviewComponent implements OnInit {
     this.logbookService.downloadATR(this.ingest.id);
   }
 
-  generateDocX() {
-    this.ingestService.downloadDocxReport(this.ingest.id);
+  downloadODTReport() {
+    this.ingestService.downloadODTReport(this.ingest.id);
   }
 }

--- a/ui/ui-frontend/projects/ingest/src/app/ingest/ingest.service.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/ingest/ingest.service.ts
@@ -40,15 +40,11 @@ import { Observable } from 'rxjs';
 import { SearchService } from 'ui-frontend-common';
 import { IngestApiService } from '../core/api/ingest-api.service';
 
-
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class IngestService extends SearchService<any> {
-  constructor(
-    private ingestApiService: IngestApiService,
-    http: HttpClient
-  ) {
+  constructor(private ingestApiService: IngestApiService, http: HttpClient) {
     super(http, ingestApiService, 'ALL');
   }
 
@@ -69,12 +65,11 @@ export class IngestService extends SearchService<any> {
     return this.ingestApiService.getOne(id);
   }
 
-  downloadDocxReport(id : string)  {
-    return this.ingestApiService.downloadDocxReport(id).subscribe(file => {
-
+  downloadODTReport(id: string) {
+    return this.ingestApiService.downloadODTReport(id).subscribe((file) => {
       const element = document.createElement('a');
       element.href = window.URL.createObjectURL(file);
-      element.download ='Bordereau-' + id + '.docx';
+      element.download = 'Bordereau-' + id + '.docx';
       element.style.visibility = 'hidden';
       document.body.appendChild(element);
       element.click();

--- a/ui/ui-frontend/projects/referential/src/app/app.module.ts
+++ b/ui/ui-frontend/projects/referential/src/app/app.module.ts
@@ -1,23 +1,20 @@
-import {registerLocaleData} from '@angular/common';
+import { registerLocaleData } from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
-import {LOCALE_ID, NgModule} from '@angular/core';
-import {MatNativeDateModule} from '@angular/material/core';
-import {BrowserModule, Title} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {NgxFilesizeModule} from 'ngx-filesize';
-import {VitamUICommonModule, WINDOW_LOCATION} from 'ui-frontend-common';
-
-import {AppRoutingModule} from './app-routing.module';
-import {AppComponent} from './app.component';
-import {CoreModule} from './core/core.module';
-import {SharedModule} from './shared/shared.module';
+import { LOCALE_ID, NgModule } from '@angular/core';
+import { MatNativeDateModule } from '@angular/material/core';
+import { BrowserModule, Title } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { NgxFilesizeModule } from 'ngx-filesize';
+import { VitamUICommonModule, WINDOW_LOCATION } from 'ui-frontend-common';
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { CoreModule } from './core/core.module';
+import { SharedModule } from './shared/shared.module';
 
 registerLocaleData(localeFr, 'fr');
 
 @NgModule({
-  declarations: [
-    AppComponent,
-  ],
+  declarations: [AppComponent],
   imports: [
     CoreModule,
     BrowserAnimationsModule,
@@ -26,14 +23,9 @@ registerLocaleData(localeFr, 'fr');
     AppRoutingModule,
     MatNativeDateModule,
     NgxFilesizeModule,
-    SharedModule
+    SharedModule,
   ],
-  providers: [
-    Title,
-    {provide: LOCALE_ID, useValue: 'fr'},
-    {provide: WINDOW_LOCATION, useValue: window.location}
-  ],
+  providers: [Title, { provide: LOCALE_ID, useValue: 'fr' }, { provide: WINDOW_LOCATION, useValue: window.location }],
   bootstrap: [AppComponent],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.html
@@ -53,7 +53,7 @@
               <vitamui-common-textarea formControlName="description" placeholder="Description" [rows]="4" required="required">
                 <ng-container *ngIf="form.get('description')?.touched">
                   <vitamui-common-input-error *ngIf="!!form.get('description')?.errors?.required">
-                    {{ 'COMMON.REQUIRED' | translate }}
+                    Champ requis
                   </vitamui-common-input-error>
                 </ng-container>
               </vitamui-common-textarea>
@@ -61,8 +61,8 @@
           </div>
         </div>
         <div class="actions">
-          <button type="button" class="btn primary" cdkStepperNext [disabled]="firstStepInvalid()">{{ 'COMMON.NEXT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="button" class="btn primary" cdkStepperNext [disabled]="firstStepInvalid()">Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
       </div>
     </cdk-step>
@@ -103,12 +103,12 @@
           </div>
         </div>
         <div class="actions">
-          <button type="button" class="btn primary" cdkStepperNext>{{ 'COMMON.NEXT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="button" class="btn primary" cdkStepperNext>Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
         <button type="button" class="back" cdkStepperPrevious>
           <i class="material-icons">arrow_back</i>
-          <ng-container>{{ 'COMMON.BACK' | translate }}</ng-container>
+          <ng-container>Retour</ng-container>
         </button>
       </div>
     </cdk-step>
@@ -171,12 +171,12 @@
           </div>
         </div>
         <div class="actions">
-          <button type="button" class="btn primary" cdkStepperNext [disabled]="thirdStepInvalid()">{{ 'COMMON.NEXT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="button" class="btn primary" cdkStepperNext [disabled]="thirdStepInvalid()">Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
         <button type="button" class="back" cdkStepperPrevious>
           <i class="material-icons">arrow_back</i>
-          <ng-container>{{ 'COMMON.BACK' | translate }}</ng-container>
+          <ng-container>Retour</ng-container>
         </button>
       </div>
     </cdk-step>
@@ -234,12 +234,12 @@
           </div>
         </div>
         <div class="actions">
-          <button type="button" class="btn primary" cdkStepperNext [disabled]="fourthStepInvalid()">{{ 'COMMON.NEXT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="button" class="btn primary" cdkStepperNext [disabled]="fourthStepInvalid()">Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
         <button type="button" class="back" cdkStepperPrevious>
           <i class="material-icons">arrow_back</i>
-          <ng-container>{{ 'COMMON.BACK' | translate }}</ng-container>
+          <ng-container>Retour</ng-container>
         </button>
       </div>
     </cdk-step>
@@ -298,12 +298,12 @@
         </div>
 
         <div class="actions">
-          <button type="button" class="btn primary" cdkStepperNext>{{ 'COMMON.NEXT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="button" class="btn primary" cdkStepperNext>Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
         <button type="button" class="back" cdkStepperPrevious>
           <i class="material-icons">arrow_back</i>
-          <ng-container>{{ 'COMMON.BACK' | translate }}</ng-container>
+          <ng-container>Retour</ng-container>
         </button>
       </div>
     </cdk-step>
@@ -350,12 +350,12 @@
           </div>
         </div>
         <div class="actions">
-          <button type="button" class="btn primary" cdkStepperNext>{{ 'COMMON.NEXT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="button" class="btn primary" cdkStepperNext>Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
         <button type="button" class="back" cdkStepperPrevious>
           <i class="material-icons">arrow_back</i>
-          <ng-container>{{ 'COMMON.BACK' | translate }}</ng-container>
+          <ng-container>Retour</ng-container>
         </button>
       </div>
     </cdk-step>
@@ -382,12 +382,12 @@
           ></vitamui-library-filing-plan>
         </div>
         <div class="actions">
-          <button type="submit" class="btn primary" [disabled]="seventhStepInvalid()">{{ 'COMMON.SUBMIT' | translate }}</button>
-          <button type="button" class="btn cancel" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
+          <button type="submit" class="btn primary" [disabled]="seventhStepInvalid()">Terminer</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
         </div>
         <button type="button" class="back" cdkStepperPrevious>
           <i class="material-icons">arrow_back</i>
-          <ng-container>{{ 'COMMON.BACK' | translate }}</ng-container>
+          <ng-container>Retour</ng-container>
         </button>
       </div>
     </cdk-step>

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
@@ -37,18 +37,17 @@
 import { HttpHeaders, HttpParams } from '@angular/common/http';
 import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import '@angular/localize/init';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { FileFormat, FilingPlanMode, IngestContract } from 'projects/vitamui-library/src/public-api';
 import { Subscription } from 'rxjs';
-import { ConfirmDialogService, Option, ExternalParametersService, ExternalParameters } from 'ui-frontend-common';
-
+import { ConfirmDialogService, ExternalParameters, ExternalParametersService, Option } from 'ui-frontend-common';
 import { ArchiveProfileApiService } from '../../core/api/archive-profile-api.service';
 import { ManagementContractApiService } from '../../core/api/management-contract-api.service';
 import { FileFormatService } from '../../file-format/file-format.service';
 import { IngestContractService } from '../ingest-contract.service';
 import { IngestContractCreateValidators } from './ingest-contract-create.validators';
-import '@angular/localize/init';
 
 const PROGRESS_BAR_MULTIPLICATOR = 100;
 

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-attachment-tab/ingest-contract-attachment-tab.component.spec.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-attachment-tab/ingest-contract-attachment-tab.component.spec.ts
@@ -1,18 +1,18 @@
-import {NO_ERRORS_SCHEMA} from '@angular/core';
-import {ComponentFixture,TestBed,waitForAsync} from '@angular/core/testing';
-import {MatDialog} from '@angular/material/dialog';
-import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {SearchUnitApiService} from 'projects/vitamui-library/src/public-api';
-import {of} from 'rxjs';
-import {ExternalParameters,ExternalParametersService} from 'ui-frontend-common';
-import {IngestContractAttachmentTabComponent} from './ingest-contract-attachment-tab.component';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { SearchUnitApiService } from 'projects/vitamui-library/src/public-api';
+import { of } from 'rxjs';
+import { ExternalParameters, ExternalParametersService, LoggerModule } from 'ui-frontend-common';
+import { AccessContractService } from '../../../access-contract/access-contract.service';
+import { IngestContractAttachmentTabComponent } from './ingest-contract-attachment-tab.component';
 
-
-describe('IngestContractAttachmentTabComponent',() => {
+describe('IngestContractAttachmentTabComponent', () => {
   let component: IngestContractAttachmentTabComponent;
   let fixture: ComponentFixture<IngestContractAttachmentTabComponent>;
 
-  const ingestContractValue={
+  const ingestContractValue = {
     tenant: 0,
     version: 1,
     description: 'desc',
@@ -35,28 +35,32 @@ describe('IngestContractAttachmentTabComponent',() => {
     formatType: [''],
     archiveProfiles: [''],
     managementContractId: 'MC-000001',
-    computeInheritedRulesAtIngest: true
+    computeInheritedRulesAtIngest: true,
   };
 
   beforeEach(
     waitForAsync(() => {
-      const parameters: Map<string,string>=new Map<string,string>();
-      parameters.set(ExternalParameters.PARAM_ACCESS_CONTRACT,'1');
-      const externalParametersServiceMock={
+      const parameters: Map<string, string> = new Map<string, string>();
+      parameters.set(ExternalParameters.PARAM_ACCESS_CONTRACT, '1');
+      const externalParametersServiceMock = {
         getUserExternalParameters: () => of(parameters),
       };
 
-      const unitValueMock={
+      const unitValueMock = {
         getByDsl: () => of({}),
+      };
+      const accessContractServiceMock = {
+        getAll: () => of([]),
       };
 
       TestBed.configureTestingModule({
         declarations: [IngestContractAttachmentTabComponent],
-        imports: [MatSnackBarModule],
+        imports: [MatSnackBarModule, LoggerModule.forRoot()],
         providers: [
-          {provide: MatDialog,useValue: {}},
-          {provide: SearchUnitApiService,useValue: unitValueMock},
-          {provide: ExternalParametersService,useValue: externalParametersServiceMock},
+          { provide: MatDialog, useValue: {} },
+          { provide: SearchUnitApiService, useValue: unitValueMock },
+          { provide: AccessContractService, useValue: accessContractServiceMock },
+          { provide: ExternalParametersService, useValue: externalParametersServiceMock },
         ],
         schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
@@ -64,13 +68,13 @@ describe('IngestContractAttachmentTabComponent',() => {
   );
 
   beforeEach(() => {
-    fixture=TestBed.createComponent(IngestContractAttachmentTabComponent);
-    component=fixture.componentInstance;
-    component.ingestContract=ingestContractValue;
+    fixture = TestBed.createComponent(IngestContractAttachmentTabComponent);
+    component = fixture.componentInstance;
+    component.ingestContract = ingestContractValue;
     fixture.detectChanges();
   });
 
-  it('should create',() => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-attachment-tab/ingest-contract-attachment-tab.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-attachment-tab/ingest-contract-attachment-tab.component.ts
@@ -1,13 +1,13 @@
 /* tslint:disable:object-literal-key-quotes quotemark */
 import { HttpHeaders } from '@angular/common/http';
 import { Component, Input, OnInit } from '@angular/core';
+import '@angular/localize/init';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AccessContract, IngestContract, SearchUnitApiService } from 'projects/vitamui-library/src/public-api';
-
+import { ExternalParameters, ExternalParametersService, Logger } from 'ui-frontend-common';
+import { AccessContractService } from '../../../access-contract/access-contract.service';
 import { IngestContractNodeUpdateComponent } from './ingest-contract-nodes-update/ingest-contract-node-update.component';
-import { ExternalParametersService, ExternalParameters } from 'ui-frontend-common';
-import '@angular/localize/init';
 
 @Component({
   selector: 'app-ingest-contract-attachment-tab',
@@ -25,7 +25,6 @@ export class IngestContractAttachmentTabComponent implements OnInit {
   accessContracts: AccessContract[];
   titles: any = {};
 
-  // tslint:disable-next-line:variable-name
   private _ingestContract: IngestContract;
 
   previousValue = (): IngestContract => {
@@ -43,17 +42,20 @@ export class IngestContractAttachmentTabComponent implements OnInit {
 
   @Input()
   set readOnly(readOnly: boolean) {
-    console.log('RO:', readOnly);
+    this.logger.info('readOnly', readOnly);
   }
 
   constructor(
     private unitService: SearchUnitApiService,
     private externalParameterService: ExternalParametersService,
     private dialog: MatDialog,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private accessContractService: AccessContractService,
+    private logger: Logger
   ) {}
 
   ngOnInit() {
+    this.accessContractService.getAll().subscribe((accessContracts) => (this.accessContracts = accessContracts));
     this.externalParameterService.getUserExternalParameters().subscribe((parameters) => {
       const accessContratId: string = parameters.get(ExternalParameters.PARAM_ACCESS_CONTRACT);
       if (accessContratId && accessContratId.length > 0) {

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract.module.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract.module.ts
@@ -9,7 +9,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
 import { TableFilterModule, VitamUICommonModule } from 'ui-frontend-common';
-
 import { SharedModule } from '../shared/shared.module';
 import { IngestContractCreateModule } from './ingest-contract-create/ingest-contract-create.module';
 import { IngestContractListComponent } from './ingest-contract-list/ingest-contract-list.component';

--- a/ui/ui-ingest/src/main/java/fr/gouv/vitamui/ingest/rest/IngestController.java
+++ b/ui/ui-ingest/src/main/java/fr/gouv/vitamui/ingest/rest/IngestController.java
@@ -45,6 +45,7 @@ import fr.gouv.vitamui.commons.api.logger.VitamUILogger;
 import fr.gouv.vitamui.commons.api.logger.VitamUILoggerFactory;
 import fr.gouv.vitamui.commons.rest.AbstractUiRestController;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationDto;
+import fr.gouv.vitamui.ingest.common.rest.RestApi;
 import fr.gouv.vitamui.ingest.service.IngestService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -108,11 +109,11 @@ public class IngestController extends AbstractUiRestController {
         return ingestService.getOne(buildUiHttpContext(), id);
     }
 
-    @ApiOperation(value = "download Docx Report for an ingest operation")
-    @GetMapping("/docxreport" + CommonConstants.PATH_ID)
-    public ResponseEntity<byte[]> genereateDocX(final @PathVariable("id") String id) {
+    @ApiOperation(value = "download ODT Report for an ingest operation")
+    @GetMapping(RestApi.INGEST_REPORT_ODT + CommonConstants.PATH_ID)
+    public ResponseEntity<byte[]> generateODTReport(final @PathVariable("id") String id) {
         LOGGER.debug("download Docx report for the ingest with id :{}", id);
-        byte[] bytes = ingestService.generateDocX(buildUiHttpContext(), id).getBody();
+        byte[] bytes = ingestService.generateODTReport(buildUiHttpContext(), id).getBody();
         return ResponseEntity.ok()
             .contentType(MediaType.APPLICATION_OCTET_STREAM).header("Content-Disposition", "attachment")
             .body(bytes);

--- a/ui/ui-ingest/src/main/java/fr/gouv/vitamui/ingest/service/IngestService.java
+++ b/ui/ui-ingest/src/main/java/fr/gouv/vitamui/ingest/service/IngestService.java
@@ -93,8 +93,8 @@ public class IngestService extends AbstractPaginateService<LogbookOperationDto> 
         return commonService.checkPagination(page, size);
     }
 
-    public ResponseEntity<byte[]> generateDocX(ExternalHttpContext context, String id) {
-        return ingestExternalRestClient.generateDocX(context, id);
+    public ResponseEntity<byte[]> generateODTReport(ExternalHttpContext context, String id) {
+        return ingestExternalRestClient.generateODTReport(context, id);
     }
 
     public IngestExternalRestClient getClient() {


### PR DESCRIPTION
## Description
Les régressions suivantes sont constatées sur la branche master_4.0.X et reproduites sur INTR16X, elles doivent être corrigées en vue de l'ouverture du service VAS :

- Plusieurs traductions ne sont pas présentes, les noms sont remplacés par des noms techniques : sélection du tenant, écran d'accueil (langue), pop-up de création du groupe de profils et du profil APP Utilisateur (LEVEL-INPUT.SUBLEVEL), message d'obligation dans le contrat d'entrée
- Impossible de créer un contrat d'entrée : fenêtre blanche 
- Il est impossible de modifier l'arborescence d'un contrat d'entrée : la liste des contrats d'accès n'apparait pas
- Le téléchargement du bdx de versement est en erreur


## Type de changement:
* Nouveau Code 
* Refactorisation de code
* Modification Ansible


## Documentation:

## Tests:
- Des tests fonctionnels sont effectués pour vérifier le fonctionnement de cette évolution.

## Migration:
- Pas de modification au niveau de la DB, 
- pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)