### PR TITLE
[VAS] Ticket 8448 : Disable merge_index_apache task in reverse role

### DIFF
--- a/deployment/roles/reverse/tasks/main.yml
+++ b/deployment/roles/reverse/tasks/main.yml
@@ -3,8 +3,9 @@
 - import_tasks: apache.yml
   when: reverse|lower == 'apache'
 
-- import_tasks: merge_index_apache.yml
-  when: reverse|lower == 'apache'  
+# Task breaking deployments (cf. ticket #8448)
+#- import_tasks: merge_index_apache.yml
+#  when: reverse|lower == 'apache'
 
 - import_tasks: nginx.yml
   when: reverse|lower == 'nginx'


### PR DESCRIPTION
La tâche `merge_index_apache` du rôle `reverse` casse les déploiements, comme cela a été remonté dans le ticket #8448.

Ce correctif temporaire commente la tâche afin qu'elle ne soit pas exécutée. Il conviendra de réadapter le code dans un second temps pour retrouver les liens Vitam UI sur la page d'accès rapide aux outils.