### PR TITLE
fix cea bug for vitam ui deployment

### DIFF
--- a/deployment/README.rst
+++ b/deployment/README.rst
@@ -194,11 +194,15 @@ ansible-playbook --become -i <inventaire> bootstrap.yml --vault-password-file va
 
 Déploiement
 =============
-
 *Playbook* ::
+   
+  ansible-playbook -i <inventaire> vitamui.yml --vault-password-file vault_pass.txt [ --extra-vars=@./environments/vitamui_extra_vars.yml ] [-e extra=yes]
 
-   ansible-playbook -i <inventaire> vitamui.yml --vault-password-file vault_pass.txt [ --extra-vars=@./environments/vitamui_extra_vars.yml ]
+pour deployer le browser , le reverse et les liens d'accès rapide vitam-ui il faut mettre la variable extra vars:  extra=yes
 
+ATTENTION: il faut avoir déployer aussi les extras Vitam, sinon le déploiement plantera. 
+
+en l'absence ce cette extra vars, le comportement par defaut est extra=no
 
 Désinstallation
 =================

--- a/deployment/roles/browser/tasks/main.yml
+++ b/deployment/roles/browser/tasks/main.yml
@@ -3,80 +3,81 @@
 #  package:
 #    name: vitam-user-vitam
 #    state: latest
-
-- name: Install Apache package for displaying data content
-  package:
-    name: httpd
-  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
-
-- name: Install Apache package for displaying data content
-  package:
-    name: apache2
-  when: ( ansible_distribution == "Debian")
-
-# TODO : idéalement, Apache ne devrait écouter que sur l'IP d'admin
-
-- name: Ensure  Apache autostart && Apache is started on Centos
-  service: 
-    name: httpd
-    enabled: yes
-    state: started
-  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
-
-- name: Ensure  Apache autostart && Apache is started on Debian
-  service: 
-    name: apache2
-    enabled: yes
-    state: started
-  when: (ansible_distribution == "Debian" )
-
-- name: add vitamui group to apache user on Centos
-  user:
-    name: apache
-    groups: vitamui
-  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
-
-- name: add vitamui group to apache user on Centos
-  user:
-    name: www-data
-    groups: vitamui
-  when: (ansible_distribution == "Debian" )
-
-- name: copy theme files
-  copy:
-    src: ".theme"
-    dest: "{{vitamui_defaults.folder.root_path}}"
-    owner: "root"
-    mode: 0644
-
-- name: add configuration file for mapping on Centos # + notify httpd restart
-  template:
-    src: "{{item}}.j2"
-    dest: "/etc/httpd/conf.d/{{item}}"
-    mode: 0500
-    owner: root
-  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
-  notify: restart apache
-  with_items:
-  - "httpd-offer-view.conf"
-
-- name: add configuration file for mapping on Debian # + notify httpd restart
-  template:
-    src: "{{item}}.j2"
-    dest: "/etc/apache2/sites-available/{{item}}"
-    mode: 0500
-    owner: root
-  when: (ansible_distribution == "Debian" )
-  notify: restart apache2
-  with_items:
-  - "httpd-offer-view.conf"
-
-- name: activate offer view in Debian only
-  file:
-    src: '/etc/apache2/sites-available/{{item}}'
-    dest: '/etc/apache2/sites-enabled/{{item}}'
-    state: link
-  when: (ansible_distribution == "Debian" )
-  notify: restart apache2
-  with_items:
-  - "httpd-offer-view.conf"
+- block:
+  - name: Install Apache package for displaying data content
+    package:
+      name: httpd
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+  
+  - name: Install Apache package for displaying data content
+    package:
+      name: apache2
+    when: ( ansible_distribution == "Debian")
+  
+  # TODO : idéalement, Apache ne devrait écouter que sur l'IP d'admin
+  
+  - name: Ensure  Apache autostart && Apache is started on Centos
+    service: 
+      name: httpd
+      enabled: yes
+      state: started
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+  
+  - name: Ensure  Apache autostart && Apache is started on Debian
+    service: 
+      name: apache2
+      enabled: yes
+      state: started
+    when: (ansible_distribution == "Debian" )
+  
+  - name: add vitamui group to apache user on Centos
+    user:
+      name: apache
+      groups: vitamui
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+  
+  - name: add vitamui group to apache user on Centos
+    user:
+      name: www-data
+      groups: vitamui
+    when: (ansible_distribution == "Debian" )
+  
+  - name: copy theme files
+    copy:
+      src: ".theme"
+      dest: "{{vitamui_defaults.folder.root_path}}"
+      owner: "root"
+      mode: 0644
+  
+  - name: add configuration file for mapping on Centos # + notify httpd restart
+    template:
+      src: "{{item}}.j2"
+      dest: "/etc/httpd/conf.d/{{item}}"
+      mode: 0500
+      owner: root
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+    notify: restart apache
+    with_items:
+    - "httpd-offer-view.conf"
+  
+  - name: add configuration file for mapping on Debian # + notify httpd restart
+    template:
+      src: "{{item}}.j2"
+      dest: "/etc/apache2/sites-available/{{item}}"
+      mode: 0500
+      owner: root
+    when: (ansible_distribution == "Debian" )
+    notify: restart apache2
+    with_items:
+    - "httpd-offer-view.conf"
+  
+  - name: activate offer view in Debian only
+    file:
+      src: '/etc/apache2/sites-available/{{item}}'
+      dest: '/etc/apache2/sites-enabled/{{item}}'
+      state: link
+    when: (ansible_distribution == "Debian" )
+    notify: restart apache2
+    with_items:
+    - "httpd-offer-view.conf"
+  when: extra | d(false)

--- a/deployment/roles/reverse/tasks/main.yml
+++ b/deployment/roles/reverse/tasks/main.yml
@@ -3,9 +3,5 @@
 - import_tasks: apache.yml
   when: reverse|lower == 'apache'
 
-# Task breaking deployments (cf. ticket #8448)
-#- import_tasks: merge_index_apache.yml
-#  when: reverse|lower == 'apache'
-
 - import_tasks: nginx.yml
   when: reverse|lower == 'nginx'

--- a/deployment/vitamui.yml
+++ b/deployment/vitamui.yml
@@ -24,5 +24,5 @@
 
 - import_playbook: reverse_proxy.yml
 
-# for dev and integration purpose
+# condition with extra vars -e extra=yes inside roles
 - import_playbook: vitamui_extra.yml

--- a/deployment/vitamui_extra.yml
+++ b/deployment/vitamui_extra.yml
@@ -4,3 +4,11 @@
   gather_facts: yes
   roles:
     - browser
+
+- hosts: hosts_vitamui_reverseproxy
+  tasks:  
+    - name: merge index
+      include_role:
+        name: reverse
+        tasks_from: merge_index_apache
+      when: reverse|lower == 'apache' and extra | d(false)


### PR DESCRIPTION
## Description
Cette PR permet de palier au bug remonté par le CEA [8676].
Elle propose de mettre en place une extra vars -e extra=yes qui permet de déployer le browser et les liens dans la page d'acces rapide vitam-ui. si l'extra vars est ommise, alors la valeur par défaut est extra=no.

## Type de changement:
Ansiblerie vitam-ui




## Contributeur
Vitam Accessible en Service (VAS)