### PR TITLE
[VAS] Bug 8660 - Make application EXTERNAL_PARAM_PROFILE_APP multi tenant

### DIFF
--- a/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/externalparamprofile/service/ExternalParamProfileInternalService.java
+++ b/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/externalparamprofile/service/ExternalParamProfileInternalService.java
@@ -40,12 +40,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.CommonConstants;
+import fr.gouv.vitamui.commons.api.domain.CriterionOperator;
 import fr.gouv.vitamui.commons.api.domain.DirectionDto;
 import fr.gouv.vitamui.commons.api.domain.ExternalParamProfileDto;
 import fr.gouv.vitamui.commons.api.domain.ExternalParametersDto;
 import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.domain.ParameterDto;
 import fr.gouv.vitamui.commons.api.domain.ProfileDto;
+import fr.gouv.vitamui.commons.api.domain.QueryDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.logger.VitamUILogger;
 import fr.gouv.vitamui.commons.api.logger.VitamUILoggerFactory;
@@ -112,7 +114,11 @@ public class ExternalParamProfileInternalService {
 
     public PaginatedValuesDto<ExternalParamProfileDto> getAllPaginated(final Integer page, final Integer size,
         final String criteria, final String orderBy, final DirectionDto direction) {
-        return externalParamProfileRepository.getAllPaginated(page, size, criteria, orderBy, direction);
+        final Integer tenantIdentifier = internalSecurityService.getTenantIdentifier();
+        QueryDto queryDto = QueryDto.fromJson(criteria);
+        queryDto
+            .addQuery(QueryDto.andQuery().addCriterion("tenantIdentifier", tenantIdentifier, CriterionOperator.EQUALS));
+        return externalParamProfileRepository.getAllPaginated(page, size, queryDto.toJson(), orderBy, direction);
     }
 
     @Transactional

--- a/deployment/scripts/mongod/2.0.0/38_update_external_params_profiles_app_multi_tenant_flag.js.j2
+++ b/deployment/scripts/mongod/2.0.0/38_update_external_params_profiles_app_multi_tenant_flag.js.j2
@@ -1,0 +1,16 @@
+db = db.getSiblingDB('iam')
+
+print("START_38_update_external_params_profiles_app_multi_tenant_flag.js");
+
+// -------- EXTERNAL_PARAM_PROFILE_APP  -----
+
+db.applications.update({
+   "identifier":"EXTERNAL_PARAM_PROFILE_APP"
+},
+{
+   $set:{
+      "hasTenantList":true
+   }
+});
+
+print("END_38_update_external_params_profiles_app_multi_tenant_flag.js");


### PR DESCRIPTION
## Description
Cette PR permet de pemettre la ségrégation des paramètres externales par tenants.


## Type de changement:
* Intégration implicite du tenant dans la recherche des externes params

## Tests:
- Des test unitaires et IT backend
- Des tests fonctionnels

## Migration:
- pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)