### PR TITLE
[Vas] Item 8660: add forgotten roles for profile app_external_params_profils

### DIFF
--- a/api/api-iam/iam-internal/src/main/config/customer-init.yml
+++ b/api/api-iam/iam-internal/src/main/config/customer-init.yml
@@ -150,6 +150,9 @@ customer-init:
         - ROLE_CREATE_EXTERNAL_PARAM_PROFILE
         - ROLE_EDIT_EXTERNAL_PARAM_PROFILE
         - ROLE_SEARCH_EXTERNAL_PARAM_PROFILE
+        - ROLE_GET_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_LOGBOOKS
 
 
     - name: Consultation

--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -157,6 +157,9 @@ customer-init:
         - ROLE_CREATE_EXTERNAL_PARAM_PROFILE
         - ROLE_EDIT_EXTERNAL_PARAM_PROFILE
         - ROLE_SEARCH_EXTERNAL_PARAM_PROFILE
+        - ROLE_GET_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_LOGBOOKS
 
     - name: Consultation
       description: Profil pour la recherche et consultation des archives dans Vitam avec mises à jour des règles, sans export DIP et sans élimination

--- a/deployment/scripts/mongod/2.0.0/39_update_external_params_profiles_app_multi_tenant_flag.js.j2
+++ b/deployment/scripts/mongod/2.0.0/39_update_external_params_profiles_app_multi_tenant_flag.js.j2
@@ -1,0 +1,24 @@
+db = db.getSiblingDB('iam')
+
+print("START_39_update_external_params_profiles_app_multi_tenant_flag.js");
+
+// -------- EXTERNAL_PARAM_PROFILE_APP  -----
+
+db.profiles.update({
+   "applicationName":"EXTERNAL_PARAM_PROFILE_APP"
+},
+{
+      $addToSet:{
+           "roles":{
+              $each:[
+                 {
+                    "name":"ROLE_GET_PROFILES",
+                    "name":"ROLE_UPDATE_PROFILES",
+                    "name":"ROLE_LOGBOOKS"
+                 }
+              ]
+           }
+        }
+});
+
+print("END_39_update_external_params_profiles_app_multi_tenant_flag.js");


### PR DESCRIPTION
## Description
Cette PR permet l'ajout des profils de recupération des logbooks et les profils pour l'application des paramètres externes (corrige un bug sur le panneau latéral de  l'application des paramètres externales ) .


## Type de changement:
* Scripts Ansible d'ajout de roles

## Tests:
- Des test unitaires et IT backend
- Des tests fonctionnels

## Migration:
- pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)