### PR TITLE
CP R16 - Fix wrong serviceca certificate in reverse apache.

### DIFF
--- a/deployment/roles/reverse/tasks/apache/apache.yml
+++ b/deployment/roles/reverse/tasks/apache/apache.yml
@@ -111,15 +111,6 @@
   with_fileglob:
     - "{{ inventory_dir }}/certs/server/ca/*.crt"
 
-- name: Copy the CA (servicesca)
-  copy:
-    src: "{{ inventory_dir }}/certs/server/hosts/{{ inventory_hostname }}/servicesca.pem"
-    dest:  "/etc/{{ apache_service }}/certs/servicesca.pem"
-    owner: "root"
-    group: "{{ apache_group }}"
-    mode: 0400
-  when: (vitam_reverse_external_protocol is defined) and (vitam_reverse_external_protocol == 'https')
-
 - name: copy httpd configuration template
   template:
     src: "apache/httpd_config"

--- a/deployment/roles/reverse/templates/apache/httpd_config
+++ b/deployment/roles/reverse/templates/apache/httpd_config
@@ -5,7 +5,6 @@
     SSLEngine on
     SSLCertificateFile /etc/{{apache_service}}/certs/reverse.crt
     SSLCertificateKeyFile /etc/{{apache_service}}/certs/reverse.key
-    SSLCACertificateFile /etc/{{apache_service}}/certs/servicesca.pem
     ServerName reverse.service.{{ consul_domain }}
     ServerAlias {{ vitam_reverse_external_dns }}
     ServerAlias {{ ip_service }}


### PR DESCRIPTION
```
[2021-09-23T10:42:52.616Z] TASK [reverse : Copy the CA (servicesca)] **************************************

[2021-09-23T10:42:52.616Z] task path: /var/lib/jenkins/workspace/vitam-deploy_meu/vitamui.git/deployment/roles/reverse/tasks/apache/apache.yml:114

[2021-09-23T10:42:52.616Z] Thursday 23 September 2021  12:42:52 +0200 (0:00:00.250)       0:00:09.031 **** 

[2021-09-23T10:42:52.692Z] An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option

[2021-09-23T10:42:52.692Z] fatal: [vitam-env-reverse.vitam-env]: FAILED! => {"changed": false, "msg": "Could not find or access '/var/lib/jenkins/workspace/vitam-deploy_meu/vitamui.git/deployment/environments/certs/server/hosts/vitam-env-reverse.vitam-env/servicesca.pem' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```