### PR TITLE
Fix path for merge_index_apache

### DIFF
--- a/deployment/vitamui_extra.yml
+++ b/deployment/vitamui_extra.yml
@@ -1,13 +1,14 @@
 ---
-   - hosts: hosts_browse
-     gather_facts: yes
-     roles:
-       - browser
-     
-   - hosts: hosts_vitamui_reverseproxy
-     tasks:  
-       - name: merge index
-         include_role:
-           name: reverse
-           tasks_from: merge_index_apache
-         when: reverse|lower == 'apache' and extra | d(false)
+
+- hosts: hosts_browse
+  gather_facts: yes
+  roles:
+    - browser
+
+- hosts: hosts_vitamui_reverseproxy
+  tasks:
+    - name: merge index
+      include_role:
+        name: reverse
+        tasks_from: apache/merge_index_apache
+      when: reverse|lower == 'apache' and extra | d(false)


### PR DESCRIPTION
```
[2021-09-23T23:58:16.351Z] TASK [merge index] *************************************************************
[2021-09-23T23:58:16.351Z] [1;30mtask path: /var/lib/jenkins/workspace/vitam-deploy_int/vitamui.git/deployment/vitamui_extra.yml:9[0m
[2021-09-23T23:58:16.413Z] [0;31mERROR! Could not find specified file in role: tasks/merge_index_apache
```