### PR TITLE
[VAS] Bug-8660- Fix wrong tenant on creating external params profile

### DIFF
--- a/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/externalparamprofile/service/ExternalParamProfileInternalService.java
+++ b/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/externalparamprofile/service/ExternalParamProfileInternalService.java
@@ -126,7 +126,7 @@ public class ExternalParamProfileInternalService {
         LOGGER.debug("create access external parameter profile");
         LOGGER.debug("create {}, {}, {} ", entityDto.getName(), entityDto.getDescription(),
             entityDto.getAccessContract());
-
+        final Integer tenantIdentifier = internalSecurityService.getTenantIdentifier();
         AuthUserDto authUserDto = internalSecurityService.getUser();
 
         String externalParamIdentifier =
@@ -140,7 +140,7 @@ public class ExternalParamProfileInternalService {
             entityDto.isEnabled(),
             false,
             "",
-            authUserDto.getProofTenantIdentifier(),
+            tenantIdentifier,
             CommonConstants.EXTERNAL_PARAMS_APP,
             List.of(
                 ServicesData.ROLE_GET_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE,


### PR DESCRIPTION
## Description
Cette PR permet de corriger un bug de création de profil external params dans un mauvais tenant.

## Type de changement:
* Correction de l'application App profile externa params
 

## Tests:
- Des test unitaires ont été fait
- Des tests fonctionnels également

## Migration:
- pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)