### PR TITLE
[VAS] BUG 8754 start end dates filters search

### DIFF
--- a/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/common/ArchiveSearchConsts.java
+++ b/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/common/ArchiveSearchConsts.java
@@ -157,11 +157,9 @@ public class ArchiveSearchConsts {
     /* Query fields */
     public static final String IDENTIFIER = "Identifier";
     public static final String UNIT_TYPE = "#unitType";
-    public static final String START_DATE = "StartDate";
     public static final String PRODUCER_SERVICE = "#originating_agency";
     public static final String GUID = "#id";
     public static final String UNITS_UPS = "#allunitups";
-    public static final String END_DATE = "EndDate";
     public static final String TITLE_OR_DESCRIPTION = "TITLE_OR_DESCRIPTION";
     public static final String ELIMINATION_TECHNICAL_ID = "ELIMINATION_TECHNICAL_ID";
     public static final String ELIMINATION_GUID = "#elimination.OperationId";
@@ -182,6 +180,10 @@ public class ArchiveSearchConsts {
     public static final String TITLE_CRITERIA = "TITLE";
     public static final String DESCRIPTION_CRITERIA = "DESCRIPTION";
 
-
+    /* StartDate and EndDate Query fields */
+    public static final String START_DATE = "StartDate";
+    public static final String START_DATE_CRITERIA = "START_DATE";
+    public static final String END_DATE = "EndDate";
+    public static final String END_DATE_CRITERIA = "END_DATE";
 
 }

--- a/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/dsl/VitamQueryHelper.java
+++ b/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/dsl/VitamQueryHelper.java
@@ -94,7 +94,7 @@ public class VitamQueryHelper {
                 query.add(buildSubQueryByOperator(searchKey, searchValues.stream().findAny().get(), operator));
             }
 
-
+            
 
     }
 
@@ -102,6 +102,12 @@ public class VitamQueryHelper {
         final List<String> searchValues)
         throws InvalidCreateOperationException {
         BooleanQuery subQueryAnd = and();
+        String searchCriteria = ArchiveSearchConsts.START_DATE_CRITERIA.equals(criteria) ?
+            ArchiveSearchConsts.START_DATE :
+            (ArchiveSearchConsts.END_DATE_CRITERIA.equals(criteria) ?
+                ArchiveSearchConsts.END_DATE : null);
+
+        LOGGER.info("The search criteria Date is {} ", searchCriteria);
         if (!CollectionUtils.isEmpty(searchValues)) {
             if (searchValues.size() > 2) {
                 throw new IllegalArgumentException("criteria date should not contains more than 2 values");
@@ -113,22 +119,23 @@ public class VitamQueryHelper {
                         .withMinute(0).withSecond(0).withNano(0);
 
                 subQueryAnd.add(VitamQueryHelper
-                    .buildSubQueryByOperator(criteria, ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER.format(beginDate),
+                    .buildSubQueryByOperator(searchCriteria, ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER.format(beginDate.plusDays(1)),
                         ArchiveSearchConsts.CriteriaOperators.EQ));
+
             } else {
                 LocalDateTime firstDate =
                     LocalDateTime.parse(searchValues.get(0), ArchiveSearchConsts.ISO_FRENCH_FORMATER);
                 LocalDateTime secondDate =
                     LocalDateTime.parse(searchValues.get(1), ArchiveSearchConsts.ISO_FRENCH_FORMATER);
 
-                subQueryAnd.add(VitamQueryHelper.buildSubQueryByOperator(criteria,
-                    ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER
-                        .format(firstDate.isAfter(secondDate) ? secondDate : firstDate),
-                    ArchiveSearchConsts.CriteriaOperators.GTE));
-                subQueryAnd.add(VitamQueryHelper.buildSubQueryByOperator(criteria,
-                    ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER
-                        .format(firstDate.isAfter(secondDate) ? firstDate : secondDate),
-                    ArchiveSearchConsts.CriteriaOperators.LTE));
+                    subQueryAnd.add(VitamQueryHelper.buildSubQueryByOperator(searchCriteria,
+                        ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER
+                            .format(firstDate.isAfter(secondDate) ? secondDate.plusDays(1) : firstDate.plusDays(1)),
+                        ArchiveSearchConsts.CriteriaOperators.GTE));
+                    subQueryAnd.add(VitamQueryHelper.buildSubQueryByOperator(searchCriteria,
+                        ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER
+                            .format(firstDate.isAfter(secondDate) ? firstDate.plusDays(1) : secondDate.plusDays(1)),
+                        ArchiveSearchConsts.CriteriaOperators.LTE));
 
             }
         }


### PR DESCRIPTION
## Description
L'objectif de cette PR est de corriger un souci au niveau de la recherche par date de début et date de fin pour trouver des unités archivistique.
[Ticket TuleUp ](https://tuleap.dev.programmevitam.fr/plugins/tracker/?aid=8754)


## Type de changement:
* Nouveau Code 
* Re-factorisation de code


## Documentation:

## Tests:
- Des tests fonctionnels sont effectués pour vérifier le fonctionnement de cette évolution.

## Migration:
- Pas de modifications au niveau de la DB, 
- Pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)