### PR TITLE
[VAS] 8740 : The inheritance switcher is no longer present on contract creation form

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.html
@@ -247,6 +247,39 @@
     <cdk-step>
       <div class="content">
         <h5>Création d'un contrat d'entrée</h5>
+        <h4>Héritage</h4>
+
+        <div class="form-group">
+          <div class="row">
+            <div class="col-12 form-control">
+              <vitamui-common-slide-toggle formControlName="computeInheritedRulesAtIngest"
+              >Calcul des héritages de règles et d'indexation des échéances
+              </vitamui-common-slide-toggle>
+              <i
+                class="material-icons field-tooltip"
+                matTooltip="Indexation des unités archivistiques indiquée comme invalide lors de leur entrée afin
+                qu'elles fassent l'objet d'un calcul lors d'un processus automatique déclenché périodiquement"
+                matTooltipClass="vitamui-tooltip"
+              >info</i
+              >
+            </div>
+          </div>
+        </div>
+        <div class="actions">
+          <button type="button" class="btn primary" cdkStepperNext>Suivant</button>
+          <button type="button" class="btn cancel" (click)="onCancel()">Annuler</button>
+        </div>
+        <button type="button" class="back" cdkStepperPrevious>
+          <i class="material-icons">arrow_back</i>
+          <ng-container>Retour</ng-container>
+        </button>
+      </div>
+    </cdk-step>
+
+
+    <cdk-step>
+      <div class="content">
+        <h5>Création d'un contrat d'entrée</h5>
         <h4>
           Position de rattachement<i
             class="material-icons field-tooltip"

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
@@ -35,7 +35,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { HttpHeaders, HttpParams } from '@angular/common/http';
-import { Component, Inject, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { AccessContract, FileFormat, FilingPlanMode, IngestContract } from 'projects/vitamui-library/src/public-api';
@@ -70,10 +70,8 @@ export class IngestContractCreateComponent implements OnInit, OnDestroy {
   // We could get the number of steps using ViewChildren(StepComponent) but this triggers a
   // "Expression has changed after it was checked" error so we instead manually define the value.
   // Make sure to update this value whenever you add or remove a step from the  template.
-  private stepCount = 4;
+  private stepCount = 8;
   private keyPressSubscription: Subscription;
-
-  @ViewChild('fileSearch', { static: false }) fileSearch: any;
 
   constructor(
     public dialogRef: MatDialogRef<IngestContractCreateComponent>,
@@ -133,7 +131,7 @@ export class IngestContractCreateComponent implements OnInit, OnDestroy {
 
       /* default */
       masterMandatory: [true, Validators.required],
-      computedInheritedRulesAtIngest: [false, Validators.required],
+      computeInheritedRulesAtIngest: [false, Validators.required],
     });
 
     this.fileFormatService.getAllForTenant('' + this.tenantIdentifier).subscribe((files) => {


### PR DESCRIPTION
## Description
The inheritance switcher is no longer present on contract creation form
## Type de changement:
* Correction 
## Tests:
Tests manuels
## Checklist:
[x] Mon code suit le style de code de ce projet.
[x] Les tests unitaires existants passent avec succès localement.
## Contributeur
VAS
