### PR TITLE
[Vas] Item 7392 - Make timout for iam internal and external for admin action configurable

### DIFF
--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -198,6 +198,9 @@ vitamui:
     port_service: 8101
     port_admin: 7101
     secure: true
+    connect_timeout: 30
+    read_timeout: 30
+    write_timeout: 30
     jvm_log: false
     logging_level: "INFO"
     log:
@@ -215,6 +218,9 @@ vitamui:
     service_name: "vitamui-iam-internal"
     port_service: 8201
     port_admin: 7201
+    connect_timeout: 30
+    read_timeout: 30
+    write_timeout: 30
     secure: true
     jvm_log: false
     logging_level: "INFO"

--- a/deployment/roles/vitamui/templates/iam-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-external/application.yml.j2
@@ -62,6 +62,9 @@ iam-external:
   iam-internal-client:
     server-host: {{ vitamui.iam_internal.host }}
     server-port: {{ vitamui.iam_internal.port_service }}
+    connect-time-out: {{ vitamui.iam_internal.connect_timeout }}
+    read-time-out: {{ vitamui.iam_internal.read_timeout }}
+    write-time-out: {{ vitamui.iam_internal.write_timeout }}
 {% if vitamui.iam_internal.secure|lower == "true" %}
     secure: {{ vitamui.iam_internal.secure|lower }}
     ssl-configuration:

--- a/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
@@ -62,6 +62,9 @@ ui-identity:
   iam-external-client:
     server-host: {{ vitamui.iam_external.host }}
     server-port: {{ vitamui.iam_external.port_service }}
+    connect-time-out: {{ vitamui.iam_external.connect_timeout }}
+    read-time-out: {{ vitamui.iam_external.read_timeout }}
+    write-time-out: {{ vitamui.iam_external.write_timeout }}
 {% if vitamui.iam_external.secure|lower == "true" %}
     secure: true
     ssl-configuration:


### PR DESCRIPTION
## Description
L'objectif de cette PR est de personaliser le timeout des services utilisés dans iam-internal pour corriger un souci de timout lors de la création d'organisation.

[Ticket TuleUp](https://tuleap.dev.programmevitam.fr/plugins/tracker/?aid=7392)


## Type de changement:
* Ansible


## Documentation:

## Tests:
- Des tests fonctionnels sont effectués pour vérifier le fonctionnement de cette évolution.

## Migration:
- Pas de modifications au niveau de la DB, 
- Pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)