### PR TITLE
[VAS] Update nginx vhost configuration for large ingest.

### DIFF
--- a/deployment/roles/reverse/defaults/main.yml
+++ b/deployment/roles/reverse/defaults/main.yml
@@ -2,12 +2,9 @@
 
 vitam_reverse_external_protocol: https
 reverse_connection_params: "acquire=5000 connectiontimeout=300 timeout=600 retry=5"
-reverse_connection_short_params: "acquire=5000 connectiontimeout=300 timeout=50 retry=5"
 
 root_path: "/vitamui/conf"
-nginx_ssl_conf: "/etc/nginx/conf.d/ssl/"
-nginx_conf_dir: "/etc/nginx/conf.d/"
-nginx_log_dir: "/var/log/nginx/"
-nginx_run_dir: "/run/"
-nginx_tmp_dir: "/etc/nginx/tmp/"
-nginx_data_dir: "/usr/share/nginx/html/"
+nginx_ssl_conf: "/etc/nginx/conf.d/ssl"
+nginx_conf_dir: "/etc/nginx/conf.d"
+nginx_log_dir: "/var/log/nginx"
+nginx_tmp_dir: "/etc/nginx/tmp"

--- a/deployment/roles/reverse/tasks/nginx/configure_nginx.yml
+++ b/deployment/roles/reverse/tasks/nginx/configure_nginx.yml
@@ -11,8 +11,6 @@
     - {path: "{{ nginx_ssl_conf }}", mode: 644}
     - {path: "{{ nginx_conf_dir }}", mode: 755}
     - {path: "{{ nginx_tmp_dir }}", mode: 755}
-    - {path: "{{ nginx_run_dir }}", mode: 755}
-    - {path: "{{ nginx_data_dir }}", mode: 755}
     - {path: "{{ nginx_log_dir }}", mode: 755}
   become: true
 

--- a/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
@@ -40,6 +40,17 @@ server {
   location /ingest {
     proxy_pass https://INGEST/ingest;
     include /etc/nginx/conf.d/proxy_params;
+
+    # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
+    # The request body is sent to the proxied server immediately as it is received.
+    proxy_request_buffering off;
+
+    # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    # Sets the maximum allowed size of the client request body.
+    # If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client.
+    # Please be aware that browsers cannot correctly display this error.
+    # Setting size to 0 disables checking of client request body size.
+    client_max_body_size 0;
   }
 {% endif %}
 

--- a/deployment/roles/reverse/templates/nginx/nginx.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/nginx.conf.j2
@@ -1,4 +1,4 @@
-user    {{ reverse_user }} {{  reverse_group }};
+user    {{ reverse_user }} {{ reverse_group }};
 
 worker_processes auto;
 
@@ -18,8 +18,8 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    client_body_temp_path   {{ nginx_tmp_dir }}/nginx;
-    access_log              {{ nginx_log_dir }}/access.log  main;
+    client_body_temp_path   {{ nginx_tmp_dir }}/;
+    access_log              {{ nginx_log_dir }}/access.log main;
     error_log               {{ nginx_log_dir }}/error.log;
 
     # Force consul agent resolution
@@ -57,14 +57,4 @@ http {
     # for more information.
     include {{ nginx_conf_dir }}/*.conf;
 
-   # server {
-   #     listen       80 default_server;
-   #     server_name  _;
-   #     root         {{ nginx_data_dir }};
-
-   #     add_header Content-Security-Policy upgrade-insecure-requests;
-
-        # Status page for consul agent check
-   #     return 301 https://$http_host$request_uri;
-   # }
 }


### PR DESCRIPTION
Bug when uploading large file with nginx reverse.

- Disable proxy_request_buffering.
- Setting client_max_body_size to unlimited.

- Cleaning code.

Tested on VAS environments.