### PR TITLE
[VAS][CP5RCX]Fix jackson sanitize tests, Adapt RequestResponse tests and use released vitam version

### DIFF
--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/owner/service/OwnerInternalServiceIntegTest.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/owner/service/OwnerInternalServiceIntegTest.java
@@ -1,33 +1,7 @@
 package fr.gouv.vitamui.iam.internal.server.owner.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import javax.ws.rs.core.Response;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
-import org.springframework.test.context.junit4.SpringRunner;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-
 import fr.gouv.vitam.common.GlobalDataRest;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.model.RequestResponse;
@@ -61,6 +35,30 @@ import fr.gouv.vitamui.iam.internal.server.tenant.domain.Tenant;
 import fr.gouv.vitamui.iam.internal.server.token.dao.TokenRepository;
 import fr.gouv.vitamui.iam.internal.server.user.dao.UserRepository;
 import fr.gouv.vitamui.iam.internal.server.utils.IamServerUtilsTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 
 /**
  * Tests the {@link OwnerInternalService}.
@@ -219,7 +217,7 @@ public class OwnerInternalServiceIntegTest extends AbstractLogbookIntegrationTes
 
         Mockito.when(internalSecurityService.getTenantIdentifier()).thenReturn(tenant.getIdentifier());
         Mockito.when(internalSecurityService.getTenant(eq(tenant.getIdentifier()))).thenReturn(tenant);
-        final RequestResponse<LogbookOperation> operationsResponse = new RequestResponseOK<JsonNode>().addHeader(GlobalDataRest.X_REQUEST_ID, "requestId")
+        final RequestResponse<LogbookOperation> operationsResponse = new RequestResponseOK<LogbookOperation>().addHeader(GlobalDataRest.X_REQUEST_ID, "requestId")
                 .addHeader(GlobalDataRest.X_APPLICATION_ID, "appId").setHttpCode(Response.Status.OK.getStatusCode());
         Mockito.when(logbookService.findEventsByIdentifierAndCollectionNames(anyString(), anyString(), any())).thenReturn(operationsResponse);
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <swagger.version>3.0.0</swagger.version>
         <trang.version>20181222</trang.version>
         <!-- En attente d'une release contenant l'évolution US 8362 de VITAM -->
-        <vitam.version>4.6.0-SNAPSHOT</vitam.version>
+        <vitam.version>5.rc.1</vitam.version>
         <xml.apis-version>2.0.2</xml.apis-version>
         <xml.resolver.version>1.2</xml.resolver.version>
         <xom.version>1.3.4</xom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
-        <jackson.version>2.11.0.rc1</jackson.version>
+        <jackson.version>2.12.3</jackson.version>
         <jaeger.tracing.version>3.2.2</jaeger.tracing.version>
         <jakarta.xml.binding.version>2.3.2</jakarta.xml.binding.version>
         <javax.el.version.version>3.0.1-b06</javax.el.version.version>


### PR DESCRIPTION
## Description
- Adapter la version jackson vitamui à 2.12.3 pour tre conforme avec vitam,
- Fixe des tests vitamui utilisant le RequestResponseOK pour être conforme avec le package common-public
- Utilisation de la verison 5.rc.1 releasé de vitam au lieu de 4.6.0-SNAPSHOT

## Type de changement:
* Adaptation et fixes

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)