### PR TITLE
[Vas] Item-7392- DOC- add documentation for managing api iam timout

### DIFF
--- a/docs/fr/exploitation/sections/procedure.md
+++ b/docs/fr/exploitation/sections/procedure.md
@@ -1,7 +1,6 @@
-
 # Procedure d'exploitation
 
-## Démarrage de la solution 
+## Démarrage de la solution
 
 ~~~console
 ansible-playbook  -i environments/<hostfile environnement> --vault-password-file
@@ -24,20 +23,18 @@ ansible-playbook  -i environments/<hostfile environnement> --vault-password-file
 vault_pass.txt --extra-vars=@./environments/vitamui_extra_vars.yml vitamui.yml
 ~~~
 
-Les services VitamUI sont stateless et vont être remplacés par une nouvelle version lors de 
-l'opération précédente.
+Les services VitamUI sont stateless et vont être remplacés par une nouvelle version lors de l'opération précédente.
 
-Les scripts de base de données MongoDb sont versionnés via un changelog interne. Un même
-script ne peut pas être joué 2 fois. Les nouveaux scripts vont être intégrés et les anciens
-scripts ou doublons de scripts ne vont pas être pris en compte. 
-
+Les scripts de base de données MongoDb sont versionnés via un changelog interne. Un même script ne peut pas être joué 2
+fois. Les nouveaux scripts vont être intégrés et les anciens scripts ou doublons de scripts ne vont pas être pris en
+compte.
 
 ## Sauvegarde de la solution
 
 La base de données Mongodb utilisée par VitamUI peut être sauvegardée de 2 manières:
 
-  1. via un playbook de sauvegarde (mongo_backup.yml)
-  2. via un dump (commande mongodump)
+1. via un playbook de sauvegarde (mongo_backup.yml)
+2. via un dump (commande mongodump)
 
 ### Sauvegarde via playbook (1)
 
@@ -79,11 +76,9 @@ ansible-playbook  -i environments/<hostfile environnement> --vault-password-file
 vault_pass.txt --extra-vars=@./environments/vitamui_extra_vars.yml mongo_backup.yml
 ~~~
 
-
 ### Sauvegarde via la commande mongodump (2)
 
-Se rendre sur la machine (vm) hébergeant l'instance mongodb de VitamUI
-et exécuter la commande suivante:
+Se rendre sur la machine (vm) hébergeant l'instance mongodb de VitamUI et exécuter la commande suivante:
 
 ~~~console
 mongodump --host "ip_machine:27017" -u [user] -p [mdp] -v --gzip 
@@ -92,11 +87,10 @@ mongodump --host "ip_machine:27017" -u [user] -p [mdp] -v --gzip
 
 ## Restoration de la solution
 
-De la même manière, la base de données Mongodb utilisée par VitamUI peut être 
-sauvegardée de 2 manières:
+De la même manière, la base de données Mongodb utilisée par VitamUI peut être sauvegardée de 2 manières:
 
-  1. via un playbook de sauvegarde (mongo_backup.yml)
-  2. via un dump (commande mongodump)
+1. via un playbook de sauvegarde (mongo_backup.yml)
+2. via un dump (commande mongodump)
 
 ### Restoration via playbook (1)
 
@@ -110,69 +104,63 @@ vault_pass.txt --extra-vars=@./environments/vitamui_extra_vars.yml
 
 ### Restoration via la commande mongodump (2)
 
-Se rendre sur la machine (vm) hébergeant l'instance mongodb de VitamUI
-et exécuter la commande suivante:
+Se rendre sur la machine (vm) hébergeant l'instance mongodb de VitamUI et exécuter la commande suivante:
 
 ~~~console
 mongorestore --host [ip machinie] --port 27017 --username [user] 
 --password [mdp] "/backup/mongod/[nom_backup] --drop --gzip --maintainInsertionOrder
 ~~~
 
-
-> Attention ! Certaines informations Vitam sont sauvegardées dans VitamUI.  
-
+> Attention ! Certaines informations Vitam sont sauvegardées dans VitamUI.
 
 ## Changement de PKI.
 
-Les certificats utilisés par Vitam et VitamUI peuvent être amenés à être changés
-en raison de sécurité ou simplement de par leur expiration.
+Les certificats utilisés par Vitam et VitamUI peuvent être amenés à être changés en raison de sécurité ou simplement de
+par leur expiration.
 
 ### Certificat Vitamui client expiré dans Vitam
 
-Le certificat client VitamUI.crt est utilisé par Vitam afin que l'application VitamUi
-accède aux informations de Vitam. Son échange se fait par les playbooks Vitam
-remove_context.yml et add_context.yml dans les sources de Vitam.
+Le certificat client VitamUI.crt est utilisé par Vitam afin que l'application VitamUi accède aux informations de Vitam.
+Son échange se fait par les playbooks Vitam remove_context.yml et add_context.yml dans les sources de Vitam.
 
-Renseigner le fichier postinstall_param.yml avec les
-informations du certificat actuel et lancer la commande suppression suivante:
+Renseigner le fichier postinstall_param.yml avec les informations du certificat actuel et lancer la commande suppression
+suivante:
 
 ~~~console
 ansible-playbook  -i environments/<hostfile environnement> --vault-password-file
 vault_pass.txt --extra-vars=@./environments/vitamui_extra_vars.yml remove_context.yml
 ~~~
 
-Se connecter à l'Ihm_demo de Vitam pour vérifier la bonne suppression du context vitamui_context
-dans les contextes applicatifs Vitam.
+Se connecter à l'Ihm_demo de Vitam pour vérifier la bonne suppression du context vitamui_context dans les contextes
+applicatifs Vitam.
 
 Une fois cette opération réalisée, il faut :
 _Régénérer ou échanger le certificat vitamui.crt afin qu'il soit valide.
-_Modifier les informations du fichier 
-postinstall_param.yml avec le nom du nouveau certificat et lancer la commande suivante:
+_Modifier les informations du fichier postinstall_param.yml avec le nom du nouveau certificat et lancer la commande
+suivante:
 
 ~~~console
 ansible-playbook  -i environments/<hostfile environnement> --vault-password-file
 vault_pass.txt --extra-vars=@./environments/vitamui_extra_vars.yml add_context.yml
 ~~~
 
-Vérifier alors dans les contextes applicatifs Vitam que le contexte vitamui_context est de nouveau 
-présent (rattaché de manière transparente au nouveau certificat).
-
+Vérifier alors dans les contextes applicatifs Vitam que le contexte vitamui_context est de nouveau présent (rattaché de
+manière transparente au nouveau certificat).
 
 ### Certificats expirés dans les services VitamUI
 
-Regénérer la PKI complète VitamUI et Vitamui. 
+Regénérer la PKI complète VitamUI et Vitamui.
 
 Rédéployer la PKI pour les 2 solutions.
 
 Les commandes sont précisées dans le dossier d'installation VitamUI.
 
-
 ## Analyse des problèmes VitamUI
 
 ### Logs
 
-Les traces applicatives ou techniques de VitamUI se trouvent sur les machines hébergeant l'application
-dans /vitamui/log/nom_service/ pour le service considéré.
+Les traces applicatives ou techniques de VitamUI se trouvent sur les machines hébergeant l'application dans
+/vitamui/log/nom_service/ pour le service considéré.
 
 Les logs sont écrits via le service rsyslog installé sur toutes les machines de la solution.
 
@@ -192,16 +180,18 @@ mongo --host <ip machine> --port 27017 admin --username=<user> --password=<passw
 
 #### Profil ANSSI:
 
-Le profil par défaut chargé au démarrage de CAS, la configuration de ce profil sur une plateforme déjà installé se fait sur la machine hénergeante le serveur CAS,
-la configuration se situe dans `/vitamui/conf/cas-server/application.yml`, dans la section `password:`
+Le profil par défaut chargé au démarrage de CAS, la configuration de ce profil sur une plateforme déjà installé se fait
+sur la machine hénergeante le serveur CAS, la configuration se situe dans `/vitamui/conf/cas-server/application.yml`,
+dans la section `password:`
 
 L'exploitant peut changer quelques contraintes de la complexité du mot de passe, sans violer les standards de l'ANSSI.
 
 ##### Exemple de changement de la taille du mot de passe:
 
-dans la section `password:`, l'attribut `length` est par défaut à 12, le changement de la taille du mot de passe revient à changer cet attribut `length`, cette valeur sera automatiquement portée par l'attribut
-`cas.authn.pm.policyPattern:` qui contient l'expression  `${password.length}$`.
-l'attribut `cas.authn.pm.policyPattern:` contient l'expression régulière de validation du mot de passe et qui se trouve dans le meme fichier de configuration.
+dans la section `password:`, l'attribut `length` est par défaut à 12, le changement de la taille du mot de passe revient
+à changer cet attribut `length`, cette valeur sera automatiquement portée par l'attribut
+`cas.authn.pm.policyPattern:` qui contient l'expression  `${password.length}$`. l'attribut `cas.authn.pm.policyPattern:`
+contient l'expression régulière de validation du mot de passe et qui se trouve dans le meme fichier de configuration.
 
 > Cette valeur ne devra pas etre inférieur à la valeur par défaut, avec le profil anssi.
 
@@ -215,7 +205,8 @@ Donc `check-occurrence: false` désactivera cette vérification.
 
 Cette contraintes pourra etre changée avec l'attribut `occurrences-chars-number:`, par défault la valeur est égal à `3`,
 
-Donc `occurrences-chars-number: 5`, augmentera le nombre de caractère tolérable issues du nom de l'utilisateur à utiliser dans un mot de passe.
+Donc `occurrences-chars-number: 5`, augmentera le nombre de caractère tolérable issues du nom de l'utilisateur à
+utiliser dans un mot de passe.
 
 > Cette valeur ne devra pas etre inférieur à la valeur par défaut.
 
@@ -223,11 +214,13 @@ Si la taille du nom de l'utilisateur est inférieur à cette valeur, la contrain
 
 ##### Exemple de changement du nombre des anciens mots de passe à ne pas réutiliser
 
-Cette contraintes pourra etre changée avec l'attribut `max-old-password:`, par défault la valeur est égal à `12` dans le profil anssi, et `3` dans le profil custom,
+Cette contraintes pourra etre changée avec l'attribut `max-old-password:`, par défault la valeur est égal à `12` dans le
+profil anssi, et `3` dans le profil custom,
 
 Donc `max-old-password: 13`, augmentera le nombre d'anciens mots de passe à ne pas réutiliser'
 
-Ce changement devra etre fait aussi sur le composant `iam-internal`, dans le fichier `/vitamui/conf/iam-internal/application.yml`, dans la section `password`.
+Ce changement devra etre fait aussi sur le composant `iam-internal`, dans le
+fichier `/vitamui/conf/iam-internal/application.yml`, dans la section `password`.
 
 > Cette valeur ne devra pas etre inférieur à la valeur par défaut, avec le profil anssi.
 > Le redémarrage du composant iam-internal est nécessaire avec ce changement.
@@ -235,10 +228,11 @@ Ce changement devra etre fait aussi sur le composant `iam-internal`, dans le fic
 ##### Exemple de personnalisation des messages redues à l'utilisateur:
 
 Les messages peuvent etre personnalisés par l'exploitant dans le bloc, par langue
+
 ```yml
 constraints:
     defaults:
-      fr:
+        fr:
             messages:
                 - message 1
                 - message 2
@@ -248,28 +242,29 @@ constraints:
                 messages:
                     - message 4
                     - message 5
-        en:
-            messages:
-                - message 1
-                - message 2
-                - ...
-            special-chars:
-                title: 'message 3'
+            en:
                 messages:
-                    - message 4
-                    - message 5
-        de:
-            messages:
-                - message 1
-                - message 2
-                - ...
-            special-chars:
-                title: 'message 3'
+                    - message 1
+                    - message 2
+                    - ...
+                special-chars:
+                    title: 'message 3'
+                    messages:
+                        - message 4
+                        - message 5
+            de:
                 messages:
-                    - message 4
-                    - message 5
-      ...
+                    - message 1
+                    - message 2
+                    - ...
+                special-chars:
+                    title: 'message 3'
+                    messages:
+                        - message 4
+                        - message 5
+        ...
  ```
+
 > C'est à charge de l'exploitant de respecter les contraintes traduites, qui devront etre en cohérence avec les blocs / attributs de son profil anssi, et qui devront pas violer les standards préconisés par l'ANSSI et la PSSI du ministère de la culture.
 
 > A chaque modification
@@ -278,17 +273,49 @@ constraints:
 
 ##### Exemple de changement de la taille du mot de passe:
 
-dans la section `password:`, l'attribut `length` est par défaut à 12, le changement de la taille du mot de passe revient à changer cet attribut `length`,  cette valeur sera automatiquement portée par l'attribut
+dans la section `password:`, l'attribut `length` est par défaut à 12, le changement de la taille du mot de passe revient
+à changer cet attribut `length`, cette valeur sera automatiquement portée par l'attribut
 `cas.authn.pm.policyPattern:` qui contient l'expression  `${password.length}$` , à la fin de l'expression régulière.
-l'attribut `cas.authn.pm.policyPattern:` contient l'expression régulière globale de validation du mot de passe et qui se trouve dans le meme fichier de configuration.
+l'attribut `cas.authn.pm.policyPattern:` contient l'expression régulière globale de validation du mot de passe et qui se
+trouve dans le meme fichier de configuration.
 
 > Cette valeur est par défaut égal à 8 pour le profil custom.
 
 ##### Exemple de changement du nombre des anciens mots de passe à ne pas réutiliser
+
 Les memes configurations que pour le profil anssi.
 
 > Veillez à redémarrer le serveur CAS, et le composant iam-internal pour appliquer ces changements.
 
+##### Gestion du timout lors de création d'organisations:
+
+La création d'oranisations est un worflow nécessitant l'execution de plusieurs actions, c'est pour cette raison que dans
+certains cas en fonction des performances de l'infrastructure, le super-admin peut constater un timeout dans ce
+workflow. Dans ce cas, on peut augmenter la valeur de ce timeout admin dans les fichiers de configurations des deux
+applications: iam-external et ui-identity-admin:
+
+#### Dans ui-identity-admin:
+
+```yml
+
+ui-identity:
+    iam-external-client:
+        connect-time-out: 30
+        read-time-out: 30
+        write-time-out: 30
+
+ ```
+
+#### Dans iam-external:
+
+```yml
+iam-external:
+    iam-internal-client:
+        connect-time-out: 30
+        read-time-out: 30
+        write-time-out: 30
+
+ ```
 
 #### Configuration avant installation de VITAMUI:
 


### PR DESCRIPTION
## Description
L'objectif de cette PR est de documenter la personalisation du timeout des services utilisés dans iam-internal pour corriger un souci de timout lors de la création d'organisation.

[Ticket TuleUp](https://tuleap.dev.programmevitam.fr/plugins/tracker/?aid=7392)


## Type de changement:
* Documentation:

## Tests:
- Des tests fonctionnels sont effectués pour vérifier le fonctionnement de cette évolution.

## Migration:
- Pas de modifications au niveau de la DB, 
- Pas de migration.
- Pas de nouveau code

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)