### PR TITLE
[VAS] item 8925 Bump Spring Core, Spring Boot, Spring Security

### DIFF
--- a/api/api-archive-search/archive-search-internal/pom.xml
+++ b/api/api-archive-search/archive-search-internal/pom.xml
@@ -95,7 +95,18 @@
             <groupId>fr.gouv.vitamui.commons</groupId>
             <artifactId>commons-mongo</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Metrics -->
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -157,11 +168,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>fr.gouv.vitamui.commons</groupId>
             <artifactId>commons-test</artifactId>
             <type>test-jar</type>
@@ -177,6 +183,11 @@
             <artifactId>iam-commons</artifactId>
             <scope>test</scope>
             <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <scope>test</scope>
         </dependency>
 
 

--- a/api/api-archive-search/archive-search-internal/pom.xml
+++ b/api/api-archive-search/archive-search-internal/pom.xml
@@ -17,7 +17,6 @@
         <rpm.skip>false</rpm.skip>
         <swagger.dir>api-internal</swagger.dir>
         <swagger.skip>false</swagger.skip>
-        <spring.data.mongo.version>3.1.7</spring.data.mongo.version>
     </properties>
 
     <dependencies>
@@ -98,26 +97,15 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Metrics -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-        </dependency>
-
-        <!-- Spring Data Mongo-->
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-mongodb</artifactId>
-            <version>${spring.data.mongo.version}</version>
         </dependency>
 
         <!-- PAC4J -->

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/ApiArchivesSearchInternalApplicationTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/ApiArchivesSearchInternalApplicationTest.java
@@ -31,12 +31,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
 public class ApiArchivesSearchInternalApplicationTest {
 
     @Autowired

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/TestMongoConfig.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/TestMongoConfig.java
@@ -81,7 +81,8 @@ public class TestMongoConfig extends AbstractMongoClientConfiguration {
     public void initIt() throws Exception {
         port = Network.getFreeServerPort();
 
-        _mongodExe = starter.prepare(new MongodConfigBuilder().version(Version.Main.PRODUCTION)
+        _mongodExe = starter.prepare(new MongodConfigBuilder()
+            .version(Version.Main.PRODUCTION)
             .net(new Net(MONGO_HOST, port, Network.localhostIsIPv6()))
             .build());
 

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/config/ApiArchiveSearchInternalServerConfigTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/config/ApiArchiveSearchInternalServerConfigTest.java
@@ -32,12 +32,13 @@ import fr.gouv.vitam.access.external.client.v2.AccessExternalClientV2;
 import fr.gouv.vitam.ingest.external.client.IngestExternalClient;
 import fr.gouv.vitamui.archive.internal.server.service.ArchiveSearchAgenciesInternalService;
 import fr.gouv.vitamui.archive.internal.server.service.ArchiveSearchInternalService;
-import fr.gouv.vitamui.commons.api.application.AbstractContextConfiguration;
 import fr.gouv.vitamui.commons.vitam.api.administration.AgencyService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -47,7 +48,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
-public class ApiArchiveSearchInternalServerConfigTest extends AbstractContextConfiguration {
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
+public class ApiArchiveSearchInternalServerConfigTest {
 
     @MockBean(name = "adminExternalClient")
     private AdminExternalClient adminExternalClient;

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/config/SearchCriteriaHistoryInternalServerConfigTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/config/SearchCriteriaHistoryInternalServerConfigTest.java
@@ -46,16 +46,18 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
 public class SearchCriteriaHistoryInternalServerConfigTest {
 
     @MockBean(name = "adminExternalClient")

--- a/api/api-archive-search/archive-search-internal/src/test/resources/application.yml
+++ b/api/api-archive-search/archive-search-internal/src/test/resources/application.yml
@@ -10,6 +10,9 @@ spring:
       enabled: false
       config:
         enabled: false
+    autoconfigure:
+      exclude:
+        - org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
   api:
     name: API Archive
     description: This API is used to manage Archive operations

--- a/api/api-archive-search/archive-search-internal/src/test/resources/application.yml
+++ b/api/api-archive-search/archive-search-internal/src/test/resources/application.yml
@@ -10,9 +10,6 @@ spring:
       enabled: false
       config:
         enabled: false
-    autoconfigure:
-      exclude:
-        - org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
   api:
     name: API Archive
     description: This API is used to manage Archive operations

--- a/api/api-iam/iam-external/pom.xml
+++ b/api/api-iam/iam-external/pom.xml
@@ -222,7 +222,7 @@
                     <executable>true</executable>
                     <attach>true</attach> <!-- Need to use the original jar for integration-tests -->
                     <mainClass>fr.gouv.vitamui.iam.external.server.ApiIamExternalServerApplication</mainClass>
-                    <jvmArguments>-Xmx512m  -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8083</jvmArguments>
+                    <jvmArguments>-Xmx512m</jvmArguments>
                     <arguments>
                         <argument>--spring.profiles.active=dev</argument>
                     </arguments>

--- a/api/api-iam/iam-external/pom.xml
+++ b/api/api-iam/iam-external/pom.xml
@@ -222,7 +222,7 @@
                     <executable>true</executable>
                     <attach>true</attach> <!-- Need to use the original jar for integration-tests -->
                     <mainClass>fr.gouv.vitamui.iam.external.server.ApiIamExternalServerApplication</mainClass>
-                    <jvmArguments>-Xmx512m</jvmArguments>
+                    <jvmArguments>-Xmx512m  -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8083</jvmArguments>
                     <arguments>
                         <argument>--spring.profiles.active=dev</argument>
                     </arguments>

--- a/api/api-iam/iam-external/src/main/resources/application-dev.yml
+++ b/api/api-iam/iam-external/src/main/resources/application-dev.yml
@@ -33,6 +33,8 @@ server:
     client-auth: need
     enabled-protocols: TLSv1.1,TLSv1.2,TLSv1.3
     ciphers: ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+  error:
+    path: /error
 
 management:
   server:

--- a/api/api-iam/iam-internal/pom.xml
+++ b/api/api-iam/iam-internal/pom.xml
@@ -135,6 +135,7 @@
         </dependency>
 
         <!-- Spring Data Mongo-->
+        <!-- TODO adapt this library to be conforme with spring boot versions in futur spring stack bumps-->
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
@@ -145,13 +146,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
             <version>${spring.version}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- UTIL -->
         <dependency>

--- a/api/api-iam/iam-internal/pom.xml
+++ b/api/api-iam/iam-internal/pom.xml
@@ -141,6 +141,18 @@
             <version>${spring.data.mongo.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- UTIL -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/api/api-iam/iam-internal/src/main/resources/application-dev.yml
+++ b/api/api-iam/iam-internal/src/main/resources/application-dev.yml
@@ -25,6 +25,8 @@ server-identity:
 server:
   host:
   port: 7083
+  error:
+    path: /error
 
 management:
   server:

--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/TestMongoConfig.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/TestMongoConfig.java
@@ -45,7 +45,8 @@ public class TestMongoConfig extends AbstractMongoClientConfiguration {
     public void initIt() throws Exception {
         port = Network.getFreeServerPort();
 
-        _mongodExe = starter.prepare(new MongodConfigBuilder().version(Version.Main.PRODUCTION)
+        _mongodExe = starter.prepare(new MongodConfigBuilder()
+            .version(Version.Main.PRODUCTION)
             .net(new Net(MONGO_HOST, port, Network.localhostIsIPv6()))
             .build());
 

--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/config/ApiIamServerConfigTest.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/config/ApiIamServerConfigTest.java
@@ -10,11 +10,12 @@ import fr.gouv.vitamui.commons.security.client.password.PasswordValidator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
 public class ApiIamServerConfigTest {
     @MockBean
     private AdminExternalClient adminExternalClient;

--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/customer/service/InitCustomerServiceIntegrationTest.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/customer/service/InitCustomerServiceIntegrationTest.java
@@ -44,6 +44,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -51,7 +53,6 @@ import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
@@ -67,6 +68,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @Import({ TestMongoConfig.class })
 @ActiveProfiles(value = "test")
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
 public class InitCustomerServiceIntegrationTest {
 
     private static final String PROFILE_NAME_1 = "profile1";

--- a/api/api-ingest/ingest-internal/src/test/java/fr/gouv/vitamui/ingest/internal/server/config/ApiIngestInternalServerConfigTest.java
+++ b/api/api-ingest/ingest-internal/src/test/java/fr/gouv/vitamui/ingest/internal/server/config/ApiIngestInternalServerConfigTest.java
@@ -46,6 +46,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -54,6 +56,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
 public class ApiIngestInternalServerConfigTest {
 
 

--- a/api/api-referential/referential-external/src/main/resources/application-dev.yml
+++ b/api/api-referential/referential-external/src/main/resources/application-dev.yml
@@ -34,6 +34,8 @@ server:
     client-auth: need
     enabled-protocols: TLSv1.1,TLSv1.2,TLSv1.3
     ciphers: ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+  error:
+    path: /error
 
 management:
   server:

--- a/api/api-referential/referential-internal/src/main/resources/application-dev.yml
+++ b/api/api-referential/referential-internal/src/main/resources/application-dev.yml
@@ -25,6 +25,8 @@ server:
   host:
   port: 7087
   tomcat.connection-timeout: 60000
+  error:
+    path: /error
 
 management:
   server:

--- a/api/api-security/security-internal/pom.xml
+++ b/api/api-security/security-internal/pom.xml
@@ -98,6 +98,12 @@
             <artifactId>spring-boot-starter-tomcat</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
         </dependency>

--- a/api/api-security/security-internal/src/main/resources/application-dev.yml
+++ b/api/api-security/security-internal/src/main/resources/application-dev.yml
@@ -18,6 +18,9 @@ server-identity:
 
 server:
   port: 8084
+  error:
+    path: /error
+
 management:
   server:
     address: localhost

--- a/api/api-security/security-internal/src/test/java/fr/gouv/vitamui/security/server/ApiSecurityApplicationTest.java
+++ b/api/api-security/security-internal/src/test/java/fr/gouv/vitamui/security/server/ApiSecurityApplicationTest.java
@@ -1,19 +1,21 @@
 package fr.gouv.vitamui.security.server;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @ActiveProfiles("test")
+@ImportAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
 public class ApiSecurityApplicationTest {
 
     @Autowired

--- a/api/api-security/security-internal/src/test/resources/application.yml
+++ b/api/api-security/security-internal/src/test/resources/application.yml
@@ -11,6 +11,9 @@ spring:
       discovery:
         enabled: false
         register: false
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
 server-identity:
   identityName: vitamui-dev

--- a/api/api-security/security-internal/src/test/resources/application.yml
+++ b/api/api-security/security-internal/src/test/resources/application.yml
@@ -11,9 +11,6 @@ spring:
       discovery:
         enabled: false
         register: false
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 
 server-identity:
   identityName: vitamui-dev

--- a/commons/commons-logbook/src/test/java/fr/gouv/vitamui/commons/logbook/TestMongoConfig.java
+++ b/commons/commons-logbook/src/test/java/fr/gouv/vitamui/commons/logbook/TestMongoConfig.java
@@ -12,7 +12,6 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
 import fr.gouv.vitamui.commons.api.converter.OffsetDateTimeToStringConverter;
 import fr.gouv.vitamui.commons.api.converter.StringToOffsetDateTimeConverter;
-import fr.gouv.vitamui.commons.logbook.dao.EventRepository;
 import fr.gouv.vitamui.commons.mongo.repository.CommonsMongoRepository;
 import fr.gouv.vitamui.commons.mongo.repository.impl.VitamUIRepositoryImpl;
 import org.springframework.context.annotation.Configuration;
@@ -48,9 +47,9 @@ public class TestMongoConfig extends AbstractMongoClientConfiguration {
         port = Network.getFreeServerPort();
 
         _mongodExe = starter.prepare(new MongodConfigBuilder()
-                .version(Version.Main.PRODUCTION)
-                .net(new Net(MONGO_HOST, port, Network.localhostIsIPv6()))
-                .build());
+            .version(Version.Main.PRODUCTION)
+            .net(new Net(MONGO_HOST, port, Network.localhostIsIPv6()))
+            .build());
 
         _mongod = _mongodExe.start();
     }

--- a/commons/commons-mongo/pom.xml
+++ b/commons/commons-mongo/pom.xml
@@ -60,13 +60,11 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
             <version>${spring.data.mongo.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/commons/commons-mongo/pom.xml
+++ b/commons/commons-mongo/pom.xml
@@ -12,6 +12,9 @@
         <artifactId>commons-parent</artifactId>
         <version>5.0-SNAPSHOT</version>
     </parent>
+    <properties>
+        <spring.data.mongo.version>3.1.7</spring.data.mongo.version>
+    </properties>
 
     <dependencies>
         <!-- VITAMUI -->
@@ -23,13 +26,16 @@
             <groupId>fr.gouv.vitamui.commons</groupId>
             <artifactId>commons-utils</artifactId>
         </dependency>
-
-        <!-- Spring -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-            <scope>provided</scope>
+            <groupId>fr.gouv.vitamui.commons</groupId>
+            <artifactId>commons-vitam</artifactId>
         </dependency>
+        <dependency>
+            <groupId>fr.gouv.vitamui.commons</groupId>
+            <artifactId>commons-rest</artifactId>
+        </dependency>
+
+        <!-- SPRING BOOT -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
@@ -41,16 +47,33 @@
     		<scope>provided</scope>
         </dependency>
         <dependency>
-    		<groupId>org.springframework.boot</groupId>
-    		<artifactId>spring-boot-starter-json</artifactId>
-    		<scope>provided</scope>
-		</dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-json</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-    		<scope>provided</scope>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <scope>provided</scope>
         </dependency>
-
+        <!-- Spring Data Mongo-->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+            <version>${spring.data.mongo.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Utils -->
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -133,7 +156,17 @@
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.gouv.vitamui.commons</groupId>
+            <artifactId>commons-test</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
         <dependency>
 		    <groupId>javax.el</groupId>
 		    <artifactId>javax.el-api</artifactId>

--- a/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/TestMongoConfig.java
+++ b/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/TestMongoConfig.java
@@ -1,8 +1,7 @@
-package fr.gouv.vitamui.commons.mongo.config;
+package fr.gouv.vitamui.commons.mongo;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
-import com.mongodb.client.MongoClient;
 import com.mongodb.connection.ClusterSettings;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
@@ -13,23 +12,24 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
 import fr.gouv.vitamui.commons.api.converter.OffsetDateTimeToStringConverter;
 import fr.gouv.vitamui.commons.api.converter.StringToOffsetDateTimeConverter;
+import fr.gouv.vitamui.commons.api.identity.ServerIdentityAutoConfiguration;
+import fr.gouv.vitamui.commons.mongo.repository.CommonsMongoRepository;
 import fr.gouv.vitamui.commons.mongo.repository.impl.VitamUIRepositoryImpl;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.validation.constraints.NotNull;
 import java.util.Collections;
 
 
 @Configuration
-@EnableMongoRepositories(basePackages = {
-    "fr.gouv.vitamui.commons.mongo.dao",
-    "fr.gouv.vitamui.commons.mongo.repository"
-}, repositoryBaseClass = VitamUIRepositoryImpl.class)
-
+@EnableMongoRepositories(basePackageClasses = {CommonsMongoRepository.class}, repositoryBaseClass = VitamUIRepositoryImpl.class)
+@Import({ServerIdentityAutoConfiguration.class})
 public class TestMongoConfig extends AbstractMongoClientConfiguration {
 
     private static final MongodStarter starter = MongodStarter.getDefaultInstance();
@@ -54,11 +54,13 @@ public class TestMongoConfig extends AbstractMongoClientConfiguration {
 
     @PreDestroy
     public void close() {
-        if (_mongod != null)
+        if (_mongod != null) {
             _mongod.stop();
+        }
 
-        if (_mongodExe != null)
+        if (_mongodExe != null) {
             _mongodExe.stop();
+        }
     }
 
     @Override
@@ -69,9 +71,10 @@ public class TestMongoConfig extends AbstractMongoClientConfiguration {
         builder.applyToClusterSettings(b -> b.applySettings(clusterSettings));
     }
 
+    @NotNull
     @Override
     protected String getDatabaseName() {
-        return "test";
+        return "db";
     }
 
     @Override
@@ -79,12 +82,6 @@ public class TestMongoConfig extends AbstractMongoClientConfiguration {
         converterConfigurationAdapter.registerConverter(new OffsetDateTimeToStringConverter());
         converterConfigurationAdapter.registerConverter(new StringToOffsetDateTimeConverter());
     }
-
-    @Override
-    protected String getMappingBasePackage() {
-        return "fr.gouv.vitamui.commons.mongo";
-    }
-
 
 
 }

--- a/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/dao/CustomSequenceRepositoryTest.java
+++ b/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/dao/CustomSequenceRepositoryTest.java
@@ -1,26 +1,24 @@
-package fr.gouv.vitamui.commons.mongo;
+package fr.gouv.vitamui.commons.mongo.dao;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Optional;
-
+import fr.gouv.vitamui.commons.mongo.CustomSequencesConstants;
+import fr.gouv.vitamui.commons.mongo.TestMongoConfig;
+import fr.gouv.vitamui.commons.mongo.domain.CustomSequence;
+import fr.gouv.vitamui.commons.mongo.repository.impl.VitamUIRepositoryImpl;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
 
-import fr.gouv.vitamui.commons.mongo.config.TestMongoConfig;
-import fr.gouv.vitamui.commons.mongo.dao.CustomSequenceRepository;
-import fr.gouv.vitamui.commons.mongo.domain.CustomSequence;
+import java.util.Optional;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
-@Import(TestMongoConfig.class)
-@ActiveProfiles("test")
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@Import({ TestMongoConfig.class })
+@EnableMongoRepositories(basePackageClasses = CustomSequenceRepository.class, repositoryBaseClass = VitamUIRepositoryImpl.class)
 public class CustomSequenceRepositoryTest {
 
     @Autowired

--- a/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/dao/PersonRepositoryPaginatedNestedObjectsTests.java
+++ b/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/dao/PersonRepositoryPaginatedNestedObjectsTests.java
@@ -1,10 +1,22 @@
-package fr.gouv.vitamui.commons.mongo;
+package fr.gouv.vitamui.commons.mongo.dao;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import fr.gouv.vitamui.commons.api.domain.DirectionDto;
+import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
+import fr.gouv.vitamui.commons.mongo.TestMongoConfig;
+import fr.gouv.vitamui.commons.mongo.domain.Address;
+import fr.gouv.vitamui.commons.mongo.domain.Person;
+import fr.gouv.vitamui.commons.mongo.repository.impl.VitamUIRepositoryImpl;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -15,34 +27,20 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.CriteriaDefinition;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-
-import fr.gouv.vitamui.commons.api.domain.DirectionDto;
-import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
-import fr.gouv.vitamui.commons.mongo.config.TestMongoConfig;
-import fr.gouv.vitamui.commons.mongo.dao.PersonRepository;
-import fr.gouv.vitamui.commons.mongo.domain.Address;
-import fr.gouv.vitamui.commons.mongo.domain.Person;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * PersonRepositoryTest.
  *
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
-@Import(TestMongoConfig.class)
+@RunWith(SpringRunner.class)
+@Import({ TestMongoConfig.class })
+@EnableMongoRepositories(basePackageClasses = PersonRepository.class, repositoryBaseClass = VitamUIRepositoryImpl.class)
 public class PersonRepositoryPaginatedNestedObjectsTests {
 
     @Autowired

--- a/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/dao/PersonRepositoryTests.java
+++ b/commons/commons-mongo/src/test/java/fr/gouv/vitamui/commons/mongo/dao/PersonRepositoryTests.java
@@ -1,11 +1,28 @@
-package fr.gouv.vitamui.commons.mongo;
+package fr.gouv.vitamui.commons.mongo.dao;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import fr.gouv.vitamui.commons.api.domain.AggregationRequestOperator;
+import fr.gouv.vitamui.commons.api.domain.Criterion;
+import fr.gouv.vitamui.commons.api.domain.CriterionOperator;
+import fr.gouv.vitamui.commons.api.domain.DirectionDto;
+import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
+import fr.gouv.vitamui.commons.mongo.TestMongoConfig;
+import fr.gouv.vitamui.commons.mongo.domain.Person;
+import fr.gouv.vitamui.commons.mongo.repository.impl.VitamUIRepositoryImpl;
+import fr.gouv.vitamui.commons.mongo.utils.MongoUtils;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -17,40 +34,21 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Example;
-import org.springframework.data.domain.ExampleMatcher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import static org.springframework.data.domain.PageRequest.of;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.CriteriaDefinition;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import fr.gouv.vitamui.commons.api.domain.AggregationRequestOperator;
-import fr.gouv.vitamui.commons.api.domain.Criterion;
-import fr.gouv.vitamui.commons.api.domain.CriterionOperator;
-import fr.gouv.vitamui.commons.api.domain.DirectionDto;
-import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
-import fr.gouv.vitamui.commons.mongo.config.TestMongoConfig;
-import fr.gouv.vitamui.commons.mongo.dao.PersonRepository;
-import fr.gouv.vitamui.commons.mongo.domain.Person;
-import fr.gouv.vitamui.commons.mongo.utils.MongoUtils;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * PersonRepositoryTest.
  *
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
-@Import(TestMongoConfig.class)
+@RunWith(SpringRunner.class)
+@Import({ TestMongoConfig.class })
+@EnableMongoRepositories(basePackageClasses = PersonRepository.class, repositoryBaseClass = VitamUIRepositoryImpl.class)
 public class PersonRepositoryTests {
 
     @Autowired

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/BaseApiErrorController.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/BaseApiErrorController.java
@@ -36,15 +36,14 @@
  */
 package fr.gouv.vitamui.commons.rest;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.http.HttpServletRequest;
-
+import fr.gouv.vitamui.commons.api.exception.NotFoundException;
+import fr.gouv.vitamui.commons.rest.dto.VitamUIError;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.util.WebUtils;
 
-import fr.gouv.vitamui.commons.api.exception.NotFoundException;
-import fr.gouv.vitamui.commons.rest.dto.VitamUIError;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
 
 public class BaseApiErrorController implements ErrorController {
 
@@ -68,7 +67,6 @@ public class BaseApiErrorController implements ErrorController {
         throw new NotFoundException("URL Not Found : " + uri);
     }
 
-    @Override
     public String getErrorPath() {
         return ERROR_MAPPING;
     }

--- a/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
@@ -26,6 +26,9 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
+
 {% endif %}
   tomcat:
     accesslog:

--- a/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
@@ -28,6 +28,9 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
+
 {% endif %}
   tomcat:
     accesslog:

--- a/deployment/roles/vitamui/templates/iam-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-external/application.yml.j2
@@ -26,6 +26,9 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
+
 {% endif %}
   tomcat:
     accesslog:

--- a/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
@@ -28,6 +28,8 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
@@ -26,6 +26,8 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
@@ -28,6 +28,8 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/referential-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-external/application.yml.j2
@@ -31,6 +31,8 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
@@ -29,6 +29,8 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/security-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/security-internal/application.yml.j2
@@ -33,6 +33,8 @@ server:
     client-auth: need
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
@@ -27,7 +27,8 @@ server:
     key-password: {{ password_keystore }}
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
-
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
@@ -31,7 +31,8 @@ server:
     key-password: {{ password_keystore }}
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
-
+  error:
+    path: /error
 {% endif %}
   tomcat:
     accesslog:

--- a/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
@@ -28,6 +28,8 @@ server:
     key-password: {{ password_keystore }}
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
@@ -27,7 +27,8 @@ server:
     key-password: {{ password_keystore }}
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
-
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
@@ -24,7 +24,8 @@ server:
     key-password: {{ password_keystore }}
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
-
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
@@ -35,7 +35,8 @@ server:
     key-password: {{ password_keystore }}
     enabled-protocols: {{ssl_setting.enabled_protocols}}
     ciphers: {{ssl_setting.ciphers}}
-
+  error:
+    path: /error
 
 {% endif %}
   tomcat:

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,16 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
                 <artifactId>spring-tx</artifactId>
                 <version>${spring.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
         <serenity.spring.version>2.2.2</serenity.spring.version>
         <serenity.version>2.2.2</serenity.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spring.boot.version>2.4.4</spring.boot.version>
-        <spring.version>5.3.5</spring.version>
+        <spring.boot.version>2.4.5</spring.boot.version>
+        <spring.version>5.3.6</spring.version>
         <spring.cloud.consul.version>3.0.2</spring.cloud.consul.version>
         <spring.security.version>5.4.5</spring.security.version>
         <swagger.version>3.0.0</swagger.version>
@@ -860,11 +860,11 @@
                 <version>${jackson.version}</version>
             </dependency>
 
-            <dependency>
+            <!--<dependency>
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
                 <version>${commons.httpclient.version}</version>
-            </dependency>
+            </dependency>-->
 
             <dependency>
                 <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <commons.collections4.version>4.4</commons.collections4.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.fileupload.version>1.4</commons.fileupload.version>
-        <commons.httpclient.version>3.1</commons.httpclient.version>
         <commons.io.version>2.7</commons.io.version>
         <commons.lang3.version>3.9</commons.lang3.version>
         <commons.text.version>1.8</commons.text.version>
@@ -93,7 +92,7 @@
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
-        <jackson.version>2.11.0.rc1</jackson.version>
+        <jackson.version>2.12.3</jackson.version>
         <jaeger.tracing.version>3.2.2</jaeger.tracing.version>
         <jakarta.xml.binding.version>2.3.2</jakarta.xml.binding.version>
         <javax.el.version.version>3.0.1-b06</javax.el.version.version>
@@ -130,10 +129,10 @@
         <serenity.spring.version>2.2.2</serenity.spring.version>
         <serenity.version>2.2.2</serenity.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spring.boot.version>2.4.5</spring.boot.version>
-        <spring.version>5.3.6</spring.version>
+        <spring.boot.version>2.5.6</spring.boot.version>
+        <spring.version>5.3.12</spring.version>
         <spring.cloud.consul.version>3.0.2</spring.cloud.consul.version>
-        <spring.security.version>5.4.5</spring.security.version>
+        <spring.security.version>5.5.3</spring.security.version>
         <swagger.version>3.0.0</swagger.version>
         <trang.version>20181222</trang.version>
         <!-- En attente d'une release contenant l'évolution US 8362 de VITAM -->
@@ -859,12 +858,6 @@
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
-            <!--<dependency>
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-                <version>${commons.httpclient.version}</version>
-            </dependency>-->
 
             <dependency>
                 <groupId>commons-io</groupId>

--- a/ui/ui-archive-search/src/main/resources/application-dev.yml
+++ b/ui/ui-archive-search/src/main/resources/application-dev.yml
@@ -24,6 +24,9 @@ server:
     enabled-protocols: TLSv1.1,TLSv1.2,TLSv1.3
     ciphers: ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
   servlet.session.cookie.path: /archive-search-api
+  error:
+    path: /error
+
 management:
   server:
     address: localhost

--- a/ui/ui-identity/src/main/java/fr/gouv/vitamui/identity/rest/ApiErrorController.java
+++ b/ui/ui-identity/src/main/java/fr/gouv/vitamui/identity/rest/ApiErrorController.java
@@ -36,37 +36,11 @@
  */
 package fr.gouv.vitamui.identity.rest;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.http.HttpServletRequest;
-
-import org.springframework.boot.web.servlet.error.ErrorController;
-import org.springframework.web.bind.annotation.RequestMapping;
+import fr.gouv.vitamui.commons.rest.BaseApiErrorController;
 import org.springframework.web.bind.annotation.RestController;
-
-import fr.gouv.vitamui.commons.rest.dto.VitamUIError;
 import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @ApiIgnore
-public class ApiErrorController implements ErrorController {
-
-    @RequestMapping(value = "/error")
-    public VitamUIError handleError(final HttpServletRequest request) {
-        final Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
-
-        if (status != null) {
-            final Integer statusCode = Integer.valueOf(status.toString());
-
-            final VitamUIError vitamuiError = new VitamUIError();
-            vitamuiError.setStatus(statusCode);
-            return vitamuiError;
-        }
-        return null;
-    }
-
-    @Override
-    public String getErrorPath() {
-        return "/error";
-    }
-
+public class ApiErrorController extends BaseApiErrorController {
 }

--- a/ui/ui-identity/src/main/resources/application-dev.yml
+++ b/ui/ui-identity/src/main/resources/application-dev.yml
@@ -39,6 +39,22 @@ ui-identity:
         key-path: src/main/resources/dev/truststore_server.jks
         key-password: changeme
       hostname-verification: false
+  referential-external-client:
+    server-host: localhost
+    server-port: 8087
+    connect-time-out: 30
+    read-time-out: 30
+    write-time-out: 30
+    secure: true
+    ssl-configuration:
+      keystore:
+        key-path: src/main/resources/dev/keystore_ui-identity-admin.jks
+        key-password: changeme
+        type: JKS
+      truststore:
+        key-path: src/main/resources/dev/truststore_server.jks
+        key-password: changeme
+      hostname-verification: false
   base-url:
     portal: "https://dev.vitamui.com:4200"
     admin-identity: "https://dev.vitamui.com:4201/"
@@ -84,6 +100,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  error:
+    path: /error
 
 management:
   server:

--- a/ui/ui-ingest/src/main/resources/application-dev.yml
+++ b/ui/ui-ingest/src/main/resources/application-dev.yml
@@ -25,6 +25,9 @@ server:
     ciphers: ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
 
   servlet.session.cookie.path: /ingest-api
+  error:
+    path: /error
+
 management:
   server:
     address: localhost

--- a/ui/ui-portal/pom.xml
+++ b/ui/ui-portal/pom.xml
@@ -145,11 +145,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/ui/ui-portal/src/main/resources/application-dev.yml
+++ b/ui/ui-portal/src/main/resources/application-dev.yml
@@ -25,6 +25,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  error:
+    path: /error
+
 management:
   server:
     address: localhost

--- a/ui/ui-referential/pom.xml
+++ b/ui/ui-referential/pom.xml
@@ -139,11 +139,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/ui/ui-referential/src/main/resources/application-dev.yml
+++ b/ui/ui-referential/src/main/resources/application-dev.yml
@@ -27,6 +27,9 @@ server:
     ciphers: ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
 
   servlet.session.cookie.path: /referential-api
+  error:
+    path: /error
+
 management:
   server:
     address: localhost


### PR DESCRIPTION
## Description
Cette PR permet de mettre à jour le framework Spring {Core, Boot, Security}
- **[Spring Core 5.3.12](https://mvnrepository.com/artifact/org.springframework/spring-core/5.3.12)** [Release](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.12)
- **[Spring security 5.5.3](https://mvnrepository.com/artifact/org.springframework.security/spring-security-core/5.5.3)** [Release](https://github.com/spring-projects/spring-security/releases/tag/5.5.3)
- **[Spring boot 2.5.6](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot/2.5.6)** [Release](https://github.com/spring-projects/spring-boot/releases/tag/v2.5.6)

Le composant commons-httpclient a été supprimé, il n'était pas utilisé !

## Type de changement:
* Mise à jour de la Stack Spring dans son ensemble

## Tests:
- Des test unitaires et d'intégration ont été fixé suite à cette montée de version
- Des tests fonctionnels pour éviter des régressions également.

## Migration:
- pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)