### PR TITLE
[VAS] Story #9296: Update conf_permission to ReadOnly.

### DIFF
--- a/deployment/environments/group_vars/all/vitam_vars.yml
+++ b/deployment/environments/group_vars/all/vitam_vars.yml
@@ -4,7 +4,7 @@ vitam_defaults:
   folder:
     root_path: "/vitam"
     folder_permission: "0750"
-    conf_permission: "0640"
+    conf_permission: "0440"
     folder_upload_permission: "0770"
     script_permission: "0750"
   users:

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -8,7 +8,7 @@ vitamui_defaults:
   folder:
     root_path: "/vitamui"
     folder_permission: "0750"
-    conf_permission: "0640"
+    conf_permission: "0440"
     folder_upload_permission: "0770"
     script_permission: "0750"
   users:


### PR DESCRIPTION
Suite à la mise en lumière de la vulnérabilité log4j, une autre vulnérabilité a été découverte concernant le composant logback.

https://cve.report/CVE-2021-42550

Elle peut-être exploitée lorsque les fichiers de configuration possèdent les droits d'écriture. Dans Vitam, l'ensemble des fichiers de configuration n'a pas besoin des droits d'écriture.

Ainsi, il est recommandé de rendre en lecture seule l'ensemble des fichiers de configuration de Vitam & Vitam-UI pour se prémunir de ce type d'attaque.