### PR TITLE
[Vas] Item 9300 - Upgrade librairies to have same versions as cas-server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
-        <jackson.version>2.12.3</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
         <jaeger.tracing.version>3.2.2</jaeger.tracing.version>
         <jakarta.xml.binding.version>2.3.2</jakarta.xml.binding.version>
         <javax.el.version.version>3.0.1-b06</javax.el.version.version>
@@ -111,11 +111,11 @@
         <junit.vintage.engine.version>5.7.0</junit.vintage.engine.version>
         <jruby.complete.version>9.2.13.0</jruby.complete.version>
         <jsonassert.version>1.5.0</jsonassert.version>
-        <logback.version>1.2.10</logback.version>
-        <lombok.version>1.18.12</lombok.version>
-        <micrometer.version>1.6.5</micrometer.version>
+        <logback.version>1.2.3</logback.version>
+        <lombok.version>1.18.20</lombok.version>
+        <micrometer.version>1.7.3</micrometer.version>
         <mapstruct.version>1.3.0.Final</mapstruct.version>
-        <mockito.version>3.11.2</mockito.version>
+        <mockito.version>3.12.1</mockito.version>
         <nio.multipart.parser.version>1.1.0</nio.multipart.parser.version>
         <pac4j.version>5.1.4</pac4j.version>
         <poi.version>4.1.2</poi.version>
@@ -131,7 +131,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <spring.boot.version>2.5.6</spring.boot.version>
         <spring.version>5.3.12</spring.version>
-        <spring.cloud.consul.version>3.0.2</spring.cloud.consul.version>
+        <spring.cloud.consul.version>3.0.3</spring.cloud.consul.version>
         <spring.security.version>5.5.3</spring.security.version>
         <swagger.version>3.0.0</swagger.version>
         <trang.version>20181222</trang.version>


### PR DESCRIPTION
Dans la PR de migration de CAS proposée plusieurs librairies ont été upgradées, Certains sont présentes dans Vitamui avec des versions différentes (mineurs).
Afin d'éviter un eventuel conflit, une migration mineure (alignement avec les versions dans CAS) est proposé.

Celà concerne les librairies suivantes:

    micrometer.version :1.6.5 ==> 1.7.3
    jackson.version: 2.10.0 ==>  2.12.4
    lombok: 1.18.12 ==> 1.18.20
    mockito: 3.11.2 ==> 3.12.1
    spring.cloud.consul.version :3.0.2 ==>3.0.3



## Type de changement

-  Versions de librairies (upgrade mineur)

## Migration
-  Versions de librairies (upgrade mineur)
 
## Checklist

 [ * ] Les tests unitaires nouveaux et existants passent avec succès .

## Contributeur

Vitam Accessible en Service (VAS)