### PR TITLE
[VAS] [CP5RC] Update component_type for cas_server from external to ui.

### DIFF
--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -233,7 +233,7 @@ vitamui:
   cas_server:
     host: "cas-server.service.{{ consul_domain }}"
     vitamui_component: "cas-server"
-    vitamui_component_type: "external"
+    vitamui_component_type: "ui"
     package_name: "vitamui-cas-server"
     store_name: "cas-server"
     service_name: "vitamui-cas-server"

--- a/deployment/roles/vitamui/tasks/ui.yml
+++ b/deployment/roles/vitamui/tasks/ui.yml
@@ -12,7 +12,7 @@
     dest: "{{ vitamui_defaults.folder.root_path}}/conf/assets"
     owner: "{{ vitamui_defaults.users.vitamui }}"
     group: "{{ vitamui_defaults.users.group }}"
-    mode: "{{ vitamui_defaults.folder.folder_permission }}"
+    mode: "{{ vitamui_defaults.folder.conf_permission }}"
   with_fileglob:
     - ../files/ui/assets/*
   tags:


### PR DESCRIPTION
Allow to properly install assets when cas-server is not colocalised with other ui components.
Otherwise, WARN logs will appears in cas-server because of missing assets.