### PR TITLE
[VAS] BUG 8754 : fixe search archive unit with start and end dates

### DIFF
--- a/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/dsl/VitamQueryHelper.java
+++ b/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/dsl/VitamQueryHelper.java
@@ -98,50 +98,6 @@ public class VitamQueryHelper {
 
     }
 
-    public static void addDatesCriteriaToQuery(BooleanQuery mainQuery, final String criteria,
-        final List<String> searchValues)
-        throws InvalidCreateOperationException {
-        BooleanQuery subQueryAnd = and();
-        String searchCriteria = ArchiveSearchConsts.START_DATE_CRITERIA.equals(criteria) ?
-            ArchiveSearchConsts.START_DATE :
-            (ArchiveSearchConsts.END_DATE_CRITERIA.equals(criteria) ?
-                ArchiveSearchConsts.END_DATE : null);
-
-        LOGGER.info("The search criteria Date is {} ", searchCriteria);
-        if (!CollectionUtils.isEmpty(searchValues)) {
-            if (searchValues.size() > 2) {
-                throw new IllegalArgumentException("criteria date should not contains more than 2 values");
-            }
-            if (searchValues.size() == 1) {
-                //Equal date
-                LocalDateTime beginDate =
-                    LocalDateTime.parse(searchValues.get(0), ArchiveSearchConsts.ISO_FRENCH_FORMATER).withHour(0)
-                        .withMinute(0).withSecond(0).withNano(0);
-
-                subQueryAnd.add(VitamQueryHelper
-                    .buildSubQueryByOperator(searchCriteria, ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER.format(beginDate.plusDays(1)),
-                        ArchiveSearchConsts.CriteriaOperators.EQ));
-
-            } else {
-                LocalDateTime firstDate =
-                    LocalDateTime.parse(searchValues.get(0), ArchiveSearchConsts.ISO_FRENCH_FORMATER);
-                LocalDateTime secondDate =
-                    LocalDateTime.parse(searchValues.get(1), ArchiveSearchConsts.ISO_FRENCH_FORMATER);
-
-                    subQueryAnd.add(VitamQueryHelper.buildSubQueryByOperator(searchCriteria,
-                        ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER
-                            .format(firstDate.isAfter(secondDate) ? secondDate.plusDays(1) : firstDate.plusDays(1)),
-                        ArchiveSearchConsts.CriteriaOperators.GTE));
-                    subQueryAnd.add(VitamQueryHelper.buildSubQueryByOperator(searchCriteria,
-                        ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER
-                            .format(firstDate.isAfter(secondDate) ? firstDate.plusDays(1) : secondDate.plusDays(1)),
-                        ArchiveSearchConsts.CriteriaOperators.LTE));
-
-            }
-        }
-        mainQuery.add(subQueryAnd);
-    }
-
     public static Query buildSubQueryByOperator(String searchKey, String value,
         ArchiveSearchConsts.CriteriaOperators operator)
         throws InvalidCreateOperationException {

--- a/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/service/ArchivesSearchFieldsQueryBuilderService.java
+++ b/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/service/ArchivesSearchFieldsQueryBuilderService.java
@@ -86,7 +86,12 @@ public class ArchivesSearchFieldsQueryBuilderService implements IArchivesSearchA
                         searchCriteria.getValues().stream().map(value -> value.getValue()).collect(
                             Collectors.toList()),
                         ArchiveSearchConsts.CriteriaOperators.valueOf(searchCriteria.getOperator())));
-                }
+                } else if (ArchiveSearchConsts.CriteriaDataType.DATE.name().equals(searchCriteria.getDataType())) {
+                      queryToFill.add(buildStartDateEndDateQuery(searchCriteria.getCriteria(),
+                          searchCriteria.getValues().stream().map(value -> value.getValue()).collect(
+                              Collectors.toList()),
+                          ArchiveSearchConsts.CriteriaOperators.valueOf(searchCriteria.getOperator())));
+                  }
 
                 else {
                     String mappedCriteriaName =
@@ -199,6 +204,33 @@ public class ArchivesSearchFieldsQueryBuilderService implements IArchivesSearchA
             }
             subQueryAnd.add(subQueryOr);
         }
+        return subQueryAnd;
+    }
+
+    private Query buildStartDateEndDateQuery(String searchCriteria, final List<String> searchValues,
+        ArchiveSearchConsts.CriteriaOperators operator)
+        throws InvalidCreateOperationException {
+        BooleanQuery subQueryAnd = and();
+        BooleanQuery subQueryOr = or();
+        String criteria = ArchiveSearchConsts.START_DATE_CRITERIA.equals(searchCriteria) ?
+            ArchiveSearchConsts.START_DATE :
+            (ArchiveSearchConsts.END_DATE_CRITERIA.equals(searchCriteria) ?
+                ArchiveSearchConsts.END_DATE : null);
+
+        LOGGER.info("The search criteria Date is {} ", criteria);
+        if (!CollectionUtils.isEmpty(searchValues)) {
+                for (String value : searchValues) {
+                    LocalDateTime searchDate =
+                        LocalDateTime.parse(value, ArchiveSearchConsts.ISO_FRENCH_FORMATER).withHour(0)
+                            .withMinute(0).withSecond(0).withNano(0);
+                    subQueryOr
+                        .add(VitamQueryHelper.buildSubQueryByOperator(criteria,
+                            ArchiveSearchConsts.ONLY_DATE_FRENCH_FORMATER.format(searchDate.plusDays(1)), operator));
+                }
+
+                subQueryAnd.add(subQueryOr);
+        }
+
         return subQueryAnd;
     }
 


### PR DESCRIPTION
L'objectif de cette PR est de corriger un bug sur la recherche des unités archivistiques avec des startdDates et des endDates.
Ticket sur [TuleUp](https://assistance.programmevitam.fr/plugins/tracker/?aid=8754)