### PR TITLE
[VAS] BUG 9119 delete elimination identifier with rule criterias

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -74,6 +74,7 @@ const DESCRIPTION_MAX_TEXT = 60;
 const PAGE_SIZE = 10;
 const FILTER_DEBOUNCE_TIME_MS = 400;
 const MAX_ELIMINATION_ANALYSIS_THRESHOLD = 10000;
+const ELIMINATION_TECHNICAL_ID = 'ELIMINATION_TECHNICAL_ID';
 
 @Component({
   selector: 'app-archive-search',
@@ -405,6 +406,15 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy {
 
   removeCriteriaByCategory(category: string) {
     if (this.searchCriterias && this.searchCriterias.size > 0) {
+      if (category === SearchCriteriaTypeEnum.APPRAISAL_RULE) {
+        this.searchCriterias.forEach((criteriaValues, key) => {
+          if (key === ELIMINATION_TECHNICAL_ID) {
+            criteriaValues.values.forEach((value) => {
+              this.removeCriteria(key, value.value, true);
+            });
+          }
+        });
+      }
       this.searchCriterias.forEach((val, key) => {
         if (SearchCriteriaTypeEnum[val.category] === category) {
           val.values.forEach((value) => {

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
@@ -51,6 +51,7 @@
     "HIDE_SEARCH_CRITERIA": "hide the search filters",
     "SHOW_MORE_RESULTS": "Show more results...",
     "NO_MORE_RESULTS": "No more results",
+    "REMOVE_SEARCH_CRITERIA_BY_CATEGORY": "Delete rule criterias",
     "SEARCH_CRITERIA_FILTER": {
       "TITLE": "Search filters",
       "DUA_TITLE": "Administrative useful life",

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
@@ -51,7 +51,7 @@
     "SHOW_SEARCH_CRITERIA": "Afficher les filtres de recherche",
     "HIDE_SEARCH_CRITERIA": "Masquer les filtres de recherche",
     "SHOW_MORE_RESULTS": "Afficher plus de résultats...",
-    "REMOVE_SEARCH_CRITERIA_BY_CATEGORY": "Supprimer les filtres de la règles",
+    "REMOVE_SEARCH_CRITERIA_BY_CATEGORY": "Supprimer les filtres de la règle",
     "NO_MORE_RESULTS": "Fin des résultats",
     "SEARCH_CRITERIA_FILTER": {
       "TITLE": "Filtre de recherche",


### PR DESCRIPTION
L'objectif de cette PR est de corriger un bug lors de la suppression des critères de recherche d'une règle DUA.
Ticket 9119 [TuleUp](https://assistance.programmevitam.fr/plugins/tracker/?aid=9119)