### PR TITLE
Fix Vitamui Build: due to Infinite loop in a malicious package

### DIFF
--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -114,7 +114,8 @@
     "utf-8-validate": "^5.0.2",
     "uuid": "^7.0.2",
     "web-animations-js": "^2.3.2",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.10.3",
+    "colors": "1.4.0"
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^8.4.1",
@@ -154,5 +155,8 @@
     "tslint": "~5.11.0",
     "typescript": "~4.0.5",
     "webpack-bundle-analyzer": "^3.8.0"
+  },
+  "overrides": {
+    "colors": "1.4.0"
   }
 }


### PR DESCRIPTION
## Description
- Correction de la 'JS Heap memory' lors de l'exécution des tests front.
- La version a été figée et forcée à 1.4.0

## Contributeur
Vitam Accessible en Service (VAS)