### PR TITLE
Story #7963: Fix consul resolution for mongo-vitamui when deployed on 2 networks

### DIFF
--- a/deployment/roles/mongo/templates/service-componentid.json.j2
+++ b/deployment/roles/mongo/templates/service-componentid.json.j2
@@ -1,6 +1,7 @@
 {
   "service": {
     "name": "{{ mongo_cluster_name }}-mongod",
+    "address": "{{ ip_service }}",
     "port": {{ mongodb.mongod_port }},
     "enable_tag_override": false,
     "tags": ["bdd","mongo","{{ mongo_cluster_name }}","{{ mongo_cluster_name }}-mongod"],


### PR DESCRIPTION
Problem when consul is binding on ip_admin.