### PR TITLE
[VAS] FIX BUG 9292: Remove useless referential-external-client parameters from ui components.

### DIFF
--- a/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
@@ -83,21 +83,6 @@ ui-archive-search:
         key-password: {{ password_truststore }}
       hostname-verification: false
 {%endif %}
-  referential-external-client:
-    server-host: {{ vitamui.referential_external.host }}
-    server-port: {{ vitamui.referential_external.port_service }}
-{% if vitamui.referential_external.secure | lower == "true" %}
-    secure: {{ vitamui.referential_external.secure | lower }}
-    ssl-configuration:
-      keystore:
-        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.package_name }}.jks
-        key-password: {{ password_keystore }}
-        type: JKS
-      truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
-      hostname-verification: false
-{%endif %}
   assets: "{{ vitamui_defaults.folder.root_path }}/conf/assets"
   portal-logo: "{{ vitamui_platform_informations.theme.portal_logo }}"
   header-logo: "{{ vitamui_platform_informations.theme.header_logo }}"

--- a/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
@@ -74,21 +74,6 @@ ui-identity:
         key-password: {{ password_truststore }} # TODO OMA : revoir
       hostname-verification: false
 {%endif %}
-  referential-external-client:
-    server-host: {{ vitamui.referential_external.host }}
-    server-port: {{ vitamui.referential_external.port_service }}
-{% if vitamui.referential_external.secure | lower == "true" %}
-    secure: {{ vitamui.referential_external.secure | lower }}
-    ssl-configuration:
-      keystore:
-        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.package_name }}.jks
-        key-password: {{ password_keystore }}
-        type: JKS
-      truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
-      hostname-verification: false
-{% endif %}
   assets: "{{ vitamui_defaults.folder.root_path }}/conf/assets"
   portal-logo: "{{ vitamui_platform_informations.theme.portal_logo }}"
   header-logo: "{{ vitamui_platform_informations.theme.header_logo }}"

--- a/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
@@ -91,21 +91,7 @@ ui-identity:
         key-password: {{ password_truststore }}
       hostname-verification: false
 {%endif %}
-  referential-external-client:
-    server-host: {{ vitamui.referential_external.host }}
-    server-port: {{ vitamui.referential_external.port_service }}
-{% if vitamui.referential_external.secure | lower == "true" %}
-    secure: {{ vitamui.referential_external.secure | lower }}
-    ssl-configuration:
-      keystore:
-        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.package_name }}.jks
-        key-password: {{ password_keystore }}
-        type: JKS
-      truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
-      hostname-verification: false
-{%endif %}
+
   base-url:
 {% if vitamui.portal.base_url is defined %}
     portal: "{{ vitamui.portal.base_url }}"

--- a/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
@@ -85,21 +85,6 @@ ui-ingest:
         key-password: {{ password_truststore }}
       hostname-verification: false
 {%endif %}
-  referential-external-client:
-    server-host: {{ vitamui.referential_external.host }}
-    server-port: {{ vitamui.referential_external.port_service }}
-{% if vitamui.referential_external.secure | lower == "true" %}
-    secure: {{ vitamui.referential_external.secure | lower }}
-    ssl-configuration:
-      keystore:
-        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.package_name }}.jks
-        key-password: {{ password_keystore }}
-        type: JKS
-      truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
-      hostname-verification: false
-{%endif %}
   assets: "{{ vitamui_defaults.folder.root_path }}/conf/assets"
   portal-logo: "{{ vitamui_platform_informations.theme.portal_logo }}"
   header-logo: "{{ vitamui_platform_informations.theme.header_logo }}"

--- a/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
@@ -68,21 +68,6 @@ ui-portal:
         key-password: {{ password_truststore }} # TODO OMA : revoir
       hostname-verification: false
 {% endif %}
-  referential-external-client:
-    server-host: {{ vitamui.referential_external.host }}
-    server-port: {{ vitamui.referential_external.port_service }}
-{% if vitamui.referential_external.secure | lower == "true" %}
-    secure: {{ vitamui.referential_external.secure | lower }}
-    ssl-configuration:
-      keystore:
-        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.package_name }}.jks
-        key-password: {{ password_keystore }}
-        type: JKS
-      truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
-      hostname-verification: false
-{%endif %}
   assets: "{{ vitamui_defaults.folder.root_path }}/conf/assets"
   portal-logo: "{{ vitamui_platform_informations.theme.portal_logo }}"
   header-logo: "{{ vitamui_platform_informations.theme.header_logo }}"


### PR DESCRIPTION
Correction de la PR #721

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Binding to target [Bindable@8b91134 type = fr.gouv.vitamui.identity.config.IdentityApplicationProperties, value = 'provided', annotations = array<Annotation>[@org.springframework.boot.context.properties.ConfigurationProperties(ignoreInvalidFields=false, ignoreUnknownFields=false, prefix=ui-identity, value=ui-identity)]] failed:

    Property: ui-identity.referential-external-client.secure
    Value: true
    Origin: URL [file:/vitamui/conf/ui-identity/application.yml] - 104:13
    Reason: The elements [ui-identity.referential-external-client.secure,ui-identity.referential-external-client.server-host,ui-identity.referential-external-client.server-port,ui-identity.referential-external-client.ssl-configuration.hostname-verification,ui-identity.referential-external-client.ssl-configuration.keystore.key-password,ui-identity.referential-external-client.ssl-configuration.keystore.key-path,ui-identity.referential-external-client.ssl-configuration.keystore.type,ui-identity.referential-external-client.ssl-configuration.truststore.key-password,ui-identity.referential-external-client.ssl-configuration.truststore.key-path] were left unbound.
    Property: ui-identity.referential-external-client.server-host
    Value: referential-external.service.consul
    Origin: URL [file:/vitamui/conf/ui-identity/application.yml] - 102:18
    Reason: The elements [ui-identity.referential-external-client.secure,ui-identity.referential-external-client.server-host,ui-identity.referential-external-client.server-port,ui-identity.referential-external-client.ssl-configuration.hostname-verification,ui-identity.referential-external-client.ssl-configuration.keystore.key-password,ui-identity.referential-external-client.ssl-configuration.keystore.key-path,ui-identity.referential-external-client.ssl-configuration.keystore.type,ui-identity.referential-external-client.ssl-configuration.truststore.key-password,ui-identity.referential-external-client.ssl-configuration.truststore.key-path] were left unbound.
    Property: ui-identity.referential-external-client.server-port
    Value: 8105
    Origin: URL [file:/vitamui/conf/ui-identity/application.yml] - 103:18
    Reason: The elements [ui-identity.referential-external-client.secure,ui-identity.referential-external-client.server-host,ui-identity.referential-external-client.server-port,ui-identity.referential-external-client.ssl-configuration.hostname-verification,ui-identity.referential-external-client.ssl-configuration.keystore.key-password,ui-identity.referential-external-client.ssl-configuration.keystore.key-path,ui-identity.referential-external-client.ssl-configuration.keystore.type,ui-identity.referential-external-client.ssl-configuration.truststore.key-password,ui-identity.referential-external-client.ssl-configuration.truststore.key-path] were left unbound.
    Property: ui-identity.referential-external-client.ssl-configuration.hostname-verification
    Value: false
    Origin: URL [file:/vitamui/conf/ui-identity/application.yml] - 113:30
    Reason: The elements [ui-identity.referential-external-client.secure,ui-identity.referential-external-client.server-host,ui-identity.referential-external-client.server-port,ui-identity.referential-external-client.ssl-configuration.hostname-verification,ui-identity.referential-external-client.ssl-configuration.keystore.key-password,ui-identity.referential-external-client.ssl-configuration.keystore.key-path,ui-identity.referential-external-client.ssl-configuration.keystore.type,ui-identity.referential-external-client.ssl-configuration.truststore.key-password,ui-identity.referential-external-client.ssl-configuration.truststore.key-path] were left unbound.
    Property: ui-identity.referential-external-client.ssl-configuration.keystore.key-password
    Value: changeme-jLF4REdGnUP9EsHX
    Origin: URL [file:/vitamui/conf/ui-identity/application.yml] - 108:23
    Reason: The elements [ui-identity.referential-external-client.secure,ui-identity.referential-external-client.server-host,ui-identity.referential-external-client.server-port,ui-identity.referential-external-client.ssl-configuration.hostname-verification,ui-identity.referential-external-client.ssl-configuration.keystore.key-password,ui-identity.referential-external-client.ssl-configuration.keystore.key-path,ui-identity.referential-external-client.ssl-configuration.keystore.type,ui-identity.referential-external-client.ssl-configuration.truststore.key-password,ui-identity.referential-external-client.ssl-configuration.truststore.key-path] were left unbound.
```