### PR TITLE
[VAS] US 9778 : Bumps lodash ini logback-core

### DIFF
--- a/cots/vitamui-mongo-express/package-lock.json
+++ b/cots/vitamui-mongo-express/package-lock.json
@@ -339,7 +339,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.5.1",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
           "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
           "requires": {
             "inherits": "2.0.3",
@@ -825,7 +825,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -853,9 +853,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -1013,9 +1013,9 @@
       "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <junit.vintage.engine.version>5.7.0</junit.vintage.engine.version>
         <jruby.complete.version>9.2.13.0</jruby.complete.version>
         <jsonassert.version>1.5.0</jsonassert.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.9</logback.version>
         <lombok.version>1.18.20</lombok.version>
         <micrometer.version>1.7.3</micrometer.version>
         <mapstruct.version>1.3.0.Final</mapstruct.version>


### PR DESCRIPTION
Bump lodash from 4.17.11 to 4.17.21 in /cots/vitamui-mongo-express

Bump ini from 1.3.5 to 1.3.8 in /cots/vitamui-mongo-express

Bumps logback-core from 1.2.3 to 1.2.9.
