### PR TITLE
[VAS] Story 9679: Default disabling of Vitam services at system startup.

### DIFF
--- a/deployment/environments/group_vars/all/vitam_vars.yml
+++ b/deployment/environments/group_vars/all/vitam_vars.yml
@@ -11,6 +11,8 @@ vitam_defaults:
     vitam: "vitam"
     vitamdb: "vitamdb"
     group: "vitam"
+  services:
+    at_boot: false
 
 # Mandatory Vitam services for VitamUI
 vitam_vars:

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -25,6 +25,7 @@ vitamui_defaults:
     api_long_call_timeout: 300
     status_retries_number: 60
     status_retries_delay: 5
+    at_boot: false
   # Filter for the vitam package version to install
   # FIXME : commented as has to be removed becuase doesn't work under Debain
   #package_version: "*"

--- a/deployment/roles/consul/tasks/main.yml
+++ b/deployment/roles/consul/tasks/main.yml
@@ -4,7 +4,6 @@
   fail: msg="{{ vitam_site_name }} not correctly configured"
   when: vitam_site_name|regex_search('[^a-zA-Z0-9\\-]') # found a bug ; no "_" allowed
 
-
 - name: Install {{ consul.package_name }} package
   package:
     name: "{{ consul.package_name }}"
@@ -20,13 +19,6 @@
   user:
     name: vitam
     groups: vitam, {{ vitamui_defaults.users.group }}
-
-- name: Enable {{ consul.service_name }} service
-  service:
-    name: "{{ consul.service_name }}"
-    enabled: true
-  notify:
-      - restart consul
 
 #### Configuration ####
 
@@ -67,6 +59,7 @@
   service:
     name: "{{ consul.service_name }}"
     state: started
+    enabled: "{{ consul.at_boot | default(service_at_boot) }}"
 
 # Changing the resolv.conf doesn't work into a docker container...
 - name: Add consul nameserver to resolv.conf

--- a/deployment/roles/consul/vars/main.yml
+++ b/deployment/roles/consul/vars/main.yml
@@ -3,3 +3,5 @@
 consul_folder_conf: "{{ vitam_defaults.folder.root_path }}/conf/consul"
 consul_folder_log: "{{ vitam_defaults.folder.root_path }}/log/consul"
 consul_folder_data: "{{ vitam_defaults.folder.root_path }}/data/consul"
+
+service_at_boot: "{{ vitam_defaults.services.at_boot | default(false) }}"

--- a/deployment/roles/logstash/tasks/main.yml
+++ b/deployment/roles/logstash/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Enable logstash
   service:
     name: "{{ logstash.service_name }}"
-    enabled: yes
+    enabled: "{{ logstash.at_boot | default(service_at_boot) }}"
   notify:
     - restart logstash
 

--- a/deployment/roles/logstash/vars/main.yml
+++ b/deployment/roles/logstash/vars/main.yml
@@ -5,3 +5,5 @@ logstash_tmp_dir: "{{ vitamui_defaults.folder.root_path }}/tmp/logstash"
 logstash_conf_dir: "{{ vitamui_defaults.folder.root_path }}/conf/logstash"
 logstash_confextra_dir: "{{ logstash_conf_dir }}/extra"
 logstash_data_dir: "{{ vitamui_defaults.folder.root_path }}/data/logstash"
+
+service_at_boot: "{{ vitam_defaults.services.at_boot | default(false) }}"

--- a/deployment/roles/mongo-express/defaults/main.yml
+++ b/deployment/roles/mongo-express/defaults/main.yml
@@ -2,3 +2,5 @@
 
 package_name: "{{ mongo_express.package_name | default('vitamui-mongo-express') }}"
 service_name: "{{ mongo_express.service_name | default('vitamui-mongo-express') }}"
+
+service_at_boot: "{{ vitamui_defaults.services.at_boot | default(false) }}"

--- a/deployment/roles/mongo-express/tasks/main.yml
+++ b/deployment/roles/mongo-express/tasks/main.yml
@@ -43,7 +43,7 @@
   systemd:
     name: "{{ service_name }}"
     state: started
-    enabled: yes
+    enabled: "{{ mongo_express.at_boot | default(service_at_boot) }}"
     daemon_reload: yes
   tags:
     - mongo-express

--- a/deployment/roles/mongo/tasks/main.yml
+++ b/deployment/roles/mongo/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: "enable {{ service_name }} service at boot"
   service:
     name: "{{ service_name }}"
-    enabled: true
+    enabled: "{{ mongodb.at_boot | default(service_at_boot) }}"
   notify:
     - restart mongod
 

--- a/deployment/roles/mongo/vars/main.yml
+++ b/deployment/roles/mongo/vars/main.yml
@@ -3,3 +3,5 @@
 mongo_tmp_path:  "{{ vitamui_defaults.folder.root_path }}/tmp/mongod"
 mongo_config_path: "{{ vitamui_defaults.folder.root_path }}/conf/mongod"
 mongo_db_path: "{{ vitamui_defaults.folder.root_path }}/data/mongod/db"
+
+service_at_boot: "{{ vitamui_defaults.services.at_boot | default(false) }}"

--- a/deployment/roles/mongo_configure/tasks/main.yml
+++ b/deployment/roles/mongo_configure/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: "restart {{ mongodb.service_name }} service"
   service:
       name: "{{ mongodb.service_name }}"
-      enabled: true
+      enabled: "{{ mongodb.at_boot | default(service_at_boot) }}"
       state: restarted
   delegate_to: "{{ item }}"
   with_items: "{{ groups['hosts_vitamui_mongod'] }}"

--- a/deployment/roles/mongo_configure/vars/main.yml
+++ b/deployment/roles/mongo_configure/vars/main.yml
@@ -1,3 +1,5 @@
 ---
 
 mongod_config_path:  '{{ vitamui_defaults.folder.root_path }}/conf/mongod'
+
+service_at_boot: "{{ vitamui_defaults.services.at_boot | default(false) }}"

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -14,13 +14,6 @@
     - restart service
   when: force_vitamui_version is not defined
 
-- name: Ensure {{ service_name }} service is enabled at boot
-  service:
-    name: "{{ service_name }}"
-    enabled: true
-  notify:
-    - restart service
-
 #### Configuration ####
 
 - name: Check that the directories exist (must be removed when the RPM plugin will be patched)
@@ -60,7 +53,7 @@
     group: "{{ vitamui_defaults.users.group }}"
     mode: "{{ vitamui_defaults.folder.folder_permission }}"
   loop: "{{ vitamui_struct.dirs }}"
-  when: 
+  when:
     - vitamui_struct.dirs is defined
     - vitamui_struct.dirs|length > 0
   notify:
@@ -128,9 +121,9 @@
     owner: "{{ vitamui_defaults.users.vitamui }}"
     group: "{{ vitamui_defaults.users.group }}"
     mode: "{{ vitamui_defaults.folder.folder_permission }}"
-  when: 
+  when:
     - vitamui_struct.secure|lower == 'true'
-    - vitamui_certificate_type is defined 
+    - vitamui_certificate_type is defined
     - "vitamui_certificate_type|lower == '{{ item.name }}'"
     - "{{ lookup('pipe', 'test -f {{ item.src }} || echo nofile') == \"\"}}"
   with_items:
@@ -143,16 +136,15 @@
   notify:
     - restart service
 
-- name: "Execute sub-tasks for the component type: {{ vitamui_struct.vitamui_component_type }}" 
+- name: "Execute sub-tasks for the component type: {{ vitamui_struct.vitamui_component_type }}"
   include_tasks: "{{ vitamui_struct.vitamui_component_type }}.yml"
   when: "{{ lookup('pipe', 'test -f {{ role_path }}/tasks/{{ vitamui_struct.vitamui_component_type }}.yml || echo nofile') == \"\" }}"
 
-- name: "Execute sub-tasks for the component: {{ vitamui_struct.vitamui_component }}" 
+- name: "Execute sub-tasks for the component: {{ vitamui_struct.vitamui_component }}"
   include_tasks: "{{ vitamui_struct.vitamui_component }}.yml"
   when: "{{ lookup('pipe', 'test -f {{ role_path }}/tasks/{{ vitamui_struct.vitamui_component }}.yml || echo nofile') == \"\" }}"
 
-- name: flush_handlers
-  meta: flush_handlers
+- meta: flush_handlers
   tags:
     - always
 
@@ -160,3 +152,4 @@
   service:
     name: "{{ service_name }}"
     state: started
+    enabled: "{{ vitamui_struct.at_boot | default(service_at_boot) }}"

--- a/deployment/roles/vitamui/vars/main.yml
+++ b/deployment/roles/vitamui/vars/main.yml
@@ -12,3 +12,5 @@ vitamui_folder_tmp: "{{ vitamui_defaults.folder.root_path }}/tmp/{{ vitamui_stru
 
 vitamui_conf_consul: "{{ consul.conf_folder }}"
 service_consul: "{{ consul.service_name }}"
+
+service_at_boot: "{{ vitamui_defaults.services.at_boot | default(false) }}"


### PR DESCRIPTION
Par défaut, l'ensemble des services Vitam-UI sont activés au démarrage des serveurs.

Cela pose plusieurs problèmes notamment en cas de crash plateforme, redémarrage imprévu de VMs ou en cas de mise à jour système qui nécessiterait un reboot.

Notamment lorsque plusieurs services Vitam-UI sont colocalisés sur une même VM, cela rend très complexe (voir impossible) le redémarrage correct de Vitam-UI car il n'y a aucune maîtrise de l'ordre de lancement de ces services.

De plus, niveau sécurité, en cas d'attaque il est recommandé de ne pas redémarrer automatiquement des services (notamment après le crash d'une vm) avant d'avoir pu clairement identifier l'origine du crash. Si les services redémarrent automatiquement, l'assaillant peut potentiellement prendre le contrôle de son attaque.

---

Ajout d'un paramètre dans l'ansiblerie pour déterminer si l'on souhaite avoir les services au boot ou pas.

Dans le fichier `environments/group_vars/all/vitamui_vars.yml`, Une nouvelle variable `vitamui_defaults.services.at_boot: false` a été rajoutée pour permettre la configuration globale pour l'ensemble des services Vitam.

Il est aussi possible de déterminer composant par composant si l'on souhaite qu'ils soient démarrés au boot.