### PR TITLE
[VAS] story #9751 Rework Vitam reverse update task

### DIFF
--- a/deployment/roles/reverse/tasks/apache/merge_index_apache.yml
+++ b/deployment/roles/reverse/tasks/apache/merge_index_apache.yml
@@ -1,85 +1,13 @@
-- name: set vitamui_consul_url
-  set_fact:
-    vitamui_consul_url: "/ui/{{ vitam_site_name }}-ui/services"
-    mongo_express_uri: "https://{{ vitam_reverse_external_dns }}/{{ mongo_express.baseuri }}"
-
-- name: save index.html
-  command: cp -p index.html index.html.{{ ansible_date_time.date }}-{{ ansible_date_time.time }}
-  args:
-    chdir: "/var/www/html-{{ vitam_site_name }}"
-
-- name: url vitam ui
+- name: Add main links
   blockinfile:
     path: "/var/www/html-{{ vitam_site_name }}/index.html"
-    marker: "<!-- {mark} BEGIN ANSIBLE MANAGED BLOCK -->"
-    insertafter: <div class="col-md-2"><a href="/ihm-recette/" class="btn btn-primary btn-xs" target="_blank">IHM recette</a> </div>
-    block: |
-                                 <div class="col-md-4"><a href="https://{{ vitam_reverse_external_dns }}" class="btn btn-primary btn-xs" target="_blank">VITAM UI</a> </div>
+    marker: "          <!-- {mark} ANSIBLE MANAGED BLOCK FOR VITAM UI LINKS -->"
+    insertafter: <!-- Vitam UI - Liens -->
+    block: "{{ lookup('template', 'apache/page/index_links.html.j2') }}"
 
-- name: consul
-  lineinfile:
+- name: Add debug information and Browser link
+  blockinfile:
     path: "/var/www/html-{{ vitam_site_name }}/index.html"
-    insertafter: ">Portail Consul</a>"
-    line: "                        <div class=\"col-md-4\"><a href=\"{{ vitamui_consul_url }}\" class=\"btn btn-primary btn-xs\" target=\"_blank\">Portail Consul UI</a>&nbsp;<a href=\"https://{{ vitam_reverse_external_dns }}/v1/health/state/any?pretty\" class=\"btn btn-primary btn-xs\" target=\"_blank\">Services health</a></div>"
-
-- name: read index.html
-  command: cat "/var/www/html-{{ vitam_site_name }}/index.html"
-  register: index_content
-
-### block in the goal to be complient with idempotence
-- block:
-  - name: Mongo express vitamui
-    replace:
-      path: "/var/www/html-{{ vitam_site_name }}/index.html"
-      regexp: (mongo-express-offer-fs-[0-9]+.*\n.*</div>)
-      replace: |
-        \1
-        <div class="col-md-3">
-        {% for host in groups['hosts_vitamui_mongod'] %}
-        <a href="{{ mongo_express_uri }}" class="btn btn-primary btn-xs" target="_blank">Mongo express {{ hostvars[host]['mongo_cluster_name'] }}</a>
-        {% endfor %}
-        </div>
-  when: index_content.stdout is not search('Mongo express.*vitamui')
-
-
-### block in the goal to be complient with idempotence
-### Browser vm vitam-ui
-- block:
-  - name: debug vitam-ui
-    replace:
-      path: "/var/www/html-{{ vitam_site_name }}/index.html"
-      regexp: "(</div>\n.*</div>\n.*\n<!-- MAIN FOOTER -->)"
-      replace: |
-        <div class="panel panel-default col-md-12 container">
-        <a class="panel-header no-toggle" href="#">
-            <h2>Debug UI</h2>
-        </a>
-        <div class="panel-body">
-        {% for item in groups['hosts_vitamui'] %}
-                    <div class="row component-line">
-                        <div class="col-md-3">{{ item }}</div>
-                        <div class="col-md-2">
-                            {% for groupe in groups %}
-                                {% if item in groups[groupe] %}
-                                    {% if (groupe not in ('hosts','all','vitam','prometheus','reverse','elasticsearch','mongo_common')) and (not(groupe is search('^zone'))) %}
-                                        {{ groupe|regex_replace('hosts_', '')| replace('_','-') }}<br/>
-                                    {% endif %}
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                        <div class="col-md-2">
-                            {% for groupe in groups %}
-                                {% if groupe is search('^zone') %}
-                                    {% if item in groups[groupe] %}{{ groupe| replace('_',' ') }}<br/>{% endif %}
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                        <div class="col-md-2">
-                            <a href="https://{{ vitam_reverse_external_dns }}/nodes/{{ item }}/browse" class="btn btn-primary btn-xs" target="_blank">/vitam browser</a>
-                        </div>
-                    </div>
-         {% endfor %}
-            </div>
-         </div>
-         \1
-  when:  index_content.stdout is not search("vitamui-security-internal")
+    marker: "          <!-- {mark} ANSIBLE MANAGED BLOCK FOR VITAM UI DEBUG -->"
+    insertafter: <!-- Vitam UI - Debug -->
+    block: "{{ lookup('template', 'apache/page/index_debug.html.j2') }}"

--- a/deployment/roles/reverse/templates/apache/page/index_debug.html.j2
+++ b/deployment/roles/reverse/templates/apache/page/index_debug.html.j2
@@ -1,0 +1,37 @@
+#jinja2: lstrip_blocks: True
+          <div class="panel panel-default col-md-12 container">
+            <a class="panel-header no-toggle" href="#">
+              <h2>Vitam UI - Debug</h2>
+            </a>
+            <div class="panel-body">
+              {% for item in groups['hosts_vitamui'] %}
+              <div class="row component-line">
+                <div class="col-md-3">{{ item }}</div>
+                <div class="col-md-2">{{ hostvars[item]['ip_admin'] }}</div>
+                <div class="col-md-2">
+                  {% for group in groups %}
+                  {% if item in groups[group] %}
+                  {% if (group not in ('hosts','all','vitam','prometheus','reverse','elasticsearch','mongo_common')) and (not(group is search('^zone'))) %}
+                  {{ group|regex_replace('hosts_', '')| replace('_','-') }}<br/>
+                  {% endif %}
+                  {% endif %}
+                  {% endfor %}
+                </div>
+                <div class="col-md-2">
+                  {% for group in groups %}
+                  {% if group is search('^zone') %}
+                  {% if item in groups[group] %}
+                  {{ group| replace('_',' ') }}<br/>
+                  {% endif %}
+                  {% endif %}
+                  {% endfor %}
+                </div>
+                {% if item in groups['hosts_browse'] %}
+                <div class="col-md-2">
+                  <a href="https://{{ vitam_reverse_external_dns }}/nodes/{{ item }}/browse" class="btn btn-primary btn-xs" target="_blank">Browser</a>
+                </div>
+                {% endif %}
+              </div>
+              {% endfor %}
+            </div>
+          </div>

--- a/deployment/roles/reverse/templates/apache/page/index_links.html.j2
+++ b/deployment/roles/reverse/templates/apache/page/index_links.html.j2
@@ -1,0 +1,33 @@
+#jinja2: lstrip_blocks: True
+          <div class="panel panel-default col-md-12 container">
+            <a class="panel-header no-toggle" href="#">
+              <h2>Vitam UI - Liens</h2>
+            </a>
+            <div class="panel-body">
+              <p class="row" style="vertical-align: middle">
+                <div class="col-md-3">Métier</div>
+                <div class="col-md-9">
+                  <a href="https://{{ vitam_reverse_external_dns }}" class="btn btn-primary btn-xs" target="_blank">Vitam UI</a>
+                </div>
+              </p>
+              {% if groups['hosts_vitamui_consul_server'] | default([]) | length > 0 %}
+              <p class="row" style="vertical-align: middle">
+                <div class="col-md-3">Consul</div>
+                <div class="col-md-9">
+                  <a href="/ui/{{ vitamui_site_name }}/services" class="btn btn-primary btn-xs" target="_blank">Consul</a>
+                  <a href="https://{{ vitam_reverse_external_dns }}/v1/health/state/any?pretty" class="btn btn-primary btn-xs" target="_blank">Health</a>
+                </div>
+              </p>
+              {% endif %}
+              <p class="row" style="vertical-align: middle">
+                <div class="col-md-3">Mongo Express</div>
+                <div class="col-md-9">
+                  {% for host in groups['hosts_vitamui_mongod'] %}
+                  {% if hostvars[host]['mongo_express_enabled'] | default(false) | bool == true %}
+                  <a href="https://{{ vitam_reverse_external_dns }}/{{ mongo_express.baseuri }}" class="btn btn-primary btn-xs" target="_blank">{{ hostvars[host]['mongo_cluster_name'] }}</a>
+                  {% endif %}
+                  {% endfor %}
+                </div>
+              </p>
+            </div>
+          </div>


### PR DESCRIPTION
Suite à la réorganisation de la page du reverse Vitam, la tâche `merge_index_apache` a dû être mise à jour.

- Adaptation de la tâche à la nouvelle organisation de la page du reverse Vitam
- Insertion des éléments basée dorénavant sur des repères fixes (commentaires) et non plus sur des éléments aléatoires du code de la page qui pouvaient rendre la tâche dysfonctionnelle
- Usage de templates pour ne plus avoir des pavés de code HTML au sein de la tâche Ansible
- Correction du problème d'indentation une fois le fichier généré (initialement illisible)
- Suppression de l'étape de sauvegarde de la page, qui est inutile et qui pollue la machine reverse