### PR TITLE
[VAS] ITEM : 9529 : add exact result number of archive unit to update rules service

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/archive-unit-rules/add-management-rules/add-management-rules.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/archive-unit-rules/add-management-rules/add-management-rules.component.html
@@ -118,11 +118,13 @@
 </ng-template>
 
 <ng-template #resultsFound>
-  <div *ngIf="showText && itemsToUpdate > 0" class="row message-text-ok">
+  <div *ngIf="showText && itemsToUpdate !== 0" class="row message-text-ok">
     <div class="col-1"><i class="material-icons">check_circle</i></div>
-    <div class="col-11">{{ 'RULES.UA_CONTROL.UA_WITH_RULES_TO_UPDATE' | translate: { itemsToUpdate: itemsToUpdate } }}</div>
+    <div class="col-11">
+      {{ 'RULES.UA_CONTROL.UA_WITH_RULES_TO_UPDATE' | translate: { itemsToUpdate: itemsToUpdate } }}
+    </div>
   </div>
-  <div *ngIf="showText && itemsWithSameRule > 0" class="row message-text-ko">
+  <div *ngIf="showText && itemsWithSameRule !== 0" class="row message-text-ko">
     <div class="col-1"><i class="material-icons">error</i></div>
     <div class="col-11">
       {{ 'RULES.UA_CONTROL.UA_WITH_SAME_RULE' | translate: { itemsWithSameRule: itemsWithSameRule } }}

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/archive-unit-rules/archive-unit-rules.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/archive-unit-rules/archive-unit-rules.component.html
@@ -16,6 +16,7 @@
         [accessContract]="accessContract"
         [selectedItem]="selectedItem"
         [ruleCategory]="ruleCategory"
+        [hasExactCount]="hasExactCount"
       ></app-add-management-rules>
     </div>
   </div>
@@ -51,6 +52,7 @@
         (delete)="deleteForm(actionName.id, $event, action)"
         (confirmStep)="confirmStep(actionName.id)"
         (cancelStep)="cancelStep(actionName.id)"
+        [hasExactCount]="hasExactCount"
       ></app-delete-unit-rules>
     </div>
   </div>
@@ -85,6 +87,7 @@
         [accessContract]="accessContract"
         [selectedItem]="selectedItem"
         [ruleCategory]="ruleCategory"
+        [hasExactCount]="hasExactCount"
       ></app-update-unit-rules>
     </div>
   </div>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/archive-unit-rules/archive-unit-rules.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/archive-unit-rules/archive-unit-rules.component.ts
@@ -61,6 +61,8 @@ export class ArchiveUnitRulesComponent implements OnInit, OnDestroy {
   selectedItem: string;
   @Input()
   ruleCategory: string;
+  @Input()
+  hasExactCount: boolean;
   ruleCategoryDuaActions: RuleCategoryAction;
 
   managementRules: ManagementRules[] = [];

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/management-rules.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/management-rules.component.html
@@ -124,7 +124,7 @@
               <div class="row">
                 <div class="col-7">
                   <span class="details-ua">
-                    {{ 'RULES.UA_SELECTED' | translate: { ua_selected: selectedItem } }}
+                    {{ 'RULES.UA_SELECTED' | translate: { ua_selected: selectedItemToShow } }}
                   </span>
                 </div>
                 <div class="col-5">
@@ -145,6 +145,7 @@
                       [accessContract]="accessContract"
                       [selectedItem]="selectedItem"
                       [ruleCategory]="item.id"
+                      [hasExactCount]="hasExactCount"
                     ></app-archive-unit-rules>
                   </mat-tab>
                 </div>
@@ -162,7 +163,7 @@
     <br />
     <div class="text-title">{{ 'RULES.DIALOG_MESSAGE.UPDATE_CONFIRM_TITLE_MESSAGE' | translate }}</div>
     <div class="text large bold">
-      {{ 'RULES.DIALOG_MESSAGE.UPDATE_CONFIRM_MESSAGE' | translate: { ua_selected: selectedItem } }}
+      {{ 'RULES.DIALOG_MESSAGE.UPDATE_CONFIRM_MESSAGE' | translate }}
     </div>
   </mat-dialog-content>
   <br />

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/management-rules.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/management-rules/management-rules.component.ts
@@ -49,6 +49,7 @@ import { ActionsRules, RuleActions, RuleActionsEnum, RuleCategoryAction, RuleSea
 import { SearchCriteriaDto, SearchCriteriaEltDto } from '../models/search.criteria';
 
 const ARCHIVE_UNIT_HOLDING_UNIT = 'ARCHIVE_UNIT_HOLDING_UNIT';
+const RESULTS_MAX_NUMBER = 10000;
 
 @Component({
   selector: 'app-management-rules',
@@ -64,7 +65,9 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
   accessContractSubscription: Subscription;
   tenantIdentifier: string;
   tenantIdentifierSubscription: Subscription;
+  hasExactCountSubscription: Subscription;
   selectedItem: number;
+  selectedItemToShow: string;
   selectedItemSubscription: Subscription;
   ruleActions: ActionsRules[] = [];
   actionsSelected: string[] = [];
@@ -110,6 +113,8 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
   messageNotAddProperty: string;
   messageNotDelete: string;
   messageNotToDeleteProperty: string;
+  hasExactCount: boolean;
+  resultNumberToShow: string;
 
   @ViewChild('confirmRuleActionsDialog', { static: true }) confirmRuleActionsDialog: TemplateRef<ManagementRulesComponent>;
   showConfirmRuleActionsDialogSuscription: Subscription;
@@ -181,6 +186,7 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
     this.loadSelectedItem();
     this.loadCriteriaSearchListToSave();
     this.loadCriteriaSearchDSLQuery();
+    this.loadHasExactCount();
 
     if (this.criteriaSearchListToSave.length === 0) {
       this.initializeParameters();
@@ -191,6 +197,7 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
     this.messageNotAddProperty = this.translateService.instant('RULES.ACTIONS.FINAL_ACTION_NOT_TO_ADD');
     this.messageNotDelete = this.translateService.instant('RULES.ACTIONS.NOT_TO_DELETE');
     this.messageNotToDeleteProperty = this.translateService.instant('RULES.ACTIONS.FINAL_ACTION_NOT_TO_DELETE_PROPERTY');
+    this.resultNumberToShow = this.translateService.instant('ARCHIVE_SEARCH.MORE_THAN_THRESHOLD');
   }
 
   initializeParameters() {
@@ -207,6 +214,7 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
     this.showConfirmRuleActionsDialogSuscription?.unsubscribe();
     this.showConfirmLeaveRuleActionsDialogSuscription?.unsubscribe();
     this.tenantIdentifierSubscription?.unsubscribe();
+    this.hasExactCountSubscription?.unsubscribe();
   }
 
   selectRule(rule: any) {
@@ -249,6 +257,13 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
   loadSelectedItem() {
     this.selectedItemSubscription = this.managementRulesSharedDataService.getselectedItems().subscribe((response) => {
       this.selectedItem = response;
+      this.selectedItemToShow = response === RESULTS_MAX_NUMBER ? this.resultNumberToShow : response.toString();
+    });
+  }
+
+  loadHasExactCount() {
+    this.hasExactCountSubscription = this.managementRulesSharedDataService.getHasExactCount().subscribe((paramater) => {
+      this.hasExactCount = paramater;
     });
   }
 
@@ -358,6 +373,7 @@ export class ManagementRulesComponent implements OnInit, OnDestroy {
       .afterClosed()
       .pipe(filter((result) => !!result))
       .subscribe(() => {
+        this.criteriaSearchDSLQuery.trackTotalHits = this.hasExactCount;
         const ruleSearchCriteriaDto: RuleSearchCriteriaDto = {
           searchCriteriaDto: this.criteriaSearchDSLQuery,
           ruleActions: allRuleActions,

--- a/ui/ui-frontend/projects/archive-search/src/app/core/management-rules-shared-data.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/core/management-rules-shared-data.service.ts
@@ -51,12 +51,14 @@ export class ManagementRulesSharedDataService {
   private ruleActions = new BehaviorSubject<ActionsRules[]>([]);
 
   private managementRules = new BehaviorSubject<ManagementRules[]>([]);
+  private hasExactCount = new BehaviorSubject<boolean>(false);
 
   selectedItem = this.selectedItems.asObservable();
   allCriteriaSearchListToSave = this.criteriaSearchListToSave.asObservable();
   allCriteriaSearchDSLQuery = this.criteriaSearchDSLQuery.asObservable();
   allRuleActions = this.ruleActions.asObservable();
   allManagementRules = this.managementRules.asObservable();
+  hasExactCounts = this.hasExactCount.asObservable();
 
   constructor() {}
 
@@ -106,5 +108,13 @@ export class ManagementRulesSharedDataService {
 
   getManagementRules(): Observable<ManagementRules[]> {
     return this.managementRules.asObservable();
+  }
+
+  emitHasExactCount(hasExactCount: boolean) {
+    this.hasExactCount.next(hasExactCount);
+  }
+
+  getHasExactCount(): Observable<boolean> {
+    return this.hasExactCount.asObservable();
   }
 }

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
@@ -391,7 +391,7 @@
     "DIALOG_MESSAGE": {
       "UPDATE_CONFIRM_TITLE_MESSAGE": "Validate rule change(s)",
       "DELETE_COMPONENT": "Are you sure you want to delete this rule update block?",
-      "UPDATE_CONFIRM_MESSAGE": "Warning, you are about to validate the rule changes on {{ua_selected}} archival units. Do you confirm this update? ",
+      "UPDATE_CONFIRM_MESSAGE": "Attention, you are about to validate the changes of rule(s) on all the archival units taken into account in the requested update. Do you confirm this update? ",
       "EXIT_CONFIRM_MESSAGE": "Are you sure you want to quit updating business rules on {{ua_selected}} selected archival units?"
     },
 

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
@@ -466,7 +466,7 @@
     "DIALOG_MESSAGE": {
       "UPDATE_CONFIRM_TITLE_MESSAGE": "Validation de changement(s) de règle(s)",
       "DELETE_COMPONENT": "Êtes-vous sur de vouloir supprimer ce bloc de mise à jour des règles ?",
-      "UPDATE_CONFIRM_MESSAGE": "Attention, vous êtes sur le point de valider les changements de règle(s) sur {{ ua_selected }} unités archivistiques. Confirmez-vous cette mise à jour ?",
+      "UPDATE_CONFIRM_MESSAGE": "Attention, vous êtes sur le point de valider les changements de règle(s) sur l'ensemble des unités archivistiques prises en compte dans la mise à jour demandée. Confirmez-vous cette mise à jour ?",
       "EXIT_CONFIRM_MESSAGE": "Êtes-vous sur de vouloir quitter la mise à jour des règles de gestion sur les {{ua_selected}} unités archivistiques sélectionnées ?"
     },
 


### PR DESCRIPTION
## Description
L'objectif de cette PR est  d'ajouter une adaptation des pop-ups de mise à jour des règles de gestion pour afficher si possible le nombre exact d'unités archivistiques impacté par la modification.
[Ticket TuleUp](https://tuleap.dev.programmevitam.fr/plugins/tracker/?aid=9529)


## Type de changement:
* Nouveau Code 
* Re-factorisation de code


## Documentation:

## Tests:
- Des tests fonctionnels sont effectués pour vérifier le fonctionnement de cette évolution.


## Migration:
- Pas de modifications au niveau de la DB, 
- Pas de migration.

## Checklist:
[X] Mon code suit le style de code de ce projet.
[X] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur
Vitam Accessible en Service (VAS)