### PR TITLE
[VAS] 10006- upgrade dependencies for : gson, jackson, xerces, esapi, antisamy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,12 @@
         <embedded.mongo.version>2.2.0</embedded.mongo.version>
         <fake.sftp.server.rule.version>2.0.1</fake.sftp.server.rule.version>
         <glassfish.javax.el.version>2.2.6</glassfish.javax.el.version>
-        <gson.version>2.8.6</gson.version>
+        <gson.version>2.8.9</gson.version>
         <guava.version>29.0-jre</guava.version>
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
-        <jackson.version>2.12.4</jackson.version>
+        <jackson.version>2.12.7</jackson.version>
         <jaeger.tracing.version>3.2.2</jaeger.tracing.version>
         <jakarta.xml.binding.version>2.3.2</jakarta.xml.binding.version>
         <javax.el.version.version>3.0.1-b06</javax.el.version.version>
@@ -140,9 +140,9 @@
         <xml.resolver.version>1.2</xml.resolver.version>
         <xom.version>1.3.4</xom.version>
         <xdocreport.version>2.0.2</xdocreport.version>
-        <xerces.version>2.12.1</xerces.version>
-        <esapi.version>2.2.3.1</esapi.version>
-        <antisamy.version>1.6.4</antisamy.version>
+        <xerces.version>2.12.2</xerces.version>
+        <esapi.version>2.3.0.0</esapi.version>
+        <antisamy.version>1.6.7</antisamy.version>
         <json-sanitize.version>1.2.2</json-sanitize.version>
         <freemarker.upgraded.version>2.3.30</freemarker.upgraded.version>
         <mongo.driver.sync.version>4.1.2</mongo.driver.sync.version>


### PR DESCRIPTION
## Description

Bump les dependencies qui sont déclarées comme vulnérables : 

Bump esapi from 2.2.3.1 to 2.3.0.0 
Bump antisamy from 1.6.4 to 1.6.7 
Bump jackson  from 2.12.4 to 2.12.6.1 
 Bump xercesImpl from 2.12.1 to 2.12.2


## Type de changement:

* Dépendences

 
## Tests:

manuel

environnement

TU

## Checklist:

*Sélectionner les éléments de la checklist*

[x] Mon code suit le style de code de ce projet.

## Contributeur

VAS (Vitam Accessible en Service)

