### PR TITLE
[VAS] Bug #10356: wording error

### DIFF
--- a/ui/ui-frontend/projects/ingest/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/ingest/src/assets/i18n/fr.json
@@ -39,7 +39,7 @@
         "HOLDING_SCHEME": "Importer un arbre de positionnement",
         "FILING_SCHEME": "Importer un plan de classement",
         "DEFAULT_WORKFLOW": "Verser un paquet d'archives (SIP)",
-        "BLANK_WORKFLOW": "Tester le versement un paquet d'archives (SIP)"
+        "BLANK_WORKFLOW": "Tester le versement d'un paquet d'archives (SIP)"
       },
       "MESSAGE_IMPORT_TYPE": {
         "HOLDING_SCHEME": "Nouvel arbre de positionnement",


### PR DESCRIPTION
## Description
BUG- Manque de "d'" dans le message Tester le versement d'un paquet d'archives (SIP)

## Type de changement:
* Correction

## Contributeur
VAS (Vitam Accessible en Service)

