### PR TITLE
[VAS] Support #10004: Remove profils for useless auto_tenant.

### DIFF
--- a/deployment/scripts/mongod/6.rc.0/11_remove_useless_tenant2_and_profiles_attached.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/11_remove_useless_tenant2_and_profiles_attached.js.j2
@@ -1,0 +1,8 @@
+db = db.getSiblingDB('iam');
+
+print("START 11_remove_useless_tenant2_and_profiles_attached.js");
+
+db.profiles.deleteOne( { "_id": "auto_system_rules","tenantIdentifier": NumberInt(2) } );
+db.tenants.deleteOne( { "_id": "auto_tenant","identifier": NumberInt(2) } );
+
+print("END 11_remove_useless_tenant2_and_profiles_attached.js");


### PR DESCRIPTION
## Description

Remove profils for useless tenant 2

## Type de changement:

* Ansiblerie

* Correction

## Tests:

* manuel

## Migration:

For existing installation, it can be manually removed from mongo.

## Contributeur

* VAS (Vitam Accessible en Service)