### PR TITLE
VAS-9979: Bump thymeleaf-spring5 from 3.0.12.RELEASE to 3.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <spring-webmvc-pac4j.version>5.1.0</spring-webmvc-pac4j.version>
         <swagger.version>3.0.0</swagger.version>
         <trang.version>20181222</trang.version>
-        <thymeleaf-spring5.version>3.0.13.RELEASE</thymeleaf-spring5.version>
+        <thymeleaf-spring5.version>3.0.15.RELEASE</thymeleaf-spring5.version>
         <vitam.version>6.rc.0-SNAPSHOT</vitam.version>
         <xml.apis-version>2.0.2</xml.apis-version>
         <xml.resolver.version>1.2</xml.resolver.version>
@@ -630,6 +630,24 @@
                 <groupId>org.thymeleaf</groupId>
                 <artifactId>thymeleaf-spring5</artifactId>
                 <version>${thymeleaf-spring5.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-webflux</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-spring-webmvc</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-expression</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Apereo CAS Server Core Api Ticket -->


### PR DESCRIPTION
Cette PR permet d'upgrader la librairie thymeleaf-spring5 vers la version 3.0.15 en excluant les librairies qui contiennent des vulnérabilities

## Contributeur


VAS (Vitam Accessible en Service)