### PR TITLE
clean code on disabling front end test & managing exception handling 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                 sh 'npmrc default'
 
                 sh '''
-                    $MVN_COMMAND clean verify -U -Pvitam -pl '!cots/vitamui-nginx,!cots/vitamui-mongod,!cots/vitamui-logstash,!cots/vitamui-mongo-express' $JAVA_TOOL_OPTIONS
+                    $MVN_COMMAND clean verify -U -DskipAllFrontendTests=true -Pvitam -pl  '!cots/vitamui-nginx,!cots/vitamui-mongod,!cots/vitamui-logstash,!cots/vitamui-mongo-express' $JAVA_TOOL_OPTIONS
                 '''
             }
             post {

--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestInternalService.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestInternalService.java
@@ -325,7 +325,10 @@ public class IngestInternalService {
             RequestResponse<Void> ingestResponse =
                 ingestExternalClient.ingest(vitamContext, inputStream, contextId, action);
 
-            // Response is always OK
+            if (!ingestResponse.isOk()) {
+                LOGGER.debug("Error on ingest streaming Upload ");
+                throw new VitamClientException("Error on ingest streaming Upload");
+            }
             final String operationId = ingestResponse.getVitamHeaders().get(GlobalDataRest.X_REQUEST_ID);
             LOGGER.debug("Ingest passed successfully : " + ingestResponse + " with operationId = " + operationId);
             return operationId;

--- a/ui/ui-frontend/pom.xml
+++ b/ui/ui-frontend/pom.xml
@@ -107,17 +107,17 @@
               <arguments>run build -- --project= --output-path=target/www</arguments>
             </configuration>
           </execution>
-         <!-- <execution>
+          <execution>
             <id>npm test</id>
             <phase>test</phase>
             <goals>
               <goal>npm</goal>
             </goals>
             <configuration>
-              <skip>${skipAllFrontend}</skip>
+              <skip>${skipAllFrontendTests}</skip>
               <arguments>run test:conf-ci</arguments>
             </configuration>
-          </execution>-->
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Description

L'objectif de cette PR :
 - est de remettre la configuration des tests front, de la corriger, et ne les désactiver que dans la pipeline de build à travers le flag en question 
- est de corriger une gestion d'exception lors d'un ingest en cas d'erreur de Vitam

## Contributeur



VAS (Vitam Accessible en Service)

