### PR TITLE
Bug/VAS-10421: fix conflict issue on mongodb-driver-core

### DIFF
--- a/cas/cas-server/pom.xml
+++ b/cas/cas-server/pom.xml
@@ -517,6 +517,7 @@
                                 <exclude>WEB-INF/lib/oauth2-oidc-sdk-*.jar</exclude>
                                 <exclude>WEB-INF/lib/pac4j-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-webmvc-pac4j-*.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-expression-*.jar</exclude>
                             </excludes>
                         </overlay>
                     </overlays>

--- a/cas/cas-server/pom.xml
+++ b/cas/cas-server/pom.xml
@@ -79,6 +79,10 @@
                     <groupId>io.dropwizard.metrics</groupId>
                     <artifactId>metrics-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>mongodb-driver-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description

L'objectif de cette PR est de corriger une anomalie lors du démarrage de CAS du à un conflit de la librairie mongo-driver


## Contributeur


VAS (Vitam Accessible en Service)
