### PR TITLE
[VAS] BUG story #10521 - Fix prerequisite role to allow nginx usage o…

### DIFF
--- a/deployment/roles/reverse/tasks/nginx/prerequisites.yml
+++ b/deployment/roles/reverse/tasks/nginx/prerequisites.yml
@@ -5,6 +5,8 @@
     state: present
     name: epel-release
   become: true
+  when:
+    - ansible_os_family == "Centos"
 
 - name: 'Tasks > reverse > prerequisites.yml | Install nginx package'
   package:
@@ -21,6 +23,16 @@
     state: present
     name: nginx-mod-stream
   become: true
+  when:
+    - ansible_os_family == "Centos"
+
+- name: 'Tasks > reverse > prerequisites.yml | Install module libnginx-mod-stream'
+  package:
+    state: present
+    name: libnginx-mod-stream
+  become: true
+  when:
+    - ansible_os_family == "Debian"
 
 - name: 'Tasks > reverse > prerequisites.yml | Set vars user and group'
   set_fact:


### PR DESCRIPTION
…n debian system as reverse

## Description

Correction du role d'installation des pré-requis pour le reverse proxy afin de permettre la bonne installation de l'alternative nginx sur Debian

## Type de changement:

*Indiquer le ou les types de changements*

* Ansiblerie

* Correction

## Documentation:

*Indiquer la documentation mise à jour*

Pas de modification documentaire

## Tests:

*Indiquer comment le code à été testé (manuel, environnement, TU, etc)*

manuellement sur environnement dédié Debian 11

## Migration:

Pas de migration nécessaire

## Checklist:

*Sélectionner les éléments de la checklist*

[x ] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

VAS (Vitam Accessible en Service)


