### PR TITLE
Bug/vas-10545: remove threshold check on computing inheritence

### DIFF
--- a/api/api-archive-search/archive-search-external/src/main/java/fr/gouv/vitamui/archives/search/external/server/service/ArchivesSearchExternalService.java
+++ b/api/api-archive-search/archive-search-external/src/main/java/fr/gouv/vitamui/archives/search/external/server/service/ArchivesSearchExternalService.java
@@ -169,10 +169,6 @@ public class ArchivesSearchExternalService extends AbstractResourceClientService
     }
 
     public String computedInheritedRules(final SearchCriteriaDto searchCriteriaDto) {
-        Optional<Long> thresholdOpt = archiveSearchThresholdService.retrieveProfilThresholds();
-        if (thresholdOpt.isPresent()) {
-            searchCriteriaDto.setThreshold(thresholdOpt.get());
-        }
         return archiveInternalRestClient.computedInheritedRules(searchCriteriaDto, getInternalHttpContext());
     }
 


### PR DESCRIPTION
## Description

l'objectif de cette PR est de désactiver le controle des seuils pour le calcul d'heritage.


## Contributeur

VAS (Vitam Accessible en Service)

