### PR TITLE
[VAS] Bug #10632: reload leaves count on new search

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.handler.spec.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.handler.spec.ts
@@ -132,6 +132,36 @@ describe('FilingHoldingSchemeHandler', () => {
     expect(node.count).toEqual(65);
   });
 
+  it('setCountRecursively should return the number of node checked, set count and reset member not found', () => {
+    node = uaNodes[0].children[0].children[2];
+    expect(node.id).toEqual('node-0-0-2');
+    expect(node.count).toBeUndefined();
+    node = uaNodes[2].children[2];
+    expect(node.id).toEqual('node-2-2');
+    expect(node.count).toBeUndefined();
+    facets = [
+      { node: 'node-0-0-2', count: 42 },
+      { node: 'node-2-2', count: 65 },
+    ];
+    expect(FilingHoldingSchemeHandler.setCountRecursively(uaNodes, facets)).toEqual(2);
+    node = uaNodes[0].children[0].children[2];
+    expect(node.id).toEqual('node-0-0-2');
+    expect(node.count).toEqual(42);
+    node = uaNodes[2].children[2];
+    expect(node.id).toEqual('node-2-2');
+    expect(node.count).toEqual(65);
+    facets = [
+      { node: 'node-2-2', count: 12 },
+    ];
+    expect(FilingHoldingSchemeHandler.setCountRecursively(uaNodes, facets)).toEqual(1);
+    node = uaNodes[0].children[0].children[2];
+    expect(node.id).toEqual('node-0-0-2');
+    expect(node.count).toEqual(0);
+    node = uaNodes[2].children[2];
+    expect(node.id).toEqual('node-2-2');
+    expect(node.count).toEqual(12);
+  });
+
   it('addChildrenRecursively should add new children and not presents ones', () => {
     const units = [
       newUnit('node-2-3', 'node-2'),

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.handler.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.handler.ts
@@ -51,9 +51,7 @@ export class FilingHoldingSchemeHandler {
   }
 
   public static setCountOnNode(node: FilingHoldingSchemeNode, facets: ResultFacet[]): number {
-    if (!node.count) {
-      node.count = 0;
-    }
+    node.count = 0;
     for (const facet of facets) {
       if (node.id === facet.node) {
         node.count = facet.count;


### PR DESCRIPTION
## Description

*Description des modifications*
Les anciens résultats étaient toujours présent lors d'une nouvelle recherche.

## Type de changement:

*Indiquer le ou les types de changements*

* Correction

## Documentation:

*Indiquer la documentation mise à jour*

[ ] Quels sont les nouvelles documentations ?

[ ] Quels sont les modifications existantes ?

[ ] Quels sont les documentations ou sections de documentations supprimés ?

## Tests:

*Indiquer comment le code à été testé (manuel, environnement, TU, etc)*

local

TU

## Migration:

*Indiquer si les modifications apportées impliquent une migration sur l'existant et comment la faire*

## Checklist:

*Sélectionner les éléments de la checklist*

[x] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

VAS (Vitam Accessible en Service)
