### PR TITLE
story 10661 Generalization of blocking / unblocking actions 

### DIFF
--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/service/ArchivesSearchAppraisalMgtRulesQueryBuilderServiceTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/service/ArchivesSearchAppraisalMgtRulesQueryBuilderServiceTest.java
@@ -81,7 +81,7 @@ public class ArchivesSearchAppraisalMgtRulesQueryBuilderServiceTest {
         "appraisal/expected-search-query-with-appraisal-inheritance.txt";
 
     public static String SEARCH_QUERY_WITH_RULE_CATEGORY_INHERITANCE_STORAGE =
-        "appraisal/expected-search-query-with-appraisal-inheritance.txt";
+        "storage/expected-search-query-with-storage-inheritance.txt";
 
     public static String SEARCH_QUERY_WITH_APPRAISAL_PREVENT_RULE_IDENTIFIER =
         "appraisal/expected-search-query-with-appraisal-prevent-rule-identifier.txt";

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/ArchiveSearchConsts.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/ArchiveSearchConsts.java
@@ -153,6 +153,12 @@ public class ArchiveSearchConsts {
 
     public final static String DISSEMINATION_RULE_IDENTIFIER = "#management.DisseminationRule.Rules.Rule";
     public final static String APPRAISAL_RULE_INHERITED = "#management.AppraisalRule.Inheritance.PreventInheritance";
+    public final static String ACCESS_RULE_INHERITED = "#management.AccessRule.Inheritance.PreventInheritance";
+    public final static String STORAGE_RULE_INHERITED = "#management.StorageRule.Inheritance.PreventInheritance";
+    public final static String HOLD_RULE_INHERITED = "#management.HoldRule.Inheritance.PreventInheritance";
+    public final static String DISSEMINATION_RULE_INHERITED = "#management.DisseminationRule.Inheritance.PreventInheritance";
+    public final static String REUSE_RULE_INHERITED = "#management.ReuseRule.Inheritance.PreventInheritance";
+    public final static String CLASSIFICATION_RULE_INHERITED = "#management.ClassificationRule.Inheritance.PreventInheritance";
 
     public final static String APPRAISAL_PREVENT_RULE_IDENTIFIER = "#management.AppraisalRule.Inheritance.PreventRulesId";
 

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtils.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtils.java
@@ -402,7 +402,7 @@ public final class MetadataSearchCriteriaUtils {
                 List<String> searchValues =
                     ruleInheritanceCriteria.getValues().stream().map(CriteriaValue::getValue).collect(
                         Collectors.toList());
-                buildInheritedCategoryQuery(searchValues,
+                buildInheritedCategoryQuery(searchValues, ruleInheritanceCriteria.getCategory(),
                     ArchiveSearchConsts.CriteriaOperators.valueOf(ruleInheritanceCriteria.getOperator()),
                     query);
             }
@@ -691,7 +691,7 @@ public final class MetadataSearchCriteriaUtils {
     }
 
     private static void buildInheritedCategoryQuery(final List<String> searchValues,
-        ArchiveSearchConsts.CriteriaOperators operator, BooleanQuery subQueryAnd)
+        ArchiveSearchConsts.CriteriaCategory category, ArchiveSearchConsts.CriteriaOperators operator, BooleanQuery subQueryAnd)
         throws InvalidCreateOperationException {
         BooleanQuery subQueryOr = or();
         if (!CollectionUtils.isEmpty(searchValues)) {
@@ -700,7 +700,7 @@ public final class MetadataSearchCriteriaUtils {
                 try {
                     subQueryOr
                         .add(VitamQueryHelper
-                            .buildSubQueryByOperator(ArchiveSearchConsts.APPRAISAL_RULE_INHERITED, searchValue,
+                            .buildSubQueryByOperator(buildInheritedValueFromCategory(category), searchValue,
                                 operator));
                 } catch (InvalidCreateOperationException exception) {
                     LOGGER.error(INVALID_CREATION_OPERATION, exception);
@@ -712,6 +712,42 @@ public final class MetadataSearchCriteriaUtils {
         subQueryAnd.add(subQueryOr);
     }
 
+    private static String buildInheritedValueFromCategory(ArchiveSearchConsts.CriteriaCategory category)
+        throws InvalidCreateOperationException {
+
+        String inheritedValue = "";
+
+        switch (category.name()) {
+            case "APPRAISAL_RULE":
+                inheritedValue = ArchiveSearchConsts.APPRAISAL_RULE_INHERITED;
+                break;
+            case "ACCESS_RULE":
+                inheritedValue = ArchiveSearchConsts.ACCESS_RULE_INHERITED;
+                break;
+            case "STORAGE_RULE":
+                inheritedValue = ArchiveSearchConsts.STORAGE_RULE_INHERITED;
+                break;
+            case "HOLD_RULE":
+                inheritedValue = ArchiveSearchConsts.HOLD_RULE_INHERITED;
+                break;
+            case "DISSEMINATION_RULE":
+                inheritedValue = ArchiveSearchConsts.DISSEMINATION_RULE_INHERITED;
+                break;
+            case "REUSE_RULE":
+                inheritedValue = ArchiveSearchConsts.REUSE_RULE_INHERITED;
+                break;
+            case "CLASSIFICATION_RULE":
+                inheritedValue = ArchiveSearchConsts.CLASSIFICATION_RULE_INHERITED;
+                break;
+            default:
+        }
+
+        if (inheritedValue.isEmpty()) {
+            throw new InvalidCreateOperationException("inheritedValue is empty or null ");
+        }
+
+        return inheritedValue;
+    }
     private static void buildRuleStartDateQuery(String ruleCategory, final List<String> searchValues,
         ArchiveSearchConsts.CriteriaOperators operator, BooleanQuery subQueryAnd)
         throws InvalidCreateOperationException {

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/management-rules.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/management-rules.component.html
@@ -97,10 +97,7 @@
               placeholder=" {{ 'RULES.OTHER_ACTIONS' | translate }}"
               [disabled]="
                 !isRuleCategorySelected ||
-                !isAllActionsValid() ||
-                isAccessRuleActionDisabled ||
-                isReuseRuleActionDisabled ||
-                isDisseminationActionDisabled
+                !isAllActionsValid() 
               "
             >
               <mat-option
@@ -127,13 +124,13 @@
                 {{ 'RULES.MORE_ACTIONS.DELETE_PROPERTY' | translate }}</mat-option
               >
               <mat-option
-                [disabled]="isBlockInheritanceCategoryDisabled || isUnlockInheritanceCategoryDisabled || isStorageRuleActionDisabled"
+                [disabled]="isBlockInheritanceCategoryDisabled || isUnlockInheritanceCategoryDisabled"
                 (click)="onSelectAction('BLOCK_CATEGORY_INHERITANCE')"
               >
                 {{ 'RULES.MORE_ACTIONS.BLOCK_PROPERTY_INHERITANCE' | translate }}</mat-option
               >
               <mat-option
-                [disabled]="isUnlockInheritanceCategoryDisabled || isBlockInheritanceCategoryDisabled || isStorageRuleActionDisabled"
+                [disabled]="isUnlockInheritanceCategoryDisabled || isBlockInheritanceCategoryDisabled"
                 (click)="onSelectAction('UNLOCK_CATEGORY_INHERITANCE')"
                 matTooltip="{{ 'RULES.MORE_ACTIONS.DELETE_BLOCK_PROPERTY_INHERITANCE' | translate }}"
                 matTooltipClass="vitamui-tooltip-rules "

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/management-rules.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/management-rules.component.ts
@@ -286,6 +286,7 @@ export class ManagementRulesComponent implements OnInit, OnChanges, OnDestroy {
       }
       const listOfActionTypes: string[] = data.map((rule) => rule.actionType);
       if (
+        preventInheritance !== undefined &&
         listOfActionTypes.length === 1 &&
         (listOfActionTypes[0] === RuleActionsEnum.BLOCK_CATEGORY_INHERITANCE ||
           listOfActionTypes[0] === RuleActionsEnum.UNLOCK_CATEGORY_INHERITANCE)
@@ -379,6 +380,7 @@ export class ManagementRulesComponent implements OnInit, OnChanges, OnDestroy {
       }
       const listOfActionTypes: string[] = data.map((rule) => rule.actionType);
       if (
+        preventInheritance !== undefined &&
         listOfActionTypes.length === 1 &&
         (listOfActionTypes[0] === RuleActionsEnum.BLOCK_CATEGORY_INHERITANCE ||
           listOfActionTypes[0] === RuleActionsEnum.UNLOCK_CATEGORY_INHERITANCE)
@@ -534,12 +536,12 @@ export class ManagementRulesComponent implements OnInit, OnChanges, OnDestroy {
         break;
 
       case 'BLOCK_CATEGORY_INHERITANCE':
-        if (!this.isBlockInheritanceCategoryDisabled && !this.isUnlockInheritanceCategoryDisabled && !this.isStorageRuleActionDisabled) {
+        if (!this.isBlockInheritanceCategoryDisabled && !this.isUnlockInheritanceCategoryDisabled) {
           this.prepareActionToAdd(rule);
         }
         break;
       case 'UNLOCK_CATEGORY_INHERITANCE':
-        if (!this.isUnlockInheritanceCategoryDisabled && !this.isBlockInheritanceCategoryDisabled && !this.isStorageRuleActionDisabled) {
+        if (!this.isUnlockInheritanceCategoryDisabled && !this.isBlockInheritanceCategoryDisabled) {
           this.prepareActionToAdd(rule);
         }
         break;
@@ -730,6 +732,7 @@ export class ManagementRulesComponent implements OnInit, OnChanges, OnDestroy {
 
       const listOfActionTypes: string[] = data.map((rule) => rule.actionType);
       if (
+        preventInheritance !== undefined &&
         listOfActionTypes.length === 1 &&
         (listOfActionTypes[0] === RuleActionsEnum.BLOCK_CATEGORY_INHERITANCE ||
           listOfActionTypes[0] === RuleActionsEnum.UNLOCK_CATEGORY_INHERITANCE)
@@ -794,6 +797,7 @@ export class ManagementRulesComponent implements OnInit, OnChanges, OnDestroy {
       }
       const listOfActionTypes: string[] = data.map((rule) => rule.actionType);
       if (
+        preventInheritance !== undefined &&
         listOfActionTypes.length === 1 &&
         (listOfActionTypes[0] === RuleActionsEnum.BLOCK_CATEGORY_INHERITANCE ||
           listOfActionTypes[0] === RuleActionsEnum.UNLOCK_CATEGORY_INHERITANCE)
@@ -866,6 +870,7 @@ export class ManagementRulesComponent implements OnInit, OnChanges, OnDestroy {
       }
       const listOfActionTypes: string[] = data.map((rule) => rule.actionType);
       if (
+        preventInheritance !== undefined &&
         listOfActionTypes.length === 1 &&
         (listOfActionTypes[0] === RuleActionsEnum.BLOCK_CATEGORY_INHERITANCE ||
           listOfActionTypes[0] === RuleActionsEnum.UNLOCK_CATEGORY_INHERITANCE)


### PR DESCRIPTION
## Description

Elle consiste à proposer deux nouvelles opérations de mise à jour des règles de gestion d'un lot d'unités archivistiques sélectionnées :
- Ajouter ou modifier le blocage d'héritage de toutes les règles d'une catégorie sélectionnée pour un lot d'archives
- Supprimer le blocage d'héritage (débloquer) de toutes les règles d'une catégorie sélectionnée pour un lot d'archives
