### PR TITLE
[VAS] Bug #10976: use object group in object

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component.html
@@ -9,7 +9,7 @@
     <div class="col">
       <div class="read-only-field">
         <label>{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.OBJECT_GROUP_ID' | translate }}</label>
-        <div>{{ archiveUnit['#id'] }}</div>
+        <div>{{ unitObject['#id'] }}</div>
       </div>
     </div>
   </div>
@@ -18,11 +18,11 @@
     <div class="col">
       <div class="read-only-field">
         <label>{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.CREATION_DATE' | translate }}</label>
-        <div>{{ archiveUnit['#approximate_creation_date'] }}</div>
+        <div>{{ unitObject['#approximate_creation_date'] }}</div>
       </div>
       <div class="read-only-field">
         <label>{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.LAST_MODIFIED_DATE' | translate }}</label>
-        <div>{{ archiveUnit['#approximate_update_date'] }}</div>
+        <div>{{ unitObject['#approximate_update_date'] }}</div>
       </div>
     </div>
   </div>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component.html
@@ -1,4 +1,4 @@
-<div class="object-details-group IDS">
+<div class="object-details-group IDS" *ngIf="unitObject">
   <div class="row">
     <div class="col title">
       {{ 'GROUPE D\'OBJETS TECHNIQUES' | translate }}

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component.ts
@@ -29,6 +29,7 @@ import {Clipboard} from '@angular/cdk/clipboard';
 import {HttpHeaders} from '@angular/common/http';
 import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
 import {ApiUnitObject, qualifiersToVersionsWithQualifier, VersionWithQualifierDto} from 'ui-frontend-common';
+import {DescriptionLevel} from 'vitamui-library';
 import {ArchiveService} from '../../archive.service';
 import {Unit} from '../../models/unit.interface';
 
@@ -59,8 +60,16 @@ export class ArchiveUnitObjectsDetailsTabComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.archiveUnit) {
-      this.sendCalls(this.archiveUnit);
+      this.unitObject = null;
+      this.versionsWithQualifiersOrdered = null;
+      if (this.uniHasObject()) {
+        this.sendCalls(this.archiveUnit);
+      }
     }
+  }
+
+  private uniHasObject(): boolean {
+    return this.archiveUnit.DescriptionLevel === DescriptionLevel.ITEM;
   }
 
   onClickDownloadObject(event: Event, versionWithQualifier: VersionWithQualifierDto) {


### PR DESCRIPTION
## Description

*Description des modifications*
Bug sur l'affichage des métadonnées techniques d'une UA dans l'APP recherche

## Type de changement:

*Indiquer le ou les types de changements*

* Correction

## Documentation:

*Indiquer la documentation mise à jour*

[ ] Quels sont les nouvelles documentations ?

[ ] Quels sont les modifications existantes ?

[ ] Quels sont les documentations ou sections de documentations supprimés ?

## Tests:

*Indiquer comment le code à été testé (manuel, environnement, TU, etc)*

manuel

## Migration:

*Indiquer si les modifications apportées impliquent une migration sur l'existant et comment la faire*

## Checklist:

*Sélectionner les éléments de la checklist*

[x] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

VAS (Vitam Accessible en Service)

