### PR TITLE
[VAS] BUG:10888 - fix: internal server error in file formats viewer

### DIFF
--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/CommonConstants.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/CommonConstants.java
@@ -353,4 +353,5 @@ public class CommonConstants {
     public static final String X_SIZE_TOTAL = "X-Size-Total";
     public static final String X_CHUNK_OFFSET = "X-Chunk-Offset";
     public static final String LOGO = "LOGO";
+    public static final String HISTORY = "history";
 }

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseCrudRestClient.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseCrudRestClient.java
@@ -213,11 +213,15 @@ public abstract class BaseCrudRestClient<D extends IdDto, C extends AbstractHttp
      */
     public JsonNode findHistoryById(final C context, final String id) {
         LOGGER.debug("Get logbook of id :{}", id);
-        final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl());
-        uriBuilder.path(CommonConstants.PATH_LOGBOOK);
+        final URI uri = UriComponentsBuilder
+            .fromHttpUrl(getUrl())
+            .path(CommonConstants.PATH_LOGBOOK)
+            .pathSegment(id, CommonConstants.HISTORY)
+            .build()
+            .toUri();
         final HttpEntity<Map<String, Object>> request = new HttpEntity<>(buildHeaders(context));
-        final ResponseEntity<JsonNode> response = restTemplate.exchange(uriBuilder.build(id), HttpMethod.GET, request,
-                JsonNode.class);
+        LOGGER.debug("Attempt to get logbook at {}", uri);
+        final ResponseEntity<JsonNode> response = restTemplate.exchange(uri, HttpMethod.GET, request, JsonNode.class);
         checkResponse(response);
         return response.getBody();
     }

--- a/ui/ui-frontend/projects/referential/src/app/file-format/file-format-preview/file-format-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/file-format/file-format-preview/file-format-preview.component.html
@@ -23,7 +23,7 @@
 
             <mat-tab label="Historique" i18n-label="History tab@@fileFormatPreviewTabHistory">
                 <vitamui-common-operation-history-tab [id]="fileFormat?.puid"
-                                                      [identifier]="fileFormat?.puid" collectionName="fileFormat" [filter]="filterEvents">
+                                                      [identifier]="fileFormat?.puid" collectionName="fileformat" [filter]="filterEvents">
                 </vitamui-common-operation-history-tab>
             </mat-tab>
         </mat-tab-group>

--- a/ui/ui-referential/src/main/java/fr/gouv/vitamui/referential/rest/FileFormatController.java
+++ b/ui/ui-referential/src/main/java/fr/gouv/vitamui/referential/rest/FileFormatController.java
@@ -130,14 +130,35 @@ public class FileFormatController extends AbstractUiRestController {
     @RequestMapping(value = "/**", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public Object getByIdOrHistory(HttpServletRequest request) throws UnsupportedEncodingException, InvalidParseOperationException {
-        LOGGER.debug("getByIdOrHistory ");
-        String requestURL = request.getRequestURL().toString();
-        String path = StringUtils.substringAfter(requestURL,"/fileformat/");
-        if (StringUtils.endsWith("/history", path)) {
-            return findHistoryById(StringUtils.substringBefore(path,"/history"));
-        } else {
-            return getById(StringUtils.removeEndIgnoreCase(path,"/"));
+        LOGGER.debug("Entering in 'getByIdOrHistory' method");
+
+        final String requestUrl = request.getRequestURL().toString();
+        final String fileFormatId = extractFileFormatId(requestUrl);
+        final boolean isHistoryRequest = isHistoryRequest(requestUrl);
+
+        LOGGER.debug("Search history for {} file format", fileFormatId);
+
+        return isHistoryRequest ? findHistoryById(fileFormatId) : getById(fileFormatId);
+    }
+
+    private String extractFileFormatId(final String url) {
+        final String pathSeparator = "/fileformat/";
+        final String historySuffix = "/history";
+        final String path = StringUtils.substringAfter(url, pathSeparator);
+        final boolean isHistoryRequest = isHistoryRequest(url);
+
+        LOGGER.debug("Is history request: {}", isHistoryRequest);
+
+        if (isHistoryRequest) {
+            return StringUtils.substringBefore(path, historySuffix);
         }
+        return StringUtils.removeEndIgnoreCase(path,"/");
+    }
+
+    private boolean isHistoryRequest(final String url) {
+        final String historySuffix = "/history";
+
+        return StringUtils.endsWith(url, historySuffix);
     }
 
     private FileFormatDto getById(final String identifier)
@@ -188,7 +209,6 @@ public class FileFormatController extends AbstractUiRestController {
 
     private LogbookOperationsResponseDto findHistoryById(String id) throws InvalidParseOperationException,
         PreconditionFailedException {
-
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for file format with id :{}", id);
         return service.findHistoryById(buildUiHttpContext(), id);


### PR DESCRIPTION
## Description

* fix bad api hydration in frontend component common option tab
* fix bad usage of endsWith method in history ui backend controller
* remove puid encoding in external referential api history call
* add tests on get file-formats and history logbooks

## Contributeur

VAS (Vitam Accessible en Service)
