### PR TITLE
[BUG] story 10848 impossible actions for empty transactions

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -69,10 +69,10 @@
             matTooltip="{{ 'COLLECT.OTHER_ACTION' | translate }}"
             matTooltipClass="vitamui-tooltip"
           >
-            <button mat-menu-item [disabled]="updateUnitsMetadataDisabled(projectDetails)" (click)="openUpdateUnitsForm()">
+            <button mat-menu-item [disabled]="updateUnitsMetadataDisabled(projectDetails) ||  isArchiveUnitsEmpty()" (click)="openUpdateUnitsForm()">
               {{ 'COLLECT.UPDATE_UNITS_METADATA.ACTION_UPDATE' | translate }}
             </button>
-            <button mat-menu-item (click)="validateTransaction()" [disabled]="isNotOpen$ | async">
+            <button mat-menu-item (click)="validateTransaction()" [disabled]="isArchiveUnitsEmpty() || (isNotOpen$ | async)">
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
             <button mat-menu-item (click)="sendTransaction()" [disabled]="isNotReady$ | async">

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -959,6 +959,10 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     return this.transaction.status !== TransactionStatus.OPEN;
   }
 
+  isArchiveUnitsEmpty(): boolean {
+    return this.archiveUnits.length === 0;
+  }
+
   getArchiveUnitType(archiveUnit: any) {
     if (archiveUnit) {
       return archiveUnit['#unitType'];


### PR DESCRIPTION
## Description

dans la page de détail des archives de la transaction où aucune archives ne figure, comportement attendu : le bouton Modifier les archives est grisé, ainsi que le bouton Valider
