### PR TITLE
story #10997 : PUA data persists in context and remains visible in the PA workflow

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.spec.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ *
+ *
+ */
+import { APP_BASE_HREF } from '@angular/common';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { ToastrModule } from 'ngx-toastr';
+import { BASE_URL, LoggerModule, ProfileService, WINDOW_LOCATION } from 'ui-frontend-common';
+import { PastisConfiguration } from '../../../core/classes/pastis-configuration';
+import { PastisApiService } from '../../../core/services';
+import { FileService } from '../../../core/services/file.service';
+import { MetadataHeaders } from '../../../models/models';
+import { FileTreeMetadataComponent } from './file-tree-metadata.component';
+import { FileTreeMetadataService } from './file-tree-metadata.service';
+
+describe('FileTreeMetadataComponent', () => {
+  let component: FileTreeMetadataComponent;
+  let fixture: ComponentFixture<FileTreeMetadataComponent>;
+  let metadataHeaders: MetadataHeaders = {
+    id: 0,
+    nomDuChamp: '',
+    nomDuChampFr: '',
+    nomDuChampEdit: '',
+    type: '',
+    valeurFixe: '',
+    cardinalite: [],
+    commentaire: '',
+    enumeration: [],
+  };
+  const matDialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['open', 'close']);
+  const matDialogSpy = jasmine.createSpyObj('MatDialog', ['open', 'close']);
+  const PA_MANDATORY_ENUM_FIELDS = [
+    'NeedAuthorization',
+    'LegalStatus',
+    'DescriptionLevel',
+    'KeywordType',
+    'PreventInheritance',
+    'FinalAction',
+    'NeedReassessingAuthorization',
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [FileTreeMetadataComponent],
+      providers: [
+        FileTreeMetadataService,
+        FileService,
+        ProfileService,
+        PastisApiService,
+        PastisConfiguration,
+        FormBuilder,
+        { provide: MatDialogRef, useValue: matDialogRefSpy },
+        { provide: MatDialog, useValue: matDialogSpy },
+        { provide: BASE_URL, useValue: '/fake-api' },
+        { provide: WINDOW_LOCATION, useValue: window.location },
+        { provide: APP_BASE_HREF, useValue: '/' },
+      ],
+      imports: [
+        HttpClientTestingModule,
+        ToastrModule.forRoot({
+          positionClass: 'toast-bottom-right',
+        }),
+        MatSnackBarModule,
+        RouterModule.forRoot([]),
+        LoggerModule.forRoot(),
+        TranslateModule.forRoot({}),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FileTreeMetadataComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    // expected
+    expect(component).toBeTruthy();
+  });
+
+  it('should return enumeration value', () => {
+    // expected
+    metadataHeaders.type = 'enumeration';
+    PA_MANDATORY_ENUM_FIELDS.forEach((fieldName) => {
+      metadataHeaders.nomDuChamp = fieldName;
+      expect(component.getMetadataInputType(metadataHeaders)).toEqual('enumeration');
+    });
+    // unexpected
+    metadataHeaders.nomDuChamp = 'StartDate';
+    metadataHeaders.type = 'date';
+    expect(component.getMetadataInputType(metadataHeaders)).not.toEqual('enumeration');
+  });
+
+  it('should return date value', () => {
+    // expected
+    metadataHeaders.nomDuChamp = 'StartDate';
+    metadataHeaders.type = 'date';
+    expect(component.getMetadataInputType(metadataHeaders)).toEqual('date');
+    // unexpected
+    metadataHeaders.nomDuChamp = 'Compressed';
+    metadataHeaders.type = 'boolean';
+    expect(component.getMetadataInputType(metadataHeaders)).not.toEqual('date');
+  });
+
+  it('should return empty string value', () => {
+    // expected
+    metadataHeaders.nomDuChamp = 'Compressed';
+    metadataHeaders.type = 'boolean';
+    expect(component.getMetadataInputType(metadataHeaders)).toEqual('');
+    // unexpected
+    metadataHeaders.nomDuChamp = 'StartDate';
+    metadataHeaders.type = 'date';
+    expect(component.getMetadataInputType(metadataHeaders)).not.toEqual('');
+  });
+});

--- a/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.ts
@@ -1,40 +1,31 @@
 /*
-Copyright © CINES - Centre Informatique National pour l'Enseignement Supérieur (2020)
-
-[dad@cines.fr]
-
-This software is a computer program whose purpose is to provide
-a web application to create, edit, import and export archive
-profiles based on the french SEDA standard
-(https://redirect.francearchives.fr/seda/).
-
-
-This software is governed by the CeCILL-C  license under French law and
-abiding by the rules of distribution of free software.  You can  use,
-modify and/ or redistribute the software under the terms of the CeCILL-C
-license as circulated by CEA, CNRS and INRIA at the following URL
-"http://www.cecill.info".
-
-As a counterpart to the access to the source code and  rights to copy,
-modify and redistribute granted by the license, users are provided only
-with a limited warranty  and the software's author,  the holder of the
-economic rights,  and the successive licensors  have only  limited
-liability.
-
-In this respect, the user's attention is drawn to the risks associated
-with loading,  using,  modifying and/or developing or reproducing the
-software by the user in light of its specific status of free software,
-that may mean  that it is complicated to manipulate,  and  that  also
-therefore means  that it is reserved for developers  and  experienced
-professionals having in-depth computer knowledge. Users are therefore
-encouraged to load and test the software's suitability as regards their
-requirements in conditions enabling the security of their systems and/or
-data to be ensured and,  more generally, to use and operate it in the
-same conditions as regards security.
-
-The fact that you are presently reading this means that you have had
-knowledge of the CeCILL-C license and that you accept its terms.
-*/
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ *
+ *
+ */
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { Component, EventEmitter, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
@@ -60,22 +51,30 @@ import {
   FileNodeInsertParams,
   nodeNameToLabel,
   TypeConstants,
-  ValueOrDataConstants
+  ValueOrDataConstants,
 } from '../../../models/file-node';
 import { CardinalityValues, MetadataHeaders } from '../../../models/models';
+import { PuaData } from '../../../models/pua-data';
 import { SedaData, SedaElementConstants } from '../../../models/seda-data';
 import { PastisDialogData } from '../../../shared/pastis-dialog/classes/pastis-dialog-data';
 import { PastisPopupMetadataLanguageService } from '../../../shared/pastis-popup-metadata-language/pastis-popup-metadata-language.service';
-import { FileTreeService } from '../file-tree/file-tree.service';
 import { UserActionAddPuaControlComponent } from '../../../user-actions/add-pua-control/add-pua-control.component';
+import { FileTreeComponent } from '../file-tree/file-tree.component';
+import { FileTreeService } from '../file-tree/file-tree.service';
 import { AttributesPopupComponent } from './attributes/attributes.component';
 import { FileTreeMetadataService } from './file-tree-metadata.service';
-import { PuaData } from '../../../models/pua-data';
-import { FileTreeComponent } from '../file-tree/file-tree.component';
-
 
 const FILE_TREE_METADATA_TRANSLATE_PATH = 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA';
 const ADD_PUA_CONTROL_TRANSLATE_PATH = 'USER_ACTION.ADD_PUA_CONTROL';
+const PA_MANDATORY_ENUM_FIELDS = [
+  'NeedAuthorization',
+  'LegalStatus',
+  'DescriptionLevel',
+  'KeywordType',
+  'PreventInheritance',
+  'FinalAction',
+  'NeedReassessingAuthorization',
+];
 
 function constantToTranslate() {
   this.notificationAjoutMetadonnee = this.translated('.NOTIFICATION_AJOUT_METADONNEE');
@@ -85,7 +84,7 @@ function constantToTranslate() {
   this.popupValider = this.translated('.POPUP_VALIDER');
   this.popupAnnuler = this.translated('.POPUP_ANNULER');
   this.popupControlOkLabel = this.translated('.POPUP_CONTROL_OK_BUTTON_LABEL');
-  this.popupControlSubTitleDialog = this.translated('.POPUP_CONTROL_SUB_TITLE_DIALOG');
+  this.popupControlSuAppComponentbTitleDialog = this.translated('.POPUP_CONTROL_SUB_TITLE_DIALOG');
   this.popupControlTitleDialog = this.translated('.POPUP_CONTROL_TITLE_DIALOG');
 }
 
@@ -97,9 +96,7 @@ function constantToTranslate() {
   // component style to apply to the select panel.
   encapsulation: ViewEncapsulation.None,
 })
-
 export class FileTreeMetadataComponent {
-
   rootAdditionalProperties: boolean;
   valueOrData = Object.values(ValueOrDataConstants);
   dataType = Object.values(DataTypeConstants);
@@ -155,14 +152,13 @@ export class FileTreeMetadataComponent {
   radioExpressionReguliere: string;
   regex: string;
   customRegex: string;
-  formatagePredefini: Array<{ label: string, value: string }> =
-    [
-      { label: 'AAAA-MM-JJ', value: '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' },
-      { label: 'AAAA-MM-JJTHH:MM:SS', value: '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$' },
-      { label: 'AAAA', value: '^[0-9]{4}$' },
-      { label: 'AAAA-MM', value: '^[0-9]{4}-[0-9]{2}$' }
-    ];
-  availableRegex: Array<{ label: string, value: string }>;
+  formatagePredefini: Array<{ label: string; value: string }> = [
+    { label: 'AAAA-MM-JJ', value: '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' },
+    { label: 'AAAA-MM-JJTHH:MM:SS', value: '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$' },
+    { label: 'AAAA', value: '^[0-9]{4}$' },
+    { label: 'AAAA-MM', value: '^[0-9]{4}-[0-9]{2}$' },
+  ];
+  availableRegex: Array<{ label: string; value: string }>;
 
   public breadcrumbDataTop: Array<BreadcrumbDataTop>;
   public breadcrumbDataMetadata: Array<BreadcrumbDataMetadata>;
@@ -170,7 +166,6 @@ export class FileTreeMetadataComponent {
   profileModeLabel: string;
 
   config: {};
-
 
   notificationAjoutMetadonnee: string;
   boutonAjoutMetadonnee: string;
@@ -227,17 +222,24 @@ export class FileTreeMetadataComponent {
   enumeration: string[];
   additionalPropertiesMetadonnee: boolean;
 
-  constructor(private fileService: FileService, private fileMetadataService: FileTreeMetadataService,
-    private sedaService: SedaService, private fb: FormBuilder, private notificationService: NotificationService,
-    private router: Router, private startupService: StartupService, public profileService: ProfileService,
-    private fileTreeService: FileTreeService, private metadataLanguageService: PastisPopupMetadataLanguageService,
-    private translateService: TranslateService) {
-
+  constructor(
+    private fileService: FileService,
+    private fileMetadataService: FileTreeMetadataService,
+    private sedaService: SedaService,
+    private fb: FormBuilder,
+    private notificationService: NotificationService,
+    private router: Router,
+    private startupService: StartupService,
+    public profileService: ProfileService,
+    private fileTreeService: FileTreeService,
+    private metadataLanguageService: PastisPopupMetadataLanguageService,
+    private translateService: TranslateService
+  ) {
     this.config = {
       locale: 'fr',
       showGoToCurrent: false,
       firstDayOfWeek: 'mo',
-      format: 'YYYY-MM-DD'
+      format: 'YYYY-MM-DD',
     };
   }
 
@@ -257,9 +259,10 @@ export class FileTreeMetadataComponent {
       this.popupControlOkLabel = 'AJOUTER LES CONTROLES';
     }
 
-
     this.additionalPropertiesMetadonnee = false;
-    this.docPath = this.isStandalone ? 'assets/doc/Standalone - Documentation APP - PASTIS.pdf' : 'assets/doc/VITAM UI - Documentation APP - PASTIS.pdf';
+    this.docPath = this.isStandalone
+      ? 'assets/doc/Standalone - Documentation APP - PASTIS.pdf'
+      : 'assets/doc/VITAM UI - Documentation APP - PASTIS.pdf';
     this.languagePopup = false;
     this._sedalanguageSub = this.metadataLanguageService.sedaLanguage.subscribe(
       (value: boolean) => {
@@ -269,12 +272,12 @@ export class FileTreeMetadataComponent {
         console.error(error);
       }
     );
-    this._fileServiceSubscriptionNodeChange = this.fileService.nodeChange.subscribe(node => {
+    this._fileServiceSubscriptionNodeChange = this.fileService.nodeChange.subscribe((node) => {
       this.clickedNode = node;
       // BreadCrumb for navigation through metadatas
       if (node && node !== undefined) {
         const breadCrumbNodeLabel: string = node.name;
-        this.fileService.tabRootNode.subscribe(tabRootNode => {
+        this.fileService.tabRootNode.subscribe((tabRootNode) => {
           if (tabRootNode) {
             const tabLabel = (nodeNameToLabel as any)[tabRootNode.name];
             this.breadcrumbDataMetadata = [{ label: tabLabel, node: tabRootNode }];
@@ -286,10 +289,12 @@ export class FileTreeMetadataComponent {
                       this.breadcrumbDataMetadata = this.breadcrumbDataMetadata.concat([{ label: '...' }]);
                     }
                   }
-                  this.breadcrumbDataMetadata = this.breadcrumbDataMetadata.concat([{
-                    label: node.parent.name,
-                    node: node.parent
-                  }]);
+                  this.breadcrumbDataMetadata = this.breadcrumbDataMetadata.concat([
+                    {
+                      label: node.parent.name,
+                      node: node.parent,
+                    },
+                  ]);
                 }
                 this.breadcrumbDataMetadata = this.breadcrumbDataMetadata.concat([{ label: breadCrumbNodeLabel, node }]);
               }
@@ -299,14 +304,21 @@ export class FileTreeMetadataComponent {
       }
     });
     // BreadCrump Top for navigation
-    this.profileModeLabel = this.profileService.profileMode === 'PUA' ? 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PUA' : 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PA';
-    this.breadcrumbDataTop = [{
-      label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.PORTAIL',
-      url: this.startupService.getPortalUrl(),
-      external: true
-    }, { label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.CREER_ET_GERER_PROFIL', url: '/' }, { label: this.profileModeLabel }];
+    this.profileModeLabel =
+      this.profileService.profileMode === 'PUA'
+        ? 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PUA'
+        : 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PA';
+    this.breadcrumbDataTop = [
+      {
+        label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.PORTAIL',
+        url: this.startupService.getPortalUrl(),
+        external: true,
+      },
+      { label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.CREER_ET_GERER_PROFIL', url: '/' },
+      { label: this.profileModeLabel },
+    ];
 
-    this._fileServiceSubscription = this.fileService.currentTree.subscribe(fileTree => {
+    this._fileServiceSubscription = this.fileService.currentTree.subscribe((fileTree) => {
       if (fileTree) {
         this.clickedNode = fileTree[0];
         this.fileService.allData.next(fileTree);
@@ -321,24 +333,28 @@ export class FileTreeMetadataComponent {
           const filteredData = this.fileService.filteredNode.getValue();
           // Initial data for metadata table based on rules defined by tabChildrenRulesChange
           if (filteredData) {
-            const dataTable = this.fileMetadataService
-              .fillDataTable(this.selectedSedaNode, filteredData, tabChildrenToInclude, tabChildrenToExclude);
+            const dataTable = this.fileMetadataService.fillDataTable(
+              this.selectedSedaNode,
+              filteredData,
+              tabChildrenToInclude,
+              tabChildrenToExclude
+            );
             this.matDataSource = new MatTableDataSource<MetadataHeaders>(dataTable);
           }
         }
       }
     });
 
-    this._fileMetadataServiceSubscriptionSelectedCardinalities = this.fileMetadataService.selectedCardinalities.subscribe(cards => {
+    this._fileMetadataServiceSubscriptionSelectedCardinalities = this.fileMetadataService.selectedCardinalities.subscribe((cards) => {
       this.selectedCardinalities = cards;
     });
 
     // Get Current sedaNode
-    this._sedaServiceSubscritptionSelectedSedaNode = this.sedaService.selectedSedaNode.subscribe(sedaNode => {
+    this._sedaServiceSubscritptionSelectedSedaNode = this.sedaService.selectedSedaNode.subscribe((sedaNode) => {
       this.selectedSedaNode = sedaNode;
     });
 
-    this._fileMetadataServiceSubscriptionDataSource = this.fileMetadataService.dataSource.subscribe(data => {
+    this._fileMetadataServiceSubscriptionDataSource = this.fileMetadataService.dataSource.subscribe((data) => {
       this.matDataSource = new MatTableDataSource<MetadataHeaders>(data);
     });
 
@@ -365,7 +381,7 @@ export class FileTreeMetadataComponent {
   setupFilter(column: string) {
     this.matDataSource.filterPredicate = (d: MetadataHeaders, filter: string) => {
       // @ts-ignore
-      const textToSearch = d[column] && d[column].toLowerCase() || '';
+      const textToSearch = (d[column] && d[column].toLowerCase()) || '';
       return textToSearch.indexOf(filter) !== -1;
     };
   }
@@ -382,11 +398,10 @@ export class FileTreeMetadataComponent {
   }
 
   translatedOnChange(): void {
-    this.translateService.onLangChange
-      .subscribe((event: LangChangeEvent) => {
-        constantToTranslate.call(this);
-        console.log(event.lang);
-      });
+    this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
+      constantToTranslate.call(this);
+      console.log(event.lang);
+    });
   }
 
   translated(nameOfFieldToTranslate: string): string {
@@ -395,7 +410,7 @@ export class FileTreeMetadataComponent {
 
   getMetadataInputPattern(type: string) {
     if (type === 'date') {
-      this.regexPattern = '([0-2][0-9]|(3)[0-1])(\/)(((0)[0-9])|((1)[0-2]))(\/)\d{4}';
+      this.regexPattern = '([0-2][0-9]|(3)[0-1])(/)(((0)[0-9])|((1)[0-2]))(/)d{4}';
       return this.regexPattern;
     }
     if (type === 'TextType' || type === null) {
@@ -405,22 +420,25 @@ export class FileTreeMetadataComponent {
   }
 
   getMetadataInputType(element: MetadataHeaders) {
-    if (element.type === 'date') {
-      return 'date';
-    }
-    if (element.enumeration.length > 0) {
-      return 'enumeration';
+    if (element) {
+      if (element.type === 'date') {
+        return 'date';
+      } else if (PA_MANDATORY_ENUM_FIELDS.includes(element.nomDuChamp)) {
+        return 'enumeration';
+      } else {
+        return '';
+      }
+    } else {
+      return '';
     }
   }
 
   findCardinality(event: any) {
-
     if (!event) {
       return CardinalityConstants.Obligatoire;
     } else {
       return event;
     }
-
   }
 
   isSedaCardinalityConform(cardList: string[], card: string) {
@@ -431,7 +449,7 @@ export class FileTreeMetadataComponent {
     if (!clickedNode.cardinality) {
       return '1';
     } else {
-      return this.cardinalityValues.find(c => c.value == clickedNode.cardinality).value;
+      return this.cardinalityValues.find((c) => c.value == clickedNode.cardinality).value;
     }
   }
 
@@ -444,7 +462,6 @@ export class FileTreeMetadataComponent {
         childNode.cardinality = newCard;
       }
     }
-
   }
 
   setNodeValue(metadata: MetadataHeaders, newValue: string) {
@@ -463,18 +480,18 @@ export class FileTreeMetadataComponent {
 
   setDocumentation(metadata: MetadataHeaders, comment: string) {
     if (this.clickedNode.name === metadata.nomDuChamp && this.clickedNode.id === metadata.id) {
-      comment ? this.clickedNode.documentation = comment : this.clickedNode.documentation = null;
+      comment ? (this.clickedNode.documentation = comment) : (this.clickedNode.documentation = null);
     } else {
       for (const node of this.clickedNode.children) {
         if (node.name === metadata.nomDuChamp && node.id === metadata.id) {
-          comment ? node.documentation = comment : node.documentation = null;
+          comment ? (node.documentation = comment) : (node.documentation = null);
         }
       }
     }
   }
 
   isElementComplex(elementName: string) {
-    const childFound = this.selectedSedaNode.Children.find(el => el.Name === elementName);
+    const childFound = this.selectedSedaNode.Children.find((el) => el.Name === elementName);
     if (childFound) {
       return childFound.Element === SedaElementConstants.complex;
     }
@@ -501,15 +518,14 @@ export class FileTreeMetadataComponent {
         Choice: null,
         Children: null,
         Enumeration: null,
-        Collection: null
+        Collection: null,
       });
       const params: FileNodeInsertParams = {
         node: this.clickedNode,
-        elementsToAdd: elements
+        elementsToAdd: elements,
       };
       this.insertItem.emit(params);
       this.notificationService.showSuccess(this.notificationAjoutMetadonnee);
-
     } else {
       this.addNode.emit(this.clickedNode);
     }
@@ -534,36 +550,39 @@ export class FileTreeMetadataComponent {
       popData.okLabel = this.popupValider;
       popData.cancelLabel = this.popupAnnuler;
 
-      const popUpAnswer = await this.fileService.openPopup(popData) as AttributeData[];
+      const popUpAnswer = (await this.fileService.openPopup(popData)) as AttributeData[];
 
       if (popUpAnswer) {
-
         // Create a list of attributes to add
-        popUpAnswer.filter(a => a.selected).forEach(attr => {
-          const fileNode = {} as FileNode;
-          fileNode.cardinality = attr.selected ? '1' : null;
-          fileNode.value = attr.valeurFixe ? attr.valeurFixe : null;
-          fileNode.documentation = attr.commentaire ? attr.commentaire : null;
-          fileNode.name = attr.nomDuChamp;
-          fileNode.type = TypeConstants.attribute;
-          fileNode.sedaData = this.sedaService.findSedaChildByName(attr.nomDuChamp, popData.fileNode.sedaData);
-          fileNode.children = [];
-          fileNode.id = attr.id;
-          attributeFileNodeListToAdd.push(fileNode);
-        });
+        popUpAnswer
+          .filter((a) => a.selected)
+          .forEach((attr) => {
+            const fileNode = {} as FileNode;
+            fileNode.cardinality = attr.selected ? '1' : null;
+            fileNode.value = attr.valeurFixe ? attr.valeurFixe : null;
+            fileNode.documentation = attr.commentaire ? attr.commentaire : null;
+            fileNode.name = attr.nomDuChamp;
+            fileNode.type = TypeConstants.attribute;
+            fileNode.sedaData = this.sedaService.findSedaChildByName(attr.nomDuChamp, popData.fileNode.sedaData);
+            fileNode.children = [];
+            fileNode.id = attr.id;
+            attributeFileNodeListToAdd.push(fileNode);
+          });
         // Create a list of attributes to remove
-        popUpAnswer.filter(a => !a.selected).forEach(attr => {
-          const fileNode: FileNode = {} as FileNode;
-          fileNode.name = attr.nomDuChamp;
-          attributeFileNodeListToRemove.push(fileNode);
-        });
+        popUpAnswer
+          .filter((a) => !a.selected)
+          .forEach((attr) => {
+            const fileNode: FileNode = {} as FileNode;
+            fileNode.name = attr.nomDuChamp;
+            attributeFileNodeListToRemove.push(fileNode);
+          });
         if (attributeFileNodeListToAdd) {
           const insertOrEditParams: FileNodeInsertAttributeParams = {
             node: popData.fileNode,
-            elementsToAdd: attributeFileNodeListToAdd
+            elementsToAdd: attributeFileNodeListToAdd,
           };
-          const attrsToAdd = attributeFileNodeListToAdd.map(e => e.name);
-          const attributeExists = popData.fileNode.children.some((child: { name: string; }) => attrsToAdd.includes(child.name));
+          const attrsToAdd = attributeFileNodeListToAdd.map((e) => e.name);
+          const attributeExists = popData.fileNode.children.some((child: { name: string }) => attrsToAdd.includes(child.name));
 
           // Add attribute (if it does not exist), or update them if they do
           if (attrsToAdd && !attributeExists) {
@@ -614,7 +633,7 @@ export class FileTreeMetadataComponent {
       this.openControls = true;
       const type: string = this.selectedSedaNode.Type;
       this.setAvailableRegex(type);
-      fileNode.puaData.enum.forEach(e => {
+      fileNode.puaData.enum.forEach((e) => {
         this.editedEnumControl.push(e);
         this.enumsControlSeleted.push(e);
       });
@@ -623,10 +642,10 @@ export class FileTreeMetadataComponent {
       const actualPattern = fileNode.puaData.pattern;
       this.openControls = true;
       this.expressionControl = true;
-      if (this.formatagePredefini.map(e => e.value).includes(actualPattern)) {
+      if (this.formatagePredefini.map((e) => e.value).includes(actualPattern)) {
         const type: string = this.selectedSedaNode.Type;
         this.setAvailableRegex(type);
-        this.regex = this.availableRegex.filter(e => e.value === actualPattern).map(e => e.value)[0];
+        this.regex = this.availableRegex.filter((e) => e.value === actualPattern).map((e) => e.value)[0];
         this.radioExpressionReguliere = 'select';
       } else {
         this.customRegex = actualPattern;
@@ -648,7 +667,6 @@ export class FileTreeMetadataComponent {
     return false;
   }
 
-
   resetContols() {
     this.arrayControl = [];
     this.enumerationControl = false;
@@ -666,29 +684,27 @@ export class FileTreeMetadataComponent {
   private setAvailableRegex(type: string) {
     switch (type) {
       case DateFormatType.date:
-        this.availableRegex = this.formatagePredefini.filter(e => e.label === 'AAAA-MM-JJ');
+        this.availableRegex = this.formatagePredefini.filter((e) => e.label === 'AAAA-MM-JJ');
         break;
       case DateFormatType.dateTime:
-        this.availableRegex = this.formatagePredefini.filter(e => e.label === 'AAAA-MM-JJTHH:MM:SS');
+        this.availableRegex = this.formatagePredefini.filter((e) => e.label === 'AAAA-MM-JJTHH:MM:SS');
         break;
       case DateFormatType.dateType:
         this.availableRegex = this.formatagePredefini;
         break;
       default:
-        this.availableRegex = this.formatagePredefini
-          .filter(e => e.label === 'AAAA-MM-JJ' || e.label === 'AAAA');
+        this.availableRegex = this.formatagePredefini.filter((e) => e.label === 'AAAA-MM-JJ' || e.label === 'AAAA');
         break;
     }
   }
 
   isDataType(): boolean {
     const type: string = this.selectedSedaNode.Type;
-    return (type === DateFormatType.date || type === DateFormatType.dateTime || type === DateFormatType.dateType);
+    return type === DateFormatType.date || type === DateFormatType.dateTime || type === DateFormatType.dateType;
   }
 
   setControlsVues(elements: string[], sedaName: string) {
-    if ((elements.includes('Enumération'))
-      || elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.ENUMERATIONS_LABEL'))) {
+    if (elements.includes('Enumération') || elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.ENUMERATIONS_LABEL'))) {
       this.enumerationControl = true;
 
       this.enumerationsSedaControl = this.sedaService.findSedaChildByName(sedaName, this.selectedSedaNode).Enumeration;
@@ -697,8 +713,10 @@ export class FileTreeMetadataComponent {
       const type: string = this.sedaService.findSedaChildByName(sedaName, this.selectedSedaNode).Type;
       this.setAvailableRegex(type);
     }
-    if ((elements.includes('Expression régulière'))
-      || elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.EXPRESSION_REGULIERE_LABEL'))) {
+    if (
+      elements.includes('Expression régulière') ||
+      elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.EXPRESSION_REGULIERE_LABEL'))
+    ) {
       this.radioExpressionReguliere = 'select';
       this.expressionControl = true;
       this.customRegex = '';
@@ -706,20 +724,23 @@ export class FileTreeMetadataComponent {
       this.setAvailableRegex(type);
       this.regex = this.formatagePredefini[0].value;
     }
-    if ((this.isStandalone && elements.includes('Longueur Min/Max'))
-      || elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.LENGTH_MIN_MAX_LABEL'))) {
+    if (
+      (this.isStandalone && elements.includes('Longueur Min/Max')) ||
+      elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.LENGTH_MIN_MAX_LABEL'))
+    ) {
       this.lengthControl = true;
     }
-    if ((this.isStandalone && elements.includes('Valeur Min/Max'))
-      || elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.VALUE_MIN_MAX_LABEL'))) {
+    if (
+      (this.isStandalone && elements.includes('Valeur Min/Max')) ||
+      elements.includes(this.translated(ADD_PUA_CONTROL_TRANSLATE_PATH + '.VALUE_MIN_MAX_LABEL'))
+    ) {
       this.valueControl = true;
     }
-
   }
 
   isNotRegexCustomisable(): boolean {
     const type: string = this.selectedSedaNode.Type;
-    return (type === DateFormatType.date || type === DateFormatType.dateTime);
+    return type === DateFormatType.date || type === DateFormatType.dateTime;
   }
 
   onDeleteNode(nodeId: number) {
@@ -772,22 +793,22 @@ export class FileTreeMetadataComponent {
    * @param nodeName The node's name to be tested
    */
   hasAttributes(nodeName: string): boolean {
-
     const node = this.sedaService.findSedaChildByName(nodeName, this.selectedSedaNode);
 
     if (node && node.Children.length > 0) {
-      return (node.Children.find(c => c.Element === SedaElementConstants.attribute) !== undefined);
+      return node.Children.find((c) => c.Element === SedaElementConstants.attribute) !== undefined;
     }
     return false;
   }
 
-
   isDeltable(name: string): boolean {
     const node = this.fileService.getFileNodeByName(this.clickedNode, name);
-    return ((node.parent.children.filter(child => child.name === name).length > 1 && this.sedaService.isSedaNodeObligatory(name, this.selectedSedaNode))
-      || !this.sedaService.isSedaNodeObligatory(name, this.selectedSedaNode));
+    return (
+      (node.parent.children.filter((child) => child.name === name).length > 1 &&
+        this.sedaService.isSedaNodeObligatory(name, this.selectedSedaNode)) ||
+      !this.sedaService.isSedaNodeObligatory(name, this.selectedSedaNode)
+    );
   }
-
 
   getSedaDefinition(elementName: string) {
     const node = this.getSedaNode(elementName);
@@ -823,7 +844,6 @@ export class FileTreeMetadataComponent {
     }
     return elementName;
   }
-
 
   resolveButtonLabel(node: FileNode) {
     if (node) {
@@ -867,12 +887,11 @@ export class FileTreeMetadataComponent {
 
   onChangeSelected(element: any, value: any) {
     if (value === undefined) {
-      this.setOrigineNodeValue(element, value)
+      this.setOrigineNodeValue(element, value);
     } else {
-      console.log(value + " Valeur On Change Selected")
+      console.log(value + ' Valeur On Change Selected');
       this.setNodeValue(element, value);
     }
-
   }
 
   private setOrigineNodeValue(metadata: any, newValue: any) {
@@ -925,7 +944,7 @@ export class FileTreeMetadataComponent {
       this.clickedControl.puaData = {} as PuaData;
     }
 
-    this.clickedControl.puaData.pattern = (this.radioExpressionReguliere === 'select') ? this.regex : this.customRegex;
+    this.clickedControl.puaData.pattern = this.radioExpressionReguliere === 'select' ? this.regex : this.customRegex;
   }
 
   onDeleteControls() {
@@ -941,15 +960,13 @@ export class FileTreeMetadataComponent {
 
   onSubmitControls() {
     if (this.enumerationControl) {
-
       if (this.clickedControl.puaData) {
         this.clickedControl.puaData.enum = this.enumsControlSeleted;
       } else {
         this.clickedControl.puaData = {
-          enum: this.enumsControlSeleted
+          enum: this.enumsControlSeleted,
         };
       }
-
     }
     if (this.expressionControl) {
       this.setPatternExpressionReguliere();
@@ -962,7 +979,7 @@ export class FileTreeMetadataComponent {
     if (indexOfElement >= 0) {
       this.enumsControlSeleted.splice(indexOfElement, 1);
       this.editedEnumControl = [];
-      this.enumsControlSeleted.forEach(e => {
+      this.enumsControlSeleted.forEach((e) => {
         this.editedEnumControl.push(e);
       });
     }
@@ -994,7 +1011,6 @@ export class FileTreeMetadataComponent {
     this.rootAdditionalProperties = FileTreeComponent.archiveUnits.additionalProperties;
   }
 
-
   isElementNameNotContentManagement(nomDuChamp: string) {
     return !(nomDuChamp === 'Content');
   }
@@ -1006,22 +1022,22 @@ export class FileTreeMetadataComponent {
   }
 
   private setNodeAdditionalPropertiesChange(additionalProperties: boolean, element: MetadataHeaders) {
-    this.clickedNode.children = this.clickedNode.children.map(node => {
-      const hasSameId = node.id === element.id
-      const hasSameName = node.name === element.nomDuChamp
+    this.clickedNode.children = this.clickedNode.children.map((node) => {
+      const hasSameId = node.id === element.id;
+      const hasSameName = node.name === element.nomDuChamp;
 
       if (hasSameId && hasSameName) {
         return {
           ...node,
           puaData: {
-            additionalProperties
+            additionalProperties,
           },
           additionalProperties,
-        }
+        };
       }
 
-      return node
-    })
+      return node;
+    });
   }
 
   getNodeAdditionalProperties(element: MetadataHeaders): boolean {
@@ -1032,6 +1048,4 @@ export class FileTreeMetadataComponent {
     }
     return false;
   }
-
-
 }


### PR DESCRIPTION
## Description

Afficher les metadonées sur la partie PA defaçon standard.
Garder le comportement de certaines metadonnées inchangé.

## Type de changement:

* Correction

## Tests:

*Indiquer comment le code à été testé (manuel, environnement, TU, etc)*

manuel

## Checklist:

*Sélectionner les éléments de la checklist*

[ ] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

VAS (Vitam Accessible en Service)
