### PR TITLE
story 11010 Unable to change the status of an entry contract 

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-information-tab/ingest-contract-information-tab.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-information-tab/ingest-contract-information-tab.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" class="side-form" (ngSubmit)="onSubmit()">
   <div class="row">
     <div class="col-10 form-control">
-      <vitamui-common-slide-toggle disabled="{{statusControl.disabled}}" [formControl]="statusControl" i18n="status@@ingestContractPreviewLabelName">
+      <vitamui-common-slide-toggle [disabled]="isReadOnly" [formControl]="statusControl" i18n="status@@ingestContractPreviewLabelName">
         Contrat actif
       </vitamui-common-slide-toggle>
     </div>

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-information-tab/ingest-contract-information-tab.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-information-tab/ingest-contract-information-tab.component.ts
@@ -60,6 +60,7 @@ export class IngestContractInformationTabComponent implements OnInit {
   form: FormGroup;
 
   submited = false;
+  isReadOnly = false;
 
   ruleFilter = new FormControl();
   statusControl = new FormControl();
@@ -90,6 +91,7 @@ export class IngestContractInformationTabComponent implements OnInit {
 
   @Input()
   set readOnly(readOnly: boolean) {
+    this.isReadOnly = readOnly;
     if (readOnly && this.form.enabled) {
       this.form.disable({ emitEvent: false });
     } else if (this.form.disabled) {


### PR DESCRIPTION
## Description

Testé sur INT et ITREC le 27/02/2023

Actuellement, avec un profil de gestion il est impossible de modifier le statut d'un contrat d'entrée actif/inactif, en effet le composant Switch/Toggle du panneau latéral dans l'onglet information est grisé "disabled" pour tous les contrats d'entrée

PI: le bug n'est pas reproductible sur le référentiel des contrats d'accès.
