### PR TITLE
[VAS]:feature/10829: add maven names

### DIFF
--- a/api/api-pastis/pastis-standalone/pom.xml
+++ b/api/api-pastis/pastis-standalone/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>pastis-standalone</artifactId>
     <description>Pastis Standalone Version</description>
-
+    <name>VITAMUI Pastis API</name>
     <properties>
         <maven.compile.target>11</maven.compile.target>
         <maven.compile.source>11</maven.compile.source>

--- a/api/api-pastis/pom.xml
+++ b/api/api-pastis/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>api-pastis</artifactId>
     <packaging>pom</packaging>
     <description>VITAMUI Pastis API</description>
+    <name>VITAMUI Pastis API</name>
 
     <modules>
         <module>pastis-commons</module>


### PR DESCRIPTION
## Description

L'objectif de cette PR est d'ajouter les noms de modules maven oubliés

## Contributeur


VAS (Vitam Accessible en Service)

