### PR TITLE
[VAS] 10829: Disable prometheus dependencies in vitamui to fix hard disk full issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -866,6 +866,24 @@
                 <groupId>fr.gouv.vitam</groupId>
                 <artifactId>common-private</artifactId>
                 <version>${vitam.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.prometheus</groupId>
+                        <artifactId>simpleclient_common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.prometheus</groupId>
+                        <artifactId>simpleclient_dropwizard</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.prometheus</groupId>
+                        <artifactId>simpleclient_hotspot</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.prometheus</groupId>
+                        <artifactId>simpleclient</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>fr.gouv.vitam</groupId>


### PR DESCRIPTION
L'objectif de cette PR est de désactiver les dépendances prometheus dans VitamUI pour éviter le problème de logs inutiles et problème de saturation des disques.