### PR TITLE
[VAS] Story 11353: Clean apt cache for upgrade.

### DIFF
--- a/deployment/roles/bootstrap_repo/tasks/main.yml
+++ b/deployment/roles/bootstrap_repo/tasks/main.yml
@@ -25,8 +25,9 @@
       group: root
       mode: 0644
 
-  - name: Update apt cache
+  - name: Update & clean apt cache
     apt:
+      clean: yes
       update_cache: yes
     register: result
     retries: "{{ packages_install_retries_number }}"


### PR DESCRIPTION
## Description

Lors du bootstrap pour une montée de version (sous debian), il est nécessaire de nettoyer le cache apt sinon l'upgrade se passe mal.

## Type de changement

* Ansiblerie

## Contributeur

* VAS (Vitam Accessible en Service)