### PR TITLE
CP 6RC - [VAS] Story 11378: Add param force_vitamui_version during vitamui package installation.

### DIFF
--- a/deployment/roles/logstash/tasks/main.yml
+++ b/deployment/roles/logstash/tasks/main.yml
@@ -35,16 +35,45 @@
     - ansible_os_family == "Debian"
     - disable_internet_repositories_install | default(false) | bool == true
 
-- name: "Install {{ logstash.package_name | default('vitamui-logstash') }} package from repo"
+- name: "Install {{ package_name }} package"
   package:
-    name: "{{ logstash.package_name | default('vitamui-logstash') }}"
+    name: "{{ package_name }}"
     state: latest
   register: result
-  retries: "{{ packages_install_retries_number }}"
+  retries: "{{ packages_install_retries_number | default(2) }}"
   until: result is succeeded
-  delay: "{{ packages_install_retries_delay }}"
-  notify:
-    - restart logstash
+  delay: "{{ packages_install_retries_delay | default(10) }}"
+  notify: restart logstash
+  when: force_vitamui_version is not defined
+
+# Force a specific version to install (even downgrade)
+- block:
+
+  - name: "Install {{ package_name }} package"
+    apt:
+      name: "{{ package_name }}={{ force_vitamui_version }}"
+      force: yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number | default(2) }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay | default(10) }}"
+    notify: restart logstash
+    when: ansible_os_family == "Debian"
+
+  - name: "Install {{ package_name }} package"
+    yum:
+      name: "{{ package_name }}-{{ force_vitamui_version }}"
+      allow_downgrade : yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number | default(2) }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay | default(10) }}"
+    notify: restart logstash
+    when: ansible_os_family == "RedHat"
+
+  when: force_vitamui_version is defined
 
 ## Logstash configuration
 

--- a/deployment/roles/logstash/vars/main.yml
+++ b/deployment/roles/logstash/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 
+package_name: "{{ logstash.package_name | default('vitamui-logstash') }}"
+
 logstash_log_dir: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/log/logstash"
 logstash_tmp_dir: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/tmp/logstash"
 logstash_conf_dir: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/conf/logstash"

--- a/deployment/roles/mongo-express/tasks/main.yml
+++ b/deployment/roles/mongo-express/tasks/main.yml
@@ -1,14 +1,47 @@
 ---
 
-- name: Install mongo-express package
+- name: "Install {{ package_name }} package"
   package:
-    name: "{{ mongo_express.package_name | default('vitamui-mongo-express') }}"
+    name: "{{ package_name }}"
     state: latest
   register: result
   retries: "{{ packages_install_retries_number | default(2) }}"
   until: result is succeeded
   delay: "{{ packages_install_retries_delay | default(10) }}"
   tags: mongo-express
+  notify: restart mongo-express
+  when: force_vitamui_version is not defined
+
+# Force a specific version to install (even downgrade)
+- block:
+
+  - name: "Install {{ package_name }} package"
+    apt:
+      name: "{{ package_name }}={{ force_vitamui_version }}"
+      force: yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number | default(2) }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay | default(10) }}"
+    tags: mongo-express
+    notify: restart mongo-express
+    when: ansible_os_family == "Debian"
+
+  - name: "Install {{ package_name }} package"
+    yum:
+      name: "{{ package_name }}-{{ force_vitamui_version }}"
+      allow_downgrade : yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number | default(2) }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay | default(10) }}"
+    tags: mongo-express
+    notify: restart mongo-express
+    when: ansible_os_family == "RedHat"
+
+  when: force_vitamui_version is defined
 
 - name: Push mongo-express script and config
   template:

--- a/deployment/roles/mongo-express/vars/main.yml
+++ b/deployment/roles/mongo-express/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+package_name: "{{ mongo_express.package_name | default('vitamui-mongo-express') }}"

--- a/deployment/roles/mongo/tasks/main.yml
+++ b/deployment/roles/mongo/tasks/main.yml
@@ -1,14 +1,44 @@
 ---
 
-- name: "Install {{ mongodb.package_name | default('vitamui-mongod') }} package"
+- name: "Install {{ package_name }} package"
   package:
-    name: "{{ mongodb.package_name | default('vitamui-mongod') }}"
+    name: "{{ package_name }}"
     state: latest
   register: result
   retries: "{{ packages_install_retries_number }}"
   until: result is succeeded
   delay: "{{ packages_install_retries_delay }}"
   notify: restart mongod
+  when: force_vitamui_version is not defined
+
+# Force a specific version to install (even downgrade)
+- block:
+
+  - name: "Install {{ package_name }} package"
+    apt:
+      name: "{{ package_name }}={{ force_vitamui_version }}"
+      force: yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number | default(2) }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay | default(10) }}"
+    notify: restart mongod
+    when: ansible_os_family == "Debian"
+
+  - name: "Install {{ package_name }} package"
+    yum:
+      name: "{{ package_name }}-{{ force_vitamui_version }}"
+      allow_downgrade : yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number | default(2) }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay | default(10) }}"
+    notify: restart mongod
+    when: ansible_os_family == "RedHat"
+
+  when: force_vitamui_version is defined
 
 - name: Disable mongod default service
   service:

--- a/deployment/roles/mongo/vars/main.yml
+++ b/deployment/roles/mongo/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 
+package_name: "{{ mongodb.package_name | default('vitamui-mongod') }}"
+
 mongo_tmp_path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/tmp/mongod"
 mongo_config_path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/conf/mongod"
 mongo_db_path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/data/mongod/db"

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -14,6 +14,37 @@
     - restart service
   when: force_vitamui_version is not defined
 
+# Force a specific version to install (even downgrade)
+- block:
+
+  - name: "Install {{ vitamui_struct.package_name | default(package_name) }} package"
+    apt:
+      name: "{{ vitamui_struct.package_name | default(package_name) }}={{ force_vitamui_version }}"
+      force: yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay }}"
+    tags: update_package_vitamui
+    notify: restart service
+    when: ansible_os_family == "Debian"
+
+  - name: "Install {{ vitamui_struct.package_name | default(package_name) }} package"
+    yum:
+      name: "{{ vitamui_struct.package_name | default(package_name) }}-{{ force_vitamui_version }}"
+      allow_downgrade : yes
+      state: present
+    register: result
+    retries: "{{ packages_install_retries_number }}"
+    until: result is succeeded
+    delay: "{{ packages_install_retries_delay }}"
+    tags: update_package_vitamui
+    notify: restart service
+    when: ansible_os_family == "RedHat"
+
+  when: force_vitamui_version is defined
+
 #### Configuration ####
 
 - name: Check that the directories exist (must be removed when the RPM plugin will be patched)

--- a/docs/fr/migration/upgrade_v5.md
+++ b/docs/fr/migration/upgrade_v5.md
@@ -3,3 +3,16 @@
 > **Important !**
 > La mise à jour vers la V5 s'opère à partir de la V5rc ou de la R16.
 > Si vous effectuez la montée de version à partir de la R16, veuillez appliquer les procédures décrites dans le chapitre: [Mise à jour V5rc](upgrade_v5rc.md)
+
+---
+
+## Application de la montée de version
+
+### Lancement du master playbook vitamui
+
+> **Important !**
+> Sous Debian, si vous appliquez la montée de version depuis la V5.RC, vous devrez rajouter le paramètre ``-e force_vitamui_version=5.2`` aux commandes suivantes. Sinon les packages vitamui ne seront pas correctement mis à jour. En effet, Debian considère que 5.rc.X > 5.X.
+
+```sh
+ansible-playbook --ask-vault-pass --extra-vars=@./environments/vitamui_extra_vars.yml -i environments/<hostfile_vitamui> ansible-vitamui/vitamui.yml
+```


### PR DESCRIPTION
## Description

Add new parameter `force_vitamui_version` on ansible to define a specific version when installing VitamUI. It allow to properly upgrade from X.rc.Y to X.Y on Debian.

## Type de changement:

* Ansiblerie

## Contributeur

* VAS (Vitam Accessible en Service)