### PR TITLE
CP 6RC - [VAS] Update puppeteer and lodash versions

### DIFF
--- a/ui/ui-frontend-common/package.json
+++ b/ui/ui-frontend-common/package.json
@@ -137,7 +137,8 @@
     "utf-8-validate": "^5.0.2",
     "web-animations-js": "^2.3.2",
     "webpack-bundle-analyzer": "^3.8.0",
-    "zone.js": "~0.10.2"
+    "zone.js": "~0.10.2",
+    "@types/lodash": "4.14.191"
   },
   "resolutions": {
     "moment": "2.26.0"

--- a/ui/ui-frontend-common/package.json
+++ b/ui/ui-frontend-common/package.json
@@ -125,7 +125,7 @@
     "node-sass": "^4.14.1",
     "popper.js": "^1.16.1",
     "protractor": "~7.0.0",
-    "puppeteer": "^19.2.2",
+    "puppeteer": "~19.6.3",
     "rxjs": "^6.5.5",
     "ts-node": "~7.0.1",
     "tsickle": "0.39.1",

--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -178,7 +178,7 @@
     "ngx-markdown": "10.1.1",
     "node-sass": "^4.14.1",
     "protractor": "^7.0.0",
-    "puppeteer": "^19.2.2",
+    "puppeteer": "~19.6.3",
     "ts-node": "~7.0.1",
     "tsickle": "^0.39.1",
     "tslint": "~6.1.0",

--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -157,7 +157,7 @@
     "@types/jasmine": "~3.3.0",
     "@types/jasminewd2": "^2.0.8",
     "@types/jszip": "^3.4.1",
-    "@types/lodash": "^4.14.156",
+    "@types/lodash": "4.14.191",
     "@types/node": "~8.9.1",
     "@types/underscore": "^1.11.2",
     "codelyzer": "6.0.1",


### PR DESCRIPTION
## Description

L'objectif de cette PR est de forcer la version de Puppeteer et la librairie lodash pour corriger le pb de build sur la branche V6-RC


## Contributeur

VAS (Vitam Accessible en Service)

