### PR TITLE
VAS-11340: minor upgrade on spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <font.awesome.version>5.11.2</font.awesome.version>
         <glassfish.javax.el.version>2.2.6</glassfish.javax.el.version>
         <gson.version>2.8.9</gson.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>32.0-jre</guava.version>
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <serenity.spring.version>2.2.2</serenity.spring.version>
         <serenity.version>2.2.2</serenity.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spring.boot.version>2.5.14</spring.boot.version>
+        <spring.boot.version>2.5.15</spring.boot.version>
         <spring.version>5.3.20</spring.version>
         <spring.cloud.consul.version>3.0.3</spring.cloud.consul.version>
         <spring.security.version>5.5.3</spring.security.version>


### PR DESCRIPTION
## Description

L'objectif de cette PR est de corriger des pbs de securité détéctées sur des versions de librairies:

## GUAVA:

Security fixes

    Reimplemented Files.createTempDir and FileBackedOutputStream to further address https://github.com/advisories/GHSA-5mg8-w23w-74h3 ([#4011](https://redirect.github.com/google/guava/issues/4011)) and https://github.com/advisories/GHSA-7g45-4rm6-3mm3 ([#2575](https://redirect.github.com/google/guava/issues/2575)). (feb83a1c8f)

While https://github.com/advisories/GHSA-5mg8-w23w-74h3 was officially closed when we deprecated Files.createTempDir in [Guava 30.0](https://github.com/google/guava/releases/tag/v30.0), we've heard from users that even recent versions of Guava have been listed as vulnerable in other databases of security vulnerabilities. In response, we've reimplemented the method (and the very rarely used FileBackedOutputStream class, which had a similar issue) to eliminate the insecure behavior entirely. This change could technically affect users in a number of different ways (discussed under "Incompatible changes" below), but in practice, the only problem users are likely to encounter is with Windows. If you are using those APIs under Windows, you should skip 32.0.0 and go straight to [32.0.1](https://github.com/google/guava/releases/tag/v32.0.1) which fixes the problem. (Unfortunately, we didn't think of the Windows problem until after the release. And while we [warn that common.io in particular may not work under Windows](https://github.com/google/guava#important-warnings), we didn't intend to regress support.) Sorry for the trouble.

## Spring boot:

In Spring Boot versions 3.0.0 - 3.0.6, 2.7.0 - 2.7.11, 2.6.0 - 2.6.14, 2.5.0 - 2.5.14 and older unsupported versions, there is potential for a denial-of-service (DoS) attack if Spring MVC is used together with a reverse proxy cache.

Specifically, an application is vulnerable if all of the conditions are true:

    The application has Spring MVC auto-configuration enabled. This is the case by default if Spring MVC is on the classpath.
    The application makes use of Spring Boot's welcome page support, either static or templated.
    Your application is deployed behind a proxy which caches 404 responses.

Your application is NOT vulnerable if any of the following are true:

    Spring MVC auto-configuration is disabled. This is true if WebMvcAutoConfiguration is explicitly excluded, if Spring MVC is not on the classpath, or if spring.main.web-application-type is set to a value other than SERVLET.
    The application does not use Spring Boot's welcome page support.
    You do not have a proxy which caches 404 responses.

Affected Spring Products and Versions

Spring Boot

3.0.0 to 3.0.6 2.7.0 to 2.7.11 2.6.0 to 2.6.14 2.5.0 to 2.5.14

Older, unsupported versions are also affected
Mitigation

Users of affected versions should apply the following mitigations:

    3.0.x users should upgrade to 3.0.7+
    2.7.x users should upgrade to 2.7.12+
    2.6.x users should upgrade to 2.6.15+
    2.5.x users should upgrade to 2.5.15+

Users of older, unsupported versions should upgrade to 3.0.7+ or 2.7.12+.

Workarounds: configure the reverse proxy not to cache 404 responses and/or not to cache responses to requests to the root (/) of the application.



## Contributeur

VAS (Vitam Accessible en Service)
