### PR TITLE
[VAS]: Bug-11356: fix build on V5-RC

### DIFF
--- a/ui/ui-frontend-common/package.json
+++ b/ui/ui-frontend-common/package.json
@@ -139,7 +139,8 @@
     "typescript": "~4.0.3",
     "url-loader": "^4.1.0",
     "utf-8-validate": "^5.0.2",
-    "webpack-bundle-analyzer": "^3.8.0"
+    "webpack-bundle-analyzer": "^3.8.0",
+    "@types/lodash": "4.14.191"
   },
   "resolutions": {
     "moment": "2.26.0"

--- a/ui/ui-frontend-common/package.json
+++ b/ui/ui-frontend-common/package.json
@@ -132,7 +132,7 @@
     "ngx-i18nsupport": "^0.17.1",
     "node-sass": "^4.14.1",
     "protractor": "~7.0.0",
-    "puppeteer": "^1.2.0",
+    "puppeteer": "~19.6.3",
     "ts-node": "~7.0.1",
     "tsickle": "~0.37.0",
     "tslint": "~6.1.0",

--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -128,7 +128,7 @@
     "@biesbjerg/ngx-translate-extract": "^7.0.2",
     "@types/jasmine": "~3.3.0",
     "@types/jasminewd2": "^2.0.8",
-    "@types/lodash": "^4.14.156",
+    "@types/lodash": "^4.14.191",
     "@types/node": "~8.9.1",
     "@types/underscore": "^1.11.2",
     "codelyzer": "^5.2.2",

--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -149,7 +149,7 @@
     "ngx-markdown": "8.2.2",
     "node-sass": "^4.14.1",
     "protractor": "^7.0.0",
-    "puppeteer": "^1.2.0",
+    "puppeteer": "~19.6.3",
     "ts-node": "~7.0.1",
     "tsickle": "^0.39.1",
     "tslint": "~5.11.0",


### PR DESCRIPTION
## Description

L'objectif de cette PR est de corriger le build de la branche V5-RC en raison d'incompatibilité de librairie JS.

## Contributeur


VAS (Vitam Accessible en Service)

