### PR TITLE
Disable daily trigger for develop.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,10 +28,6 @@ pipeline {
         )
     }
 
-    triggers {
-        cron( env.BRANCH_NAME == 'develop' ? '00 20 * * *' : '')
-    }
-
     stages {
         stage('Set variables for automatic run') {
             agent none


### PR DESCRIPTION
## Description

When a PR is merged into a master branch, Jenkins will automatically trigger a build.

This cron trigger is no longer necessary.

## Type de changement

* Build

## Contributeur

* VAS (Vitam Accessible en Service)