### PR TITLE
Revert " VAS-11340: minor upgrade on guava library"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <serenity.spring.version>2.2.2</serenity.spring.version>
         <serenity.version>2.2.2</serenity.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spring.boot.version>2.5.15</spring.boot.version>
+        <spring.boot.version>2.5.14</spring.boot.version>
         <spring.version>5.3.20</spring.version>
         <spring.cloud.consul.version>3.0.3</spring.cloud.consul.version>
         <spring.security.version>5.5.3</spring.security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <font.awesome.version>5.11.2</font.awesome.version>
         <glassfish.javax.el.version>2.2.6</glassfish.javax.el.version>
         <gson.version>2.8.9</gson.version>
-        <guava.version>32.0-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.14</http.core.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>


### PR DESCRIPTION
## Description

rollback de la montée de version de spring boot pour faire passer le build de develop     
(la version 32.0 n'existe plus, et la 32.0.0 empeche cas de se lancer)

## Type de changement

* Build

## Contributeur

* VAS (Vitam Accessible en Service)