### PR TITLE
Story 10070: Deliver Consul systemd script with ansible.

### DIFF
--- a/deployment/roles/consul/handlers/main.yml
+++ b/deployment/roles/consul/handlers/main.yml
@@ -1,11 +1,7 @@
 ---
 
-- name: restart consul
-  service:
+- name: "consul - restart service"
+  systemd:
     name: "{{ consul.service_name | default('vitam-consul') }}"
     state: restarted
-
-- name: reload consul
-  service:
-    name: "{{ consul.service_name | default('vitam-consul') }}"
-    state: reloaded
+    daemon_reload: yes

--- a/deployment/roles/consul/tasks/main.yml
+++ b/deployment/roles/consul/tasks/main.yml
@@ -12,8 +12,16 @@
   retries: "{{ packages_install_retries_number }}"
   until: result is succeeded
   delay: "{{ packages_install_retries_delay }}"
-  notify:
-    - restart consul
+  notify: "consul - restart service"
+
+- name: Deploy systemd service file for vitam-consul
+  template:
+    src: vitam-consul.service.j2
+    dest: "{{ '/lib/systemd/system' if ansible_os_family == 'Debian' else '/usr/lib/systemd/system' }}/vitam-consul.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: "consul - restart service"
 
 - name: rustine VITAMUI ensure vitam user is member of vitamui group
   user:
@@ -37,20 +45,25 @@
     - log
     - data
     - tmp
-  notify:
-    - restart consul
+  notify: "consul - restart service"
+
+- name: Deploy consul sysconfig file
+  template:
+    src: sysconfig.j2
+    dest: "{{ consul_folder_conf }}/sysconfig"
+    owner: "{{ vitam_defaults.users.vitam }}"
+    group: "{{ vitam_defaults.users.group }}"
+    mode: "{{ vitam_defaults.folder.conf_permission }}"
+  notify: "consul - restart service"
 
 - name: Deploy consul common configuration files
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ consul.conf_folder | default('/vitam/conf/consul') }}/{{ item }}"
+    src: consul.json.j2
+    dest: "{{ consul.conf_folder | default('/vitam/conf/consul') }}/consul.json"
     owner: "{{ vitam_defaults.users.vitam }}"
     group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
     mode: "{{ vitamui_defaults.folder.conf_permission | default('0440') }}"
-  with_items:
-    - "consul.json"
-  notify:
-      - reload consul
+  notify: "consul - restart service"
 
 # Ensure that the installation is complete and consul up before setting up the system-wide dns resolver...
 - meta: flush_handlers
@@ -71,8 +84,6 @@
     block: |
       nameserver 127.0.0.1
   when: inventory_hostname not in single_vm_hostnames
-
-- meta: flush_handlers
 
 - name: Wait for consul port to be open
   wait_for:

--- a/deployment/roles/consul/templates/sysconfig.j2
+++ b/deployment/roles/consul/templates/sysconfig.j2
@@ -1,0 +1,3 @@
+CMD_OPTS="agent -config-dir={{ vitam_defaults.folder.root_path }}/conf/consul -data-dir={{ vitam_defaults.folder.root_path }}/data/consul"
+CONSUL_UI_BETA=true
+#GOMAXPROCS=4

--- a/deployment/roles/consul/templates/vitam-consul.service.j2
+++ b/deployment/roles/consul/templates/vitam-consul.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Consul is a distributed, highly-available, and multi-datacenter aware tool for service discovery, configuration, and orchestration.
+Documentation=http://www.consul.io
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ vitam_defaults.users.vitam }}
+Group={{ vitam_defaults.users.group }}
+EnvironmentFile=-{{ vitam_defaults.folder.root_path }}/conf/consul/sysconfig
+ExecStart={{ vitam_defaults.folder.root_path }}/bin/consul/consul $CMD_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+#CapabilityBoundingSet=CAP_NET_BIND_SERVICE #KWA: doesn't seem to do anything...
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Description

The vitam-consul package do not contain the systemd script that must be delivered as an Ansible configuration.

## Type de changement

* Ansiblerie

## Contributeur

* VAS (Vitam Accessible en Service)