### PR TITLE
Story 11676: Fix ansible.cfg configuration since removing mitogen.

### DIFF
--- a/deployment/ansible.cfg
+++ b/deployment/ansible.cfg
@@ -9,3 +9,6 @@ fact_caching = jsonfile
 forks = 20
 timeout = 60
 host_key_checking = False
+
+[ssh_connection]
+retries = 5

--- a/tools/docker/mongo/ansible.cfg
+++ b/tools/docker/mongo/ansible.cfg
@@ -2,16 +2,9 @@
 [defaults]
 hash_behaviour = merge
 roles_path     = ../../../deployment/roles/
-filter_plugins =  ./../../../deployment/filter_plugins/
-#fact_caching_connection = ./tmp/facts_cache
-#fact_caching = jsonfile
-# The timeout is defined in seconds
-# This is 2 hours
-fact_caching_timeout = 7200
-
+filter_plugins = ../../../deployment/filter_plugins/
 host_key_checking = False
-strategy_plugins = ../../../deployment/lib/mitogen-0.2.9/ansible_mitogen/plugins/strategy
-strategy = mitogen_linear
 
 [ssh_connection]
 pipelining = True
+retries = 5


### PR DESCRIPTION
## Description

* Fix the ansible.cfg for mongo dev deployment.
* Add improvements parameters on global ansible.cfg

## Type de changement

* Ansiblerie

## Contributeur

* VAS (Vitam Accessible en Service)