### PR TITLE
[CP-V6-RC]- VAS/Bug-11469: fix wrong messages for elimination analysis

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/common-services/archive-unit-elimination.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/common-services/archive-unit-elimination.service.ts
@@ -101,7 +101,7 @@ export class ArchiveUnitEliminationService {
       const eliminationAnalysisResponse = data.$results;
       if (eliminationAnalysisResponse && eliminationAnalysisResponse[0].itemId) {
         const guid = eliminationAnalysisResponse[0].itemId;
-        const message = this.translateService.instant('ARCHIVE_SEARCH.ELIMINATION.ELIMINATION_LAUNCHED');
+        const message = this.translateService.instant('ARCHIVE_SEARCH.ELIMINATION.ELIMINATION_ANALYSIS_LAUNCHED');
         const serviceUrl = this.startupService.getReferentialUrl() + '/logbook-operation/tenant/' + tenantIdentifier + '?guid=' + guid;
         this.archiveHelperService.openSnackBarForWorkflow(this.snackBar, message, serviceUrl);
       }

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
@@ -91,6 +91,7 @@
     "ELIMINATION": {
       "ANALYSIS": "Launch elimination analysis",
       "ELIMINATION_LAUNCHED": "Your request for elimination has been taken into account",
+      "ELIMINATION_ANALYSIS_LAUNCHED": "Your request for elimination analysis has been taken into account",
       "THRESHOLD_EXCEEDED": "The elimination analysis cannot be started. Please restrict your selection to a maximum of 10,000 archival units.",
       "EXECUTION": "Delete archives",
       "TO_ELIMINATE": "Do you want to eliminate",

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
@@ -92,6 +92,7 @@
     "ELIMINATION": {
       "ANALYSIS": "Lancer une analyse d'élimination",
       "ELIMINATION_LAUNCHED": "Votre demande d'élimination a bien été prise en compte",
+      "ELIMINATION_ANALYSIS_LAUNCHED": "Votre demande d'analyse d'élimination a bien été prise en compte",
       "THRESHOLD_EXCEEDED": "L’analyse d’élimination ne peut être lancée. Merci de restreindre votre sélection à 10 000 unités archivistiques maximum.",
       "EXECUTION": "Eliminer des archives",
       "TO_ELIMINATE": "Voulez-vous éliminer les",


### PR DESCRIPTION
## Description

L'objectif de cette PR est de corriger une erreur d'affichage du bandeau de confirmation d'une opération d'analyse d'élimination


## Contributeur


VAS (Vitam Accessible en Service)


