### PR TITLE
CP V5 - VAS/Bug-11469: fix wrong messages for elimination analysis

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -1467,7 +1467,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy {
 
         if (this.eliminationAnalysisResponse && this.eliminationAnalysisResponse[0].itemId) {
           const guid = this.eliminationAnalysisResponse[0].itemId;
-          const message = this.translateService.instant('ARCHIVE_SEARCH.ELIMINATION.ELIMINATION_LAUNCHED');
+          const message = this.translateService.instant('ARCHIVE_SEARCH.ELIMINATION.ELIMINATION_ANALYSIS_LAUNCHED');
           const serviceUrl =
             this.startupService.getReferentialUrl() + '/logbook-operation/tenant/' + this.tenantIdentifier + '?guid=' + guid;
 

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
@@ -46,7 +46,6 @@
         "CLASSIFICATIONREASSESSINGDATE": "Reassessment date",
         "NEEDREASSESSINGAUTHORIZATION": "Need for re-evaluation authorization"
       },
-
       "HOLD_RULE_PROPERTIES": {
         "HOLDREASON": "Motif de la règle de gel",
         "HOLDOWNER": "Propriétaire",
@@ -84,6 +83,7 @@
     "ELIMINATION": {
       "ANALYSIS": "Launch elimination analysis",
       "ELIMINATION_LAUNCHED": "Your request for elimination has been taken into account",
+      "ELIMINATION_ANALYSIS_LAUNCHED": "Your request for elimination analysis has been taken into account",
       "THRESHOLD_EXCEEDED": "The elimination analysis cannot be started. Please restrict your selection to a maximum of 10,000 archival units.",
       "EXECUTION": "Delete archives",
       "TO_ELIMINATE": "Do you want to eliminate",
@@ -198,7 +198,6 @@
         "DESCRIPTION_LEVEL": "Archive unit type",
         "ALL_ARCHIVE_UNIT_TYPES": "Type",
         "ELIMINATION_TECHNICAL_ID_APPRAISAL_RULE": "Elimination analysis operation Identifier",
-
         "ORIGIN": {
           "INHERITE_AT_LEAST_ONE_APPRAISAL_RULE": "Inherits at least one DUA rule",
           "HAS_AT_LEAST_ONE_APPRAISAL_RULE": "Has at least one DUA ruler",
@@ -233,7 +232,7 @@
         "SELECT_OTHER_FIELD": "Select another criteria",
         "SP_COMM": "Originating agency Comm",
         "SP_COMM_DT": "Originating agency Comm DT",
-        "TYPE" : "Type"
+        "TYPE": "Type"
       }
     },
     "ARCHIVE_UNIT_PREVIEW": {
@@ -395,7 +394,6 @@
       "UPDATE_CONFIRM_MESSAGE": "Warning, you are about to validate the rule changes on {{ua_selected}} archival units. Do you confirm this update? ",
       "EXIT_CONFIRM_MESSAGE": "Are you sure you want to quit updating business rules on {{ua_selected}} selected archival units?"
     },
-
     "CATEGORIES_NAME": {
       "STORAGE_RULE": "Current useful life (CUL)",
       "APPRAISAL_RULE": "Administrative useful life (AUL)",
@@ -405,7 +403,6 @@
       "REUSE_RULE": "Reuse",
       "CLASSIFICATION_RULE": "Classification"
     },
-
     "ALERTE_MESSAGES": {
       "BACK_TO_SELECTION": "Return to selection",
       "ACTION_ALERTE_TITLE": "The requested action is not possible for this selection",

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
@@ -46,7 +46,6 @@
         "CLASSIFICATIONREASSESSINGDATE": "Date de réévaluation",
         "NEEDREASSESSINGAUTHORIZATION": "Besoin d'autorisation de réévaluation"
       },
-
       "HOLD_RULE_PROPERTIES": {
         "HOLDREASON": "Motif de la règle de gel",
         "HOLDOWNER": "Propriétaire",
@@ -84,6 +83,7 @@
     "ELIMINATION": {
       "ANALYSIS": "Lancer une analyse d'élimination",
       "ELIMINATION_LAUNCHED": "Votre demande d'élimination a bien été prise en compte",
+      "ELIMINATION_ANALYSIS_LAUNCHED": "Votre demande d'analyse d'élimination a bien été prise en compte",
       "THRESHOLD_EXCEEDED": "L’analyse d’élimination ne peut être lancée. Merci de restreindre votre sélection à 10 000 unités archivistiques maximum.",
       "EXECUTION": "Eliminer des archives",
       "TO_ELIMINATE": "Voulez-vous éliminer les",
@@ -470,7 +470,6 @@
       "UPDATE_CONFIRM_MESSAGE": "Attention, vous êtes sur le point de valider les changements de règle(s) sur {{ ua_selected }} unités archivistiques. Confirmez-vous cette mise à jour ?",
       "EXIT_CONFIRM_MESSAGE": "Êtes-vous sur de vouloir quitter la mise à jour des règles de gestion sur les {{ua_selected}} unités archivistiques sélectionnées ?"
     },
-
     "CATEGORIES_NAME": {
       "STORAGE_RULE": "Durée d'utilité courante (DUC)",
       "APPRAISAL_RULE": "Durée d'utilité administrative (DUA)",
@@ -480,7 +479,6 @@
       "REUSE_RULE": "Réutilisation",
       "CLASSIFICATION_RULE": "Classification"
     },
-
     "ALERTE_MESSAGES": {
       "BACK_TO_SELECTION": "Revenir à la sélection",
       "ACTION_ALERTE_TITLE": "L'action demandée n'est pas possible pour cette sélection",


### PR DESCRIPTION
## Description

L'objectif de cette PR est de corriger une erreur d'affichage du bandeau de confirmation d'une opération d'analyse d'élimination


## Contributeur


VAS (Vitam Accessible en Service)


