### PR TITLE
fix: pastis standalone build

### DIFF
--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -150,6 +150,7 @@
     "@angular-builders/custom-webpack": "^8.4.1",
     "@angular-devkit/build-angular": "^0.1001.3",
     "@angular-devkit/build-ng-packagr": "^0.1001.3",
+    "@angular-devkit/core": "^10.1.3",
     "@angular/cli": "^10.1.3",
     "@angular/compiler-cli": "10.1.3",
     "@angular/language-service": "10.1.3",


### PR DESCRIPTION
## Description

Depuis `develop` les commandes suiventes ne passent pas.

```sh
cd api/api-pastis/pastis-standalone
./build.sh
```