### PR TITLE
Story 11250: Upgrade MongoDB to 7.0.2. 

### DIFF
--- a/api/api-iam/README.md
+++ b/api/api-iam/README.md
@@ -32,7 +32,7 @@ En développement, définir également la propriété `config.dir` qui doit poin
 ## Connect to the Mongo shell (if needed)
 
 ```shell
-mongo --port 27018 -u "mongod_dbuser_iam" -p "mongod_dbpwd_iam" --authenticationDatabase "iam"
+mongosh --port 27018 -u "mongod_dbuser_iam" -p "mongod_dbpwd_iam" --authenticationDatabase "iam"
 ```
 
 

--- a/api/api-iam/iam-external/src/test/mongo/populate-admin.txt
+++ b/api/api-iam/iam-external/src/test/mongo/populate-admin.txt
@@ -1,40 +1,40 @@
 # add admin profiles
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofileusers",
    "name" : "adminprofileusers",
    "description" : "adminprofileusers",
    "tenantId" : "vitamui",
    "applicationName" : "USERS", "roles": { "GET_USERS" : null, "CREATE_USERS" : null, "UPDATE_USERS" : null, "DELETE_USERS" : null, "GET_USERS_PROFILE" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofilegroups",
    "name" : "adminprofilegroups",
    "description" : "adminprofilegroups",
    "tenantId" : "vitamui",
    "applicationName" : "GROUPS", "roles": { "GET_GROUPS" : null, "CREATE_GROUPS" : null, "UPDATE_GROUPS" : null, "DELETE_GROUPS" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofileprofiles",
    "name" : "adminprofileprofiles",
    "description" : "adminprofileprofiles",
    "tenantId" : "vitamui",
    "applicationName" : "PROFILES", "roles": { "GET_PROFILES" : null, "CREATE_PROFILES" : null, "UPDATE_PROFILES" : null, "DELETE_PROFILES" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofileproviders",
    "name" : "adminprofileproviders",
    "description" : "adminprofileproviders",
    "tenantId" : "vitamui",
    "applicationName" : "PROVIDERS", "roles": { "GET_PROVIDERS" : null, "CREATE_PROVIDERS" : null, "UPDATE_PROVIDERS" : null, "DELETE_PROVIDERS" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofiletenants",
    "name" : "adminprofiletenants",
    "description" : "adminprofiletenants",
    "tenantId" : "vitamui",
    "applicationName" : "TENANTS", "roles": { "GET_TENANTS" : null, "CREATE_TENANTS" : null, "UPDATE_TENANTS" : null, "DELETE_TENANTS" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofilecustomers",
    "name" : "adminprofilecustomers",
    "description" : "adminprofilecustomers",
@@ -43,7 +43,7 @@ db.profiles.insert({
 });
 
 # add admin profile group
-db.groups.insert({
+db.groups.insertOne({
   "_id" : "admingroup",
    "name" : "admingroup",
    "description" : "admingroup",
@@ -52,7 +52,7 @@ db.groups.insert({
 });
 
 # add admin user
-db.users.insert({
+db.users.insertOne({
   "_id" : "adminuser",
   "enabled" : true,
   "password" : "neverused",

--- a/api/api-iam/iam-internal/src/test/mongo/populate-admin.txt
+++ b/api/api-iam/iam-internal/src/test/mongo/populate-admin.txt
@@ -1,40 +1,40 @@
 # add admin profiles
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofileusers",
    "name" : "adminprofileusers",
    "description" : "adminprofileusers",
    "tenantId" : "vitamui",
    "applicationName" : "USERS", "roles": { "GET_USERS" : null, "CREATE_USERS" : null, "UPDATE_USERS" : null, "DELETE_USERS" : null, "GET_USERS_PROFILE" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofilegroups",
    "name" : "adminprofilegroups",
    "description" : "adminprofilegroups",
    "tenantId" : "vitamui",
    "applicationName" : "GROUPS", "roles": { "GET_GROUPS" : null, "CREATE_GROUPS" : null, "UPDATE_GROUPS" : null, "DELETE_GROUPS" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofileprofiles",
    "name" : "adminprofileprofiles",
    "description" : "adminprofileprofiles",
    "tenantId" : "vitamui",
    "applicationName" : "PROFILES", "roles": { "GET_PROFILES" : null, "CREATE_PROFILES" : null, "UPDATE_PROFILES" : null, "DELETE_PROFILES" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofileproviders",
    "name" : "adminprofileproviders",
    "description" : "adminprofileproviders",
    "tenantId" : "vitamui",
    "applicationName" : "PROVIDERS", "roles": { "GET_PROVIDERS" : null, "CREATE_PROVIDERS" : null, "UPDATE_PROVIDERS" : null, "DELETE_PROVIDERS" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofiletenants",
    "name" : "adminprofiletenants",
    "description" : "adminprofiletenants",
    "tenantId" : "vitamui",
    "applicationName" : "TENANTS", "roles": { "GET_TENANTS" : null, "CREATE_TENANTS" : null, "UPDATE_TENANTS" : null, "DELETE_TENANTS" : null }
 });
-db.profiles.insert({
+db.profiles.insertOne({
   "_id" : "adminprofilecustomers",
    "name" : "adminprofilecustomers",
    "description" : "adminprofilecustomers",
@@ -43,7 +43,7 @@ db.profiles.insert({
 });
 
 # add admin profile group
-db.groups.insert({
+db.groups.insertOne({
   "_id" : "admingroup",
    "name" : "admingroup",
    "description" : "admingroup",
@@ -52,7 +52,7 @@ db.groups.insert({
 });
 
 # add admin user
-db.users.insert({
+db.users.insertOne({
   "_id" : "adminuser",
   "enabled" : true,
   "password" : "neverused",

--- a/api/api-security/README.md
+++ b/api/api-security/README.md
@@ -25,5 +25,5 @@ mvn spring-boot:run
 ## Connect to the Mongo shell (if needed)
 
 ```shell
-mongo --port 27018 -u "mongod_dbuser_security" -p "mongod_dbpwd_security" --authenticationDatabase "security"
+mongosh --port 27018 -u "mongod_dbuser_security" -p "mongod_dbpwd_security" --authenticationDatabase "security"
 ```

--- a/cas/cas-server/README.md
+++ b/cas/cas-server/README.md
@@ -133,7 +133,7 @@ mongosh --port 27018 -u "mongod_dbuser_cas" -p "mongod_dbpwd_cas" --authenticati
 The OAuth server support is enabled in the CAS server. To support the resource owner password grant type, an appropriate service must be declared:
 
 ```json
-db.services.insert({
+db.services.insertOne({
   "_id" : NumberInt(61),
   "_class" : "org.apereo.cas.support.oauth.services.OAuthRegisteredService",
   "clientId": "testclientid",
@@ -151,7 +151,7 @@ db.services.insert({
 or with a JSON response:
 
 ```json
-db.services.insert({
+db.services.insertOne({
   "_id" : NumberInt(61),
   "_class" : "org.apereo.cas.support.oauth.services.OAuthRegisteredService",
   "clientId": "testclientid",

--- a/cas/cas-server/README.md
+++ b/cas/cas-server/README.md
@@ -124,7 +124,7 @@ The underneath SMS provider is Twilio.
 ## Connect to the Mongo shell (if needed)
 
 ```shell
-mongo --port 27018 -u "mongod_dbuser_cas" -p "mongod_dbpwd_cas" --authenticationDatabase "cas"
+mongosh --port 27018 -u "mongod_dbuser_cas" -p "mongod_dbpwd_cas" --authenticationDatabase "cas"
 ```
 
 

--- a/cots/vitamui-mongod/templates/vitamui-mongod.service
+++ b/cots/vitamui-mongod/templates/vitamui-mongod.service
@@ -1,22 +1,30 @@
 [Unit]
-Description=High-performance, schema-free document-oriented database
-After=network.target
-After=syslog.target
+Description=MongoDB (mongod) Database Service
+Documentation=https://docs.mongodb.org/manual
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-Type=simple
-Environment="LC_ALL=C"
-ExecStart=/usr/bin/mongod  -f /vitamui/conf/__NAME__/mongod.conf run
-Restart=always
 User=__USER__
 Group=__GROUP__
-# ulimits
+ExecStart=/usr/bin/mongod -f /vitamui/conf/__NAME__/mongod.conf
+# file size
 LimitFSIZE=infinity
+# cpu time
 LimitCPU=infinity
+# virtual memory size
 LimitAS=infinity
+# open files
 LimitNOFILE=64000
-LimitRSS=infinity
+# processes/threads
 LimitNPROC=64000
+# locked memory
+LimitMEMLOCK=infinity
+# total threads (user+kernel)
+TasksMax=infinity
+TasksAccounting=false
+# Recommended limits for mongod as specified in
+# https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 
 [Install]
 WantedBy=multi-user.target

--- a/deployment/ansible-vitamui-migration/migration_mongodb_60.yml
+++ b/deployment/ansible-vitamui-migration/migration_mongodb_60.yml
@@ -1,0 +1,72 @@
+---
+
+# Mongodb migration from 5.0 to 6.0
+###################################
+
+# Confirm launching this playbook
+- hosts: localhost
+  any_errors_fatal: yes
+  gather_facts: no
+  vars_prompt:
+    name: "confirmation"
+    prompt: "This playbook will migrate your mongo clusters from 5.0 to 6.0.\n\nAre you sure you want to run this playbook ?\nAnswer with 'YES'"
+    default: "NO"
+    private: no
+  tasks:
+    - name: Check Confirmation
+      fail: msg="Playbook run confirmation failed"
+      when: confirmation|upper != "YES"
+
+################################################################################
+# Starting mongo-vitamui migration
+################################################################################
+
+# Checks feature compatibility version & state
+- hosts: hosts_vitamui_mongod
+  gather_facts: no
+  roles:
+    - mongodb_check_feature_compatibility
+    - mongodb_check_replica_state
+  vars:
+    mongo_compatibility_list: ['5.0', '6.0']
+
+################################################################################
+## Upgrade replica set (mongod)
+
+# set_members_groups for mongod
+- hosts: hosts_vitamui_mongod
+  gather_facts: no
+  roles:
+    - mongodb_set_members_groups
+
+# upgrade secondaries mongod
+- hosts: hosts_vitamui_mongod
+  roles:
+    - mongodb_upgrade_package
+  vars:
+    mongo_version: 6.0.11
+    mongo_primary: false
+  serial: 1
+
+# upgrade primary mongod
+- hosts: hosts_vitamui_mongod
+  roles:
+    - mongodb_upgrade_package
+  vars:
+    mongo_version: 6.0.11
+    mongo_primary: true
+  serial: 1
+
+################################################################################
+
+# set_featurecompatibility
+- hosts: hosts_vitamui_mongod
+  gather_facts: no
+  roles:
+    - mongodb_set_feature_compatibility
+  vars:
+    mongo_version: 6.0
+
+################################################################################
+# End of mongo-vitamui migration
+################################################################################

--- a/deployment/ansible-vitamui-migration/migration_mongodb_70.yml
+++ b/deployment/ansible-vitamui-migration/migration_mongodb_70.yml
@@ -1,0 +1,72 @@
+---
+
+# Mongodb migration from 6.0 to 7.0
+###################################
+
+# Confirm launching this playbook
+- hosts: localhost
+  any_errors_fatal: yes
+  gather_facts: no
+  vars_prompt:
+    name: "confirmation"
+    prompt: "This playbook will migrate your mongo clusters from 6.0 to 7.0.\n\nAre you sure you want to run this playbook ?\nAnswer with 'YES'"
+    default: "NO"
+    private: no
+  tasks:
+    - name: Check Confirmation
+      fail: msg="Playbook run confirmation failed"
+      when: confirmation|upper != "YES"
+
+################################################################################
+# Starting mongo-vitamui migration
+################################################################################
+
+# Checks feature compatibility version & state
+- hosts: hosts_vitamui_mongod
+  gather_facts: no
+  roles:
+    - mongodb_check_feature_compatibility
+    - mongodb_check_replica_state
+  vars:
+    mongo_compatibility_list: ['6.0', '7.0']
+
+################################################################################
+## Upgrade replica set (mongod)
+
+# set_members_groups for mongod
+- hosts: hosts_vitamui_mongod
+  gather_facts: no
+  roles:
+    - mongodb_set_members_groups
+
+# upgrade secondaries mongod
+- hosts: hosts_vitamui_mongod
+  roles:
+    - mongodb_upgrade_package
+  vars:
+    mongo_version: 7.0.2
+    mongo_primary: false
+  serial: 1
+
+# upgrade primary mongod
+- hosts: hosts_vitamui_mongod
+  roles:
+    - mongodb_upgrade_package
+  vars:
+    mongo_version: 7.0.2
+    mongo_primary: true
+  serial: 1
+
+################################################################################
+
+# set_featurecompatibility
+- hosts: hosts_vitamui_mongod
+  gather_facts: no
+  roles:
+    - mongodb_set_feature_compatibility
+  vars:
+    mongo_version: 7.0
+
+################################################################################
+# End of mongo-vitamui migration
+################################################################################

--- a/deployment/roles/init_app_bdd/tasks/check_auth.yml
+++ b/deployment/roles/init_app_bdd/tasks/check_auth.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check if authent is enabled
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
   register: mongo_authent_enabled
   failed_when: false
   no_log: "{{ hide_passwords_during_deploy }}"

--- a/deployment/roles/init_app_bdd/tasks/referential.yml
+++ b/deployment/roles/init_app_bdd/tasks/referential.yml
@@ -20,7 +20,7 @@
     - update_mongodb_configuration
 
 - name: Load referential scripts in database
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/scripts/referential/{{ item | basename | regex_replace('\\.j2$') }}"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/scripts/referential/{{ item | basename | regex_replace('\\.j2$') }}"
   no_log: "{{ hide_passwords_during_deploy }}"
   with_fileglob:
     - "{{ role_path }}/templates/referential/*"

--- a/deployment/roles/init_app_bdd/templates/referential/01_referential.js.j2
+++ b/deployment/roles/init_app_bdd/templates/referential/01_referential.js.j2
@@ -10,7 +10,7 @@ db = db.getSiblingDB('{{ mongodb.iam.db }}')
 
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_access_contract" },
     {
         "$set" : {
@@ -36,7 +36,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_ingest_contract" },
     {
         "$set" : {
@@ -64,7 +64,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_ontology" },
     {
         "$set" : {
@@ -91,7 +91,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_agencies" },
     {
         "$set" : {
@@ -120,7 +120,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_file_format" },
     {
         "$set" : {
@@ -148,7 +148,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_context" },
     {
         "$set" : {
@@ -174,7 +174,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_security_profile" },
     {
         "$set" : {
@@ -201,7 +201,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_audit" },
     {
         "$set" : {
@@ -226,7 +226,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_secure" },
     {
         "$set" : {
@@ -250,7 +250,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_dsl" },
     {
         "$set" : {
@@ -272,7 +272,7 @@ db.profiles.update(
     { "upsert":true }
 );
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_probative_value" },
     {
         "$set" : {
@@ -448,7 +448,7 @@ db.groups.updateOne(
 // ====================================== APPLICATIONS ======================================
 
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "AUDIT_APP" },
     {
         "$set" : {
@@ -474,7 +474,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "SECURE_APP" },
     {
         "$set" : {
@@ -500,7 +500,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "INGEST_APP" },
     {
         "$set" : {
@@ -526,7 +526,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "ACCESS_APP" },
     {
         "$set" : {
@@ -552,7 +552,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "AGENCIES_APP" },
     {
         "$set" : {
@@ -578,7 +578,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "FILE_FORMATS_APP" },
     {
         "$set" : {
@@ -604,7 +604,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "CONTEXTS_APP" },
     {
         "$set" : {
@@ -630,7 +630,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "SECURITY_PROFILES_APP" },
     {
         "$set" : {
@@ -656,7 +656,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "ONTOLOGY_APP" },
     {
         "$set" : {
@@ -682,7 +682,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "DSL_APP" },
     {
         "$set" : {
@@ -708,7 +708,7 @@ db.applications.update(
     { "upsert":true }
 );
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "PROBATIVE_VALUE_APP" },
     {
         "$set" : {
@@ -745,7 +745,7 @@ db = db.getSiblingDB('{{ mongodb.security.db }}')
 
 print("INFO 01_referential.js : START security update");
 
-db.contexts.update(
+db.contexts.updateOne(
     { "_id" : "ui_referential_context" },
     {
         "$set" : {
@@ -797,7 +797,7 @@ print("INFO 01_referential.js : START cas database update");
 db = db.getSiblingDB('{{ mongodb.cas.db }}')
 
 
-db.services.update(
+db.services.updateOne(
     { "_id" :  NumberInt(4) },
     {
         "$set" : {

--- a/deployment/roles/init_app_bdd/templates/referential/01_referential.js.j2
+++ b/deployment/roles/init_app_bdd/templates/referential/01_referential.js.j2
@@ -772,7 +772,7 @@ db.contexts.updateOne(
 
 
 {% macro insertCertififcate(pemFile, contextId) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/roles/init_app_bdd/templates/referential/01_referential.js.j2
+++ b/deployment/roles/init_app_bdd/templates/referential/01_referential.js.j2
@@ -776,7 +776,7 @@ db.certificates.remove(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/roles/init_archive_search_app_bdd/tasks/archive-search.yml
+++ b/deployment/roles/init_archive_search_app_bdd/tasks/archive-search.yml
@@ -20,7 +20,7 @@
     - update_mongodb_configuration
 
 - name: Load archive search scripts in database
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/scripts/archive-search/{{ item | basename | regex_replace('\\.j2$') }}"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/scripts/archive-search/{{ item | basename | regex_replace('\\.j2$') }}"
   no_log: "{{ hide_passwords_during_deploy }}"
   with_fileglob:
     - "{{ role_path }}/templates/archive-search/*"

--- a/deployment/roles/init_archive_search_app_bdd/tasks/check_mongo_auth.yml
+++ b/deployment/roles/init_archive_search_app_bdd/tasks/check_mongo_auth.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check if authent is enabled
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
   register: mongo_authent_enabled
   failed_when: false
   no_log: "{{ hide_passwords_during_deploy }}"

--- a/deployment/roles/init_archive_search_app_bdd/templates/archive-search/01_archive-search.js.j2
+++ b/deployment/roles/init_archive_search_app_bdd/templates/archive-search/01_archive-search.js.j2
@@ -123,7 +123,7 @@ db.contexts.updateOne(
 
 
 {% macro insertCertififcate(pemFile, contextId) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/roles/init_archive_search_app_bdd/templates/archive-search/01_archive-search.js.j2
+++ b/deployment/roles/init_archive_search_app_bdd/templates/archive-search/01_archive-search.js.j2
@@ -10,7 +10,7 @@ db = db.getSiblingDB('{{ mongodb.iam.db }}')
 
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_archive_search_profile" },
     {
         "$set" : {
@@ -69,7 +69,7 @@ db.groups.updateOne(
 // ====================================== APPLICATIONS ======================================
 
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "ARCHIVE_SEARCH_MANAGEMENT_APP" },
     {
         "$set" : {
@@ -103,7 +103,7 @@ db = db.getSiblingDB('{{ mongodb.security.db }}')
 
 print("INFO 01_archive_search.js : START security update");
 
-db.contexts.update(
+db.contexts.updateOne(
     { "_id" : "ui_archive_search_context" },
     {
         "$set" : {
@@ -148,7 +148,7 @@ print("INFO 01_archive_search.js : START cas database update");
 db = db.getSiblingDB('{{ mongodb.cas.db }}')
 
 
-db.services.update(
+db.services.updateOne(
     { "_id" :  NumberInt(4) },
     {
         "$set" : {

--- a/deployment/roles/init_archive_search_app_bdd/templates/archive-search/01_archive-search.js.j2
+++ b/deployment/roles/init_archive_search_app_bdd/templates/archive-search/01_archive-search.js.j2
@@ -127,7 +127,7 @@ db.certificates.remove(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/roles/init_ingest_app_bdd/tasks/check_mongo_auth.yml
+++ b/deployment/roles/init_ingest_app_bdd/tasks/check_mongo_auth.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check if authent is enabled
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
   register: mongo_authent_enabled
   failed_when: false
   no_log: "{{ hide_passwords_during_deploy }}"

--- a/deployment/roles/init_ingest_app_bdd/tasks/ingest.yml
+++ b/deployment/roles/init_ingest_app_bdd/tasks/ingest.yml
@@ -20,7 +20,7 @@
     - update_mongodb_configuration
 
 - name: Load ingest scripts in database
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/scripts/ingest/{{ item | basename | regex_replace('\\.j2$') }}"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/scripts/ingest/{{ item | basename | regex_replace('\\.j2$') }}"
   no_log: "{{ hide_passwords_during_deploy }}"
   with_fileglob:
     - "{{ role_path }}/templates/ingest/*"

--- a/deployment/roles/init_ingest_app_bdd/templates/ingest/01_ingest.js.j2
+++ b/deployment/roles/init_ingest_app_bdd/templates/ingest/01_ingest.js.j2
@@ -128,7 +128,7 @@ db.certificates.remove(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/roles/init_ingest_app_bdd/templates/ingest/01_ingest.js.j2
+++ b/deployment/roles/init_ingest_app_bdd/templates/ingest/01_ingest.js.j2
@@ -124,7 +124,7 @@ db.contexts.updateOne(
 
 
 {% macro insertCertififcate(pemFile, contextId) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/roles/init_ingest_app_bdd/templates/ingest/01_ingest.js.j2
+++ b/deployment/roles/init_ingest_app_bdd/templates/ingest/01_ingest.js.j2
@@ -10,7 +10,7 @@ db = db.getSiblingDB('{{ mongodb.iam.db }}')
 
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
-db.profiles.update(
+db.profiles.updateOne(
     { "_id" : "system_ingest_profile" },
     {
         "$set" : {
@@ -70,7 +70,7 @@ db.groups.updateOne(
 // ====================================== APPLICATIONS ======================================
 
 
-db.applications.update(
+db.applications.updateOne(
     { "identifier" : "INGEST_MANAGEMENT_APP" },
     {
         "$set" : {
@@ -104,7 +104,7 @@ db = db.getSiblingDB('{{ mongodb.security.db }}')
 
 print("INFO 01_ingest.js : START security update");
 
-db.contexts.update(
+db.contexts.updateOne(
     { "_id" : "ui_ingest_context" },
     {
         "$set" : {
@@ -149,7 +149,7 @@ print("INFO 01_ingest.js : START cas database update");
 db = db.getSiblingDB('{{ mongodb.cas.db }}')
 
 
-db.services.update(
+db.services.updateOne(
     { "_id" :  NumberInt(4) },
     {
         "$set" : {

--- a/deployment/roles/mongo/tasks/check_auth.yml
+++ b/deployment/roles/mongo/tasks/check_auth.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check if authent is enabled
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+  command: "mongosh {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
   register: mongo_authent_enabled
   failed_when: false
   no_log: "{{ hide_passwords_during_deploy }}"
@@ -27,7 +27,7 @@
 # When authentication is required, we set mongodb admin credentials
 - name: Set mongodb authentication credentials
   set_fact:
-    mongo_credentials: " -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet"
+    mongo_credentials: "-u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }}"
   when: "mongo_authent_enabled.rc == 0"
   no_log: "{{ hide_passwords_during_deploy }}"
 

--- a/deployment/roles/mongo/tasks/main.yml
+++ b/deployment/roles/mongo/tasks/main.yml
@@ -176,7 +176,7 @@
     #     - update_mongodb_configuration
 
     - name: Initiate the replica set
-      command: "mongo --host {{ ip_service }} --port {{ mongodb.mongod_port }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/init-replica.js"
+      command: "mongosh --host {{ ip_service }} --port {{ mongodb.mongod_port }} --quiet --file {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/init-replica.js"
       tags:
         - update_mongodb_configuration
 
@@ -194,7 +194,7 @@
         - update_mongodb_configuration
 
     - name: Create the local shard user
-      command: "mongo --host {{ ip_service }}:{{ mongodb.mongod_port }} {{ mongo_credentials }} {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/local-user.js"
+      command: "mongosh --host {{ ip_service }} --port {{ mongodb.mongod_port }} {{ mongo_credentials }} --quiet --file {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/local-user.js"
       tags:
         - update_mongodb_configuration
 

--- a/deployment/roles/mongo/templates/init-replica.js.j2
+++ b/deployment/roles/mongo/templates/init-replica.js.j2
@@ -11,7 +11,15 @@ function checkExistingReplicaSet() {
 
     try {
         var rsStatus = rs.status();
+
+        if (!rsStatus.ok) {
+            printjson(rsStatus);
+            throw "ERROR : Cannot check mongod replica set status";
+        }
+
         print("INFO : Exiting mongod replica set found");
+        return true;
+
     } catch (error) {
         if (error.message && error.message.includes("no replset config has been received")) {
             print("INFO : No mongod replica set found");
@@ -21,8 +29,6 @@ function checkExistingReplicaSet() {
         print("ERROR : Cannot check mongod replica set status");
         throw error;
     }
-
-    return true;
 }
 
 function checkExistingReplicaSetMembers() {
@@ -42,16 +48,11 @@ function checkExistingReplicaSetMembers() {
             }
         }
 
-        if (targetMembers.length != rsConfigMembers.length) {
+        if (targetMembers.length !== rsConfigMembers.length) {
             printjson(rsConfig);
             throw "ERROR : Found unexpected / unknown mongod ReplicaSet members";
         }
     } catch (error) {
-        if (error.message && error.message.includes("no replset config has been received")) {
-            print("INFO : No mongod replica set configuration found");
-            return false;
-        }
-
         print("ERROR : Cannot check mongod replica set members");
         throw error;
     }
@@ -61,7 +62,7 @@ function buildTargetReplicaSetMemberConfiguration() {
     var idCpt = 0;
     let members = [ { _id: idCpt++, host: "{{ ip_service }}:{{ mongodb.mongod_port }}" } ];
 {% for host in groups['hosts_vitamui_mongod'] %}
-    {% if hostvars[host]['mongo_rs_bootstrap'] is not defined or hostvars[host]['mongo_rs_bootstrap']|lower != "true" %}
+    {% if hostvars[host]['mongo_rs_bootstrap'] is not defined or hostvars[host]['mongo_rs_bootstrap'] | lower != "true" %}
     members.push({
         _id: idCpt++,
         host: "{{ hostvars[host]['ip_service'] }}:{{ mongodb.mongod_port }}"
@@ -82,7 +83,7 @@ function initReplicaSetPrimary() {
         }
     )
 
-    if(!rsInit.ok) {
+    if (!rsInit.ok) {
         printjson(rsInit);
         throw "ERROR : Cannot initialize mongod replica set";
     }
@@ -95,12 +96,12 @@ function waitForReplicaSetPrimaryElection() {
 
         status = rs.status();
 
-        if(!status.ok) {
+        if (!status.ok) {
             printjson(status);
             throw "ERROR : Cannot get mongod replica set status";
         }
 
-        if(status.myState === 1) {
+        if (status.myState === 1) {
             print("OK : mongod replica set elected primary node");
             return;
         }
@@ -120,12 +121,12 @@ function waitForWritablePrimary() {
 
         instanceStatus = db.hello();
 
-        if(!instanceStatus.ok) {
+        if (!instanceStatus.ok) {
             printjson(instanceStatus);
             throw "ERROR : Cannot get db instance status";
         }
 
-        if(instanceStatus.isWritablePrimary) {
+        if (instanceStatus.isWritablePrimary) {
             print("OK : Primary node is writable");
             return;
         }
@@ -138,7 +139,7 @@ function waitForWritablePrimary() {
     throw "ERROR : Timeout - NO PRIMARY NODE FOUND";
 }
 
-if(checkExistingReplicaSet()) {
+if (checkExistingReplicaSet()) {
     checkExistingReplicaSetMembers();
     print("INFO : mongod replica set already configured.");
 } else {

--- a/deployment/roles/mongo/templates/init-replica.js.j2
+++ b/deployment/roles/mongo/templates/init-replica.js.j2
@@ -9,44 +9,51 @@
 
 function checkExistingReplicaSet() {
 
-    var rsStatus = rs.status();
-
-    if(!rsStatus.ok) {
-
-        if(rsStatus.codeName === "NotYetInitialized") {
+    try {
+        var rsStatus = rs.status();
+        print("INFO : Exiting mongod replica set found");
+    } catch (error) {
+        if (error.message && error.message.includes("no replset config has been received")) {
             print("INFO : No mongod replica set found");
             return false;
         }
 
-        printjson(rsStatus);
-        throw "ERROR : Cannot check mongod replica set status";
+        print("ERROR : Cannot check mongod replica set status");
+        throw error;
     }
-
-    print("INFO : Exiting mongod replica set found");
 
     return true;
 }
 
 function checkExistingReplicaSetMembers() {
+    try {
+        var rsConfig = rs.config();
 
-    var rsConfig = rs.config();
+        let targetMembers = buildTargetReplicaSetMemberConfiguration();
+        let rsConfigMembers = rsConfig.members;
 
-    let targetMembers = buildTargetReplicaSetMemberConfiguration();
-    let rsConfigMembers = rsConfig.members;
-
-    for (const targetMember of targetMembers) {
-        let rsConfigMember = rsConfigMembers.find(member => member.host === targetMember.host);
-        if(rsConfigMember) {
-            print("INFO : host " + targetMember.host + " found in mongod replica set");
-        } else {
-            printjson(rsConfig);
-            throw "ERROR : Host " + targetMember.host + " not found in mongod replica set";
+        for (const targetMember of targetMembers) {
+            let rsConfigMember = rsConfigMembers.find(member => member.host === targetMember.host);
+            if (rsConfigMember) {
+                print("INFO : host " + targetMember.host + " found in mongod replica set");
+            } else {
+                printjson(rsConfig);
+                throw "ERROR : Host " + targetMember.host + " not found in mongod replica set";
+            }
         }
-    }
 
-    if(targetMembers.length != rsConfigMembers.length) {
-        printjson(rsConfig);
-        throw "ERROR : Found unexpected / unknown mongod ReplicaSet members";
+        if (targetMembers.length != rsConfigMembers.length) {
+            printjson(rsConfig);
+            throw "ERROR : Found unexpected / unknown mongod ReplicaSet members";
+        }
+    } catch (error) {
+        if (error.message && error.message.includes("no replset config has been received")) {
+            print("INFO : No mongod replica set configuration found");
+            return false;
+        }
+
+        print("ERROR : Cannot check mongod replica set members");
+        throw error;
     }
 }
 

--- a/deployment/roles/mongo_backup/tasks/backup_collection.yml
+++ b/deployment/roles/mongo_backup/tasks/backup_collection.yml
@@ -1,11 +1,10 @@
 ---
 
-- name: mongo dump collection 
-  command: "mongodump --host  {{ ip_service }} --db {{db}} --collection {{inner_item}} {{mongo_credentials}} --gzip --out {{mongo_dump_folder}}"
-  with_items: 
+- name: mongo dump collection
+  command: "mongodump --host {{ ip_service }} --db {{db}} --collection {{inner_item}} {{mongo_credentials}} --gzip --out {{mongo_dump_folder}}"
+  with_items:
   - "{{collections}}"
   loop_control:
     loop_var: inner_item
-  no_log: "{{ hide_passwords_during_deploy }}" 
+  no_log: "{{ hide_passwords_during_deploy }}"
   ignore_errors: yes
-  

--- a/deployment/roles/mongo_backup/tasks/backup_db.yml
+++ b/deployment/roles/mongo_backup/tasks/backup_db.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: "mongo dump db ({{db}})"
-  command: "mongodump --host  {{ ip_service }} --db {{db}} {{mongo_credentials}} --gzip --out {{mongo_dump_folder}}"
-  no_log: "{{ hide_passwords_during_deploy }}" 
+  command: "mongodump --host {{ ip_service }} --db {{db}} {{mongo_credentials}} --gzip --out {{mongo_dump_folder}}"
+  no_log: "{{ hide_passwords_during_deploy }}"
   ignore_errors: yes

--- a/deployment/roles/mongo_common/tasks/main.yml
+++ b/deployment/roles/mongo_common/tasks/main.yml
@@ -3,7 +3,6 @@
 - name: Install common mongodb packages
   package:
     name:
-      - mongodb-org-shell
       - mongodb-mongosh
       - mongodb-database-tools
     state: present

--- a/deployment/roles/mongo_configure/tasks/main.yml
+++ b/deployment/roles/mongo_configure/tasks/main.yml
@@ -1,37 +1,25 @@
 ---
 
-- name: Check if authent is enabled
-  command: "mongo {{ ip_service }}:{{ mongodb.mongod_port }}/admin -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+- name: Set mongo connection & credentials
+  set_fact:
+    mongo_connection: "--host {{ ip_service }} --port {{ mongodb.mongod_port }} --quiet"
+    mongo_credentials: "-u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }}"
+  no_log: "{{ hide_passwords_during_deploy }}"
+  tags: update_mongodb_configuration
+
+# Detect if authentication is enabled
+- name: Verify if authent is enabled
+  command: "mongosh {{ mongo_connection }} {{ mongo_credentials }} --eval 'db.help();'"
   register: mongo_authent_enabled
   failed_when: false
   no_log: "{{ hide_passwords_during_deploy }}"
-  tags:
-    - update_mongodb_configuration
+  tags: update_mongodb_configuration
 
-# Set mongo_no_auth facts
-
-- name: Set default mongo facts
+- name: Disable mongo credentials as authent is not enabled
   set_fact:
     mongo_credentials: ""
-    mongo_no_auth: false
-  tags:
-    - update_mongodb_configuration
-
-- name: Set mongo_no_auth fact to true
-  set_fact:
-    mongo_no_auth: true
-  when: "mongo_authent_enabled.rc != 0"
-  tags:
-    - update_mongodb_configuration
-
-# When authentication is required, we set mongodb admin credentials
-- name: Set mongodb authentication credentials
-  set_fact:
-    mongo_credentials: " -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet"
-  when: "mongo_authent_enabled.rc == 0"
-  no_log: "{{ hide_passwords_during_deploy }}"
-  tags:
-    - update_mongodb_configuration
+  when: mongo_authent_enabled.rc != 0
+  tags: update_mongodb_configuration
 
 # Activate security on mongo instances
 - name: Activate security on mongod instances
@@ -43,8 +31,7 @@
         authorization: enabled
         clusterAuthMode: keyFile
         keyFile: "{{ mongod_config_path }}/keyfile"
-  tags:
-    - update_mongodb_configuration
+  tags: update_mongodb_configuration
 
 # Restart the mongo instances (to enable auth)
 - name: "restart {{ mongodb.service_name | default('vitamui-mongod') }} service"
@@ -54,14 +41,12 @@
     state: restarted
   delegate_to: "{{ item }}"
   with_items: "{{ groups['hosts_vitamui_mongod'] }}"
-  tags:
-    - update_mongodb_configuration
+  tags: update_mongodb_configuration
 
-# Make sure the service is open (mongos listening on 27017)
+# Make sure the service is open (mongod listening on 27017)
 - name: "Wait for the service port {{ mongodb.mongod_port }} to be open"
   wait_for:
     host: "{{ ip_service }}"
     port: "{{ mongodb.mongod_port }}"
     timeout: "{{ vitamui_defaults.services.start_timeout }}"
-  tags:
-    - update_mongodb_configuration
+  tags: update_mongodb_configuration

--- a/deployment/roles/mongo_init/tasks/check_auth.yml
+++ b/deployment/roles/mongo_init/tasks/check_auth.yml
@@ -7,7 +7,7 @@
 
 - block:
     - name: Check if authent is enabled
-      command: "mongo --host mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+      command: "mongosh --host \"mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }}\" -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
       register: mongo_authent_enabled
       failed_when: false
       no_log: "{{ hide_passwords_during_deploy }}"
@@ -20,7 +20,7 @@
 
 - block:
     - name: Load script in database (docker)
-      shell: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongo --host mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'\""
+      shell: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh --host mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'\""
 
       failed_when: false
       register: mongo_authent_enabled

--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -94,12 +94,12 @@
     mode: 0755
 
 - name: Load script in database
-  shell: "mongo \"mongodb://{{ mongod_uri }}/admin\" {{ mongo_credentials }} {{ mongod_output_dir_entry_point }}/main_script.js"
+  shell: "mongosh \"mongodb://{{ mongod_uri }}/admin\" {{ mongo_credentials }} --quiet --file {{ mongod_output_dir_entry_point }}/main_script.js"
 #  no_log: "{{ hide_passwords_during_deploy }}"
   when: mongodb.docker is not defined or not mongodb.docker.enable
 
 - name: Load script in database test (docker)
-  command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongo \\\"mongodb://{{ mongod_uri }}/admin\\\" {{ mongo_credentials }} {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js \""
+  command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh \\\"mongodb://{{ mongod_uri }}/admin\\\" {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js \""
   #no_log: "{{ hide_passwords_during_deploy }}"
   when: mongodb.docker is defined and mongodb.docker.enable
 

--- a/deployment/roles/mongo_restore/tasks/restore_collection.yml
+++ b/deployment/roles/mongo_restore/tasks/restore_collection.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Restore each collection for {{db}}
-  command: "mongorestore --host  {{ ip_service }} --db {{db}} --collection {{inner_item}} {{mongo_credentials}} --gzip {{mongo_dump_folder}}/{{db}}/{{inner_item}}.bson.gz"
+  command: "mongorestore --host {{ ip_service }} --db {{db}} --collection {{inner_item}} {{mongo_credentials}} --gzip {{mongo_dump_folder}}/{{db}}/{{inner_item}}.bson.gz"
   with_items: "{{collections}}"
   loop_control:
     loop_var: inner_item

--- a/deployment/roles/mongodb_check_feature_compatibility/tasks/main.yml
+++ b/deployment/roles/mongodb_check_feature_compatibility/tasks/main.yml
@@ -1,5 +1,15 @@
 ---
 
+- name: Ensure mongosh package is present
+  package:
+    name:
+      - mongodb-mongosh
+    state: present
+  register: result
+  retries: "{{ packages_install_retries_number }}"
+  until: result is succeeded
+  delay: "{{ packages_install_retries_delay }}"
+
 - name: Copy check_compatibility_version database script
   template:
     src: check_compatibility_version.js.j2

--- a/deployment/roles/mongodb_check_feature_compatibility/tasks/main.yml
+++ b/deployment/roles/mongodb_check_feature_compatibility/tasks/main.yml
@@ -9,7 +9,7 @@
     mode: "{{ vitamui_defaults.folder.conf_permission }}"
 
 - name: "Check compatibility version with mongo {{ mongo_compatibility_list }}"
-  shell: "mongo {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet < {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/check_compatibility_version.js"
+  command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/check_compatibility_version.js"
   no_log: "{{ hide_passwords_during_deploy }}"
   ignore_errors: true # To properly catch output on the next task
   register: output_compatibility_version

--- a/deployment/roles/mongodb_check_replica_state/tasks/main.yml
+++ b/deployment/roles/mongodb_check_replica_state/tasks/main.yml
@@ -9,7 +9,7 @@
     mode: "{{ vitamui_defaults.folder.conf_permission }}"
 
 - name: Check replica state
-  shell: "mongo {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet < {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/check_replica_state.js"
+  command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/check_replica_state.js"
   no_log: "{{ hide_passwords_during_deploy }}"
   ignore_errors: true # To properly catch output on the next task
   register: output_replica_state

--- a/deployment/roles/mongodb_migration_v5/files/is_master.js
+++ b/deployment/roles/mongodb_migration_v5/files/is_master.js
@@ -1,3 +1,0 @@
-// https://www.mongodb.com/docs/v4.2/reference/command/isMaster/#output
-
-rs.isMaster().ismaster

--- a/deployment/roles/mongodb_migration_v5/tasks/reconfig.yml
+++ b/deployment/roles/mongodb_migration_v5/tasks/reconfig.yml
@@ -1,15 +1,8 @@
 ---
 
-- name: Copy is_master database script
-  copy:
-    src: is_master.js
-    dest: "{{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}"
-    owner: "{{ vitamui_defaults.users.vitamuidb }}"
-    group: "{{ vitamui_defaults.users.group }}"
-    mode: "{{ vitamui_defaults.folder.conf_permission }}"
-
+# https://www.mongodb.com/docs/v4.2/reference/command/isMaster/#output
 - name: Check if the member is primary of the replicaset or not
-  shell: "mongo {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet < {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/is_master.js"
+  command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --eval 'rs.isMaster().ismaster'"
   register: primary_test_command
   no_log: "{{ hide_passwords_during_deploy }}"
 
@@ -23,8 +16,7 @@
   when: primary_test_command.stdout == 'true'
 
 - name: "Reconfigure replicaset for {{ mongo_type }}"
-  shell: "mongo --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet < {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/script/{{ mongo_type }}/reconfig.js"
+  command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/script/{{ mongo_type }}/reconfig.js"
   no_log: "{{ hide_passwords_during_deploy }}"
   when:
-    - mongo_type == 'mongod'
     - primary_test_command.stdout == 'true'

--- a/deployment/roles/mongodb_set_feature_compatibility/tasks/main.yml
+++ b/deployment/roles/mongodb_set_feature_compatibility/tasks/main.yml
@@ -9,5 +9,5 @@
     mode: "{{ vitamui_defaults.folder.conf_permission | default('0440') }}"
 
 - name: "Set_feature_compatibility to {{ mongo_version }}"
-  shell: "mongo {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet < {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/script/mongod/set_feature_compatibility.js"
+  command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/script/mongod/set_feature_compatibility.js"
   no_log: "{{ hide_passwords_during_deploy }}"

--- a/deployment/roles/mongodb_set_feature_compatibility/tasks/main.yml
+++ b/deployment/roles/mongodb_set_feature_compatibility/tasks/main.yml
@@ -1,5 +1,15 @@
 ---
 
+- name: Ensure mongosh package is present
+  package:
+    name:
+      - mongodb-mongosh
+    state: present
+  register: result
+  retries: "{{ packages_install_retries_number }}"
+  until: result is succeeded
+  delay: "{{ packages_install_retries_delay }}"
+
 - name: Copy set_feature_compatibility database script
   template:
     src: set_feature_compatibility.js.j2

--- a/deployment/roles/mongodb_set_feature_compatibility/templates/set_feature_compatibility.js.j2
+++ b/deployment/roles/mongodb_set_feature_compatibility/templates/set_feature_compatibility.js.j2
@@ -1,3 +1,3 @@
 // https://www.mongodb.com/docs/manual/reference/command/setFeatureCompatibilityVersion/
 
-db.adminCommand( { setFeatureCompatibilityVersion: "{{ mongo_version }}" } )
+db.adminCommand( { setFeatureCompatibilityVersion: "{{ mongo_version }}"{% if mongo_version >= 7.0 %}, confirm: true{% endif %} } )

--- a/deployment/roles/mongodb_set_members_groups/files/is_master.js
+++ b/deployment/roles/mongodb_set_members_groups/files/is_master.js
@@ -1,3 +1,0 @@
-// https://www.mongodb.com/docs/v4.2/reference/command/isMaster/#output
-
-rs.isMaster().ismaster

--- a/deployment/roles/mongodb_set_members_groups/tasks/main.yml
+++ b/deployment/roles/mongodb_set_members_groups/tasks/main.yml
@@ -1,15 +1,8 @@
 ---
 
-- name: Copy is_master database script
-  copy:
-    src: is_master.js
-    dest: "{{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}"
-    owner: "{{ vitamui_defaults.users.vitamuidb }}"
-    group: "{{ vitamui_defaults.users.group }}"
-    mode: "{{ vitamui_defaults.folder.conf_permission }}"
-
+# https://www.mongodb.com/docs/v4.2/reference/command/isMaster/#output
 - name: Check if the member is primary of the replicaset or not
-  shell: "mongo {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet < {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/is_master.js"
+  command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --eval 'rs.isMaster().ismaster'"
   register: primary_test_command
   no_log: "{{ hide_passwords_during_deploy }}"
 

--- a/deployment/roles/mongodb_upgrade_package/files/shutdown.js
+++ b/deployment/roles/mongodb_upgrade_package/files/shutdown.js
@@ -1,1 +1,4 @@
-db.adminCommand( { shutdown: 1 } );
+// https://www.mongodb.com/docs/v5.0/tutorial/manage-mongodb-processes/#use-shutdownserver--
+
+db = db.getSiblingDB('admin');
+db.shutdownServer();

--- a/deployment/roles/mongodb_upgrade_package/files/step_down.js
+++ b/deployment/roles/mongodb_upgrade_package/files/step_down.js
@@ -1,3 +1,0 @@
-// https://www.mongodb.com/docs/manual/reference/method/rs.stepDown/
-
-rs.stepDown()

--- a/deployment/roles/mongodb_upgrade_package/tasks/main.yml
+++ b/deployment/roles/mongodb_upgrade_package/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Remove deprecated mongodb packages
   package:
     name:
+      - mongodb-org-shell
       - mongodb-org-tools
       - mongodb-org-database-tools-extra
     state: absent

--- a/deployment/roles/mongodb_upgrade_package/tasks/update_packages_mongod.yml
+++ b/deployment/roles/mongodb_upgrade_package/tasks/update_packages_mongod.yml
@@ -42,6 +42,11 @@
     no_log: "{{ hide_passwords_during_deploy }}"
     ignore_errors: true # as we are brutally disconnected by the server (because of shutdown)
 
+  - name: Workaround to manually force shutdown as services are set to Restart=always
+    systemd:
+      name: "{{ mongodb.service_name | default('vitamui-mongod') }}"
+      state: stopped
+
   # Upgrade the package
   - name: "Update mongodb packages ({{ mongo_version }})"
     yum:

--- a/deployment/roles/mongodb_upgrade_package/tasks/update_packages_mongod.yml
+++ b/deployment/roles/mongodb_upgrade_package/tasks/update_packages_mongod.yml
@@ -11,19 +11,19 @@
       mode: "{{ vitamui_defaults.folder.conf_permission }}"
     with_items:
       - shutdown.js
-      - step_down.js
       - wait_until_proper_node_state.js
       - wait_until_not_master.js
 
   # Elect a new primary member (if we are the primary and if there is more than 1 node)
   - block:
+    # https://www.mongodb.com/docs/manual/reference/method/rs.stepDown/
     - name: Step down the member (elect a new primary member)
-      shell: "mongosh {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/step_down.js"
+      command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --eval 'rs.stepDown();'"
       no_log: "{{ hide_passwords_during_deploy }}"
       ignore_errors: true # as we are brutally disconnected by the server (because reboot)
 
     - name: Wait until this member is not primary anymore
-      shell: "mongosh {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script//{{ mongo_type }}/wait_until_not_master.js"
+      command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script//{{ mongo_type }}/wait_until_not_master.js"
       no_log: "{{ hide_passwords_during_deploy }}"
       ignore_errors: true # To properly catch output on the next task
       register: output_not_master
@@ -38,7 +38,7 @@
       - groups['hosts_vitamui_mongod'] | length > 1
 
   - name: Graceful shutdown of node
-    shell: "mongosh {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/shutdown.js"
+    command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/shutdown.js"
     no_log: "{{ hide_passwords_during_deploy }}"
     ignore_errors: true # as we are brutally disconnected by the server (because of shutdown)
 
@@ -47,27 +47,25 @@
     yum:
       name:
         - "mongodb-org-server-{{ mongo_version }}"
-        - "mongodb-org-shell-{{ mongo_version }}"
       state: present
       update_cache: yes   # make sure cache is up to date for upgrade
     register: result
     retries: "{{ packages_install_retries_number }}"
     until: result is succeeded
     delay: "{{ packages_install_retries_delay }}"
-    when: ansible_distribution == "CentOS"
+    when: ansible_os_family == "RedHat"
 
   - name: "Update mongodb packages ({{ mongo_version }})"
     apt:
       name:
         - "mongodb-org-server={{ mongo_version }}"
-        - "mongodb-org-shell={{ mongo_version }}"
       state: present
       update_cache: yes   # make sure cache is up to date for upgrade
     register: result
     retries: "{{ packages_install_retries_number }}"
     until: result is succeeded
     delay: "{{ packages_install_retries_delay }}"
-    when: ansible_distribution == "Debian"
+    when: ansible_os_family == "Debian"
 
   - name: Disable default mongodb service
     systemd:
@@ -89,7 +87,7 @@
       timeout: "{{ vitamui_defaults.services.start_timeout }}"
 
   - name: Wait for node to join the cluster and reach "secondary" or "primary" status
-    shell: "mongosh {{ ip_service }}:{{ mongo_port }}/admin -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/wait_until_proper_node_state.js"
+    command: "mongosh --host {{ ip_service }} --port {{ mongo_port }} -u {{ mongodb.localadmin.user }} -p {{ mongodb.localadmin.password }} --quiet --file {{ vitamui_defaults.folder.root_path }}/script/{{ mongo_type }}/wait_until_proper_node_state.js"
     no_log: "{{ hide_passwords_during_deploy }}"
     ignore_errors: true # To properly catch output on the next task
     register: output_node_state

--- a/deployment/scripts/mongod/1.0.0/01_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/01_iam_ref.js.j2
@@ -16,7 +16,7 @@ db.createCollection('operations');
 
 // ========================================= CUSTOMERS =========================================
 
-db.customers.insert({
+db.customers.insertOne({
   "_id": "system_customer",
   "code": "000000",
   "identifier" : NumberInt(1),
@@ -48,7 +48,7 @@ db.customers.insert({
 
 // ========================================= OWNERS =========================================
 
-db.owners.insert({
+db.owners.insertOne({
   "_id": "system_owner",
   "identifier" : NumberInt(1),
   "enabled": true,
@@ -65,7 +65,7 @@ db.owners.insert({
   }
 });
 
-db.owners.insert({
+db.owners.insertOne({
   "_id": "system_owner_cas",
   "identifier" : NumberInt(2),
   "enabled": true,
@@ -84,7 +84,7 @@ db.owners.insert({
 
 // ========================================= PROVIDERS =========================================
 
-db.providers.insert({
+db.providers.insertOne({
   "_id": "system_idp",
   "identifier" : NumberInt(1),
   "code": "000002",
@@ -105,43 +105,43 @@ db.providers.insert({
 
 // ========================================= SEQUENCES =========================================
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "tenant_identifier",
   "name": "tenantIdentifier",
   "sequence": NumberInt({{ vitamui_platform_informations.first_customer_tenant }})
 });
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "user_identifier",
   "name": "userIdentifier",
   "sequence": NumberInt(100)
 });
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "profile_identifier",
   "name": "profileIdentifier",
   "sequence": NumberInt(200)
 });
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "group_identifier",
   "name": "groupIdentifier",
   "sequence": NumberInt(100)
 });
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "provider_identifier",
   "name": "providerIdentifier",
   "sequence": NumberInt(50)
 });
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "customer_identifier",
   "name": "customerIdentifier",
   "sequence": NumberInt(10)
 });
 
-db.sequences.insert({
+db.sequences.insertOne({
   "_id": "owner_identifier",
   "name": "ownerIdentifier",
   "sequence": NumberInt(50)
@@ -149,7 +149,7 @@ db.sequences.insert({
 
 // ========================================= TENANTS =========================================
 
-db.tenants.insert({
+db.tenants.insertOne({
   "_id": "system_tenant",
   "name": "Tenant système",
   "proof": true,
@@ -164,7 +164,7 @@ db.tenants.insert({
   "accessContractLogbookIdentifier" : "AC-000002"
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
   "_id": "cas_tenant",
   "name": "Tenant CAS",
   "enabled": true,
@@ -179,7 +179,7 @@ db.tenants.insert({
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_user_profile",
   "identifier" : NumberInt(1),
   "name": "User Profile",
@@ -217,7 +217,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_group_profile",
   "identifier" : NumberInt(2),
   "name": "Group Profile",
@@ -249,7 +249,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_profile_profile",
   "identifier" : NumberInt(3),
   "name": "Profile System",
@@ -278,7 +278,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_customer_profile",
   "identifier" : NumberInt(4),
   "name": "Customer Profile",
@@ -355,7 +355,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_surrogate_profile",
   "identifier" : NumberInt(5),
   "name": "Surrogate Profile",
@@ -388,7 +388,7 @@ db.profiles.insert({
 });
 
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_account_profile",
   "identifier" : NumberInt(13),
   "name": "Account Profile",
@@ -406,7 +406,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_hierarchy_profile",
   "identifier" : NumberInt(17),
   "name": "Hierarchy profile",
@@ -435,7 +435,7 @@ db.profiles.insert({
 
 // ----------------------------------------- LEVEL "CAS" -----------------------------------------
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "cas_profile",
   "identifier" : NumberInt(25),
   "name": "Cas Profile",
@@ -479,7 +479,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "cas_system_profile",
   "identifier" : NumberInt(26),
   "name": "Cas System Profile",
@@ -497,7 +497,7 @@ db.profiles.insert({
 
 // ----------------------------------------- LEVEL "SUPPORT" -----------------------------------------
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_account_profile_support",
   "identifier" : NumberInt(28),
   "name": "Account Profile Support",
@@ -515,7 +515,7 @@ db.profiles.insert({
   ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_surrogate_profile_support",
   "identifier" : NumberInt(32),
   "name": "Surrogate Profile Support",
@@ -551,7 +551,7 @@ db.profiles.insert({
 
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
-db.groups.insert({
+db.groups.insertOne({
   "_id": "admin_group",
   "identifier" : NumberInt(1),
   "name": "Groupe de l'administrateur VitamUI",
@@ -569,7 +569,7 @@ db.groups.insert({
   "customerId": "system_customer"
 });
 
-db.groups.insert({
+db.groups.insertOne({
   "_id": "super_admin_group",
   "identifier" : NumberInt(2),
   "name": "Groupe de l'adminstrateur de l'instance",
@@ -587,7 +587,7 @@ db.groups.insert({
 
 // ----------------------------------------- LEVEL "SUPPORT" -----------------------------------------
 
-db.groups.insert({
+db.groups.insertOne({
   "_id": "support_group",
   "identifier" : NumberInt(4),
   "name": "Groupe de l'utilisateur support",
@@ -604,7 +604,7 @@ db.groups.insert({
 
 // ----------------------------------------- LEVEL "CAS" -----------------------------------------
 
-db.groups.insert({
+db.groups.insertOne({
   "_id": "cas_group",
   "identifier" : NumberInt(5),
   "name": "Groupe d'accès à IAM",
@@ -623,7 +623,7 @@ db.groups.insert({
 
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
-db.users.insert({
+db.users.insertOne({
   "_id": "admin_user",
   "level": "",
   "enabled": true,
@@ -648,7 +648,7 @@ db.users.insert({
   "passwordExpirationDate": "2050-01-09T00:00:00.000+01:00"
 });
 
-db.users.insert({
+db.users.insertOne({
   "_id": "superadmin_user",
   "level": "",
   "enabled": true,
@@ -675,7 +675,7 @@ db.users.insert({
 
 // ----------------------------------------- LEVEL "SUPPORT" -----------------------------------------
 
-db.users.insert({
+db.users.insertOne({
   "_id": "support_user",
   "level": "SUPPORT",
   "enabled": true,
@@ -702,7 +702,7 @@ db.users.insert({
 
 // ----------------------------------------- LEVEL "CAS" -----------------------------------------
 
-db.users.insert({
+db.users.insertOne({
   "_id": "casuser",
   "level": "",
   "enabled": true,
@@ -729,7 +729,7 @@ db.users.insert({
 
 // ========================================= TOKENS =========================================
 
-db.tokens.insert({
+db.tokens.insertOne({
   "_id": "tokcas_ie6UZsEcHIWrfv2x",
   "updatedDate": "May 15, 2008 6:30:58 PM",
   "refId": "casuser"

--- a/deployment/scripts/mongod/1.0.0/01_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/01_iam_ref.js.j2
@@ -2,15 +2,15 @@ db = db.getSiblingDB('iam')
 
 print("START 01_iam_ref.js");
 
-db.users.remove({});
-db.groups.remove({});
-db.profiles.remove({});
-db.tenants.remove({});
-db.providers.remove({});
-db.owners.remove({});
-db.customers.remove({});
-db.sequences.remove({});
-db.tokens.remove({});
+db.users.deleteMany({});
+db.groups.deleteMany({});
+db.profiles.deleteMany({});
+db.tenants.deleteMany({});
+db.providers.deleteMany({});
+db.owners.deleteMany({});
+db.customers.deleteMany({});
+db.sequences.deleteMany({});
+db.tokens.deleteMany({});
 db.createCollection('events');
 db.createCollection('operations');
 

--- a/deployment/scripts/mongod/1.0.0/02_security_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/02_security_ref.js.j2
@@ -5,7 +5,7 @@ print("START 02_security_ref.js");
 db.contexts.remove({});
 db.createCollection('events');
 
-db.contexts.insert({
+db.contexts.insertOne({
   "_id": "cas_context",
   "name": "Contexte CAS",
   "fullAccess": false,
@@ -13,7 +13,7 @@ db.contexts.insert({
   "roleNames": ["ROLE_CAS_LOGIN", "ROLE_CAS_CHANGE_PASSWORD", "ROLE_CAS_USERS", "ROLE_CAS_SUBROGATIONS", "ROLE_CAS_LOGOUT", "ROLE_GET_PROVIDERS", "ROLE_GET_USERS"]
 });
 
-db.contexts.insert({
+db.contexts.insertOne({
   "_id" : "ui_portal_context",
   "name": "Contexte UI Portal",
   "fullAccess" : true,
@@ -21,7 +21,7 @@ db.contexts.insert({
   "roleNames" : []
 });
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_identity_context",
     "name": "Contexte UI Identity",
     "fullAccess" : true,
@@ -34,7 +34,7 @@ db.contexts.insert({
     ]
 });
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_admin_identity_context",
     "name": "Contexte UI Identity",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/1.0.0/02_security_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/02_security_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('security')
 
 print("START 02_security_ref.js");
 
-db.contexts.remove({});
+db.contexts.deleteMany({});
 db.createCollection('events');
 
 db.contexts.insertOne({

--- a/deployment/scripts/mongod/1.0.0/03_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/03_application_ref.js.j2
@@ -1,6 +1,6 @@
 db = db.getSiblingDB('{{ mongodb.iam.db }}')
 
-db.applications.remove({});
+db.applications.deleteMany({});
 
 db.applications.insertOne({
     "identifier" : "CUSTOMERS_APP",

--- a/deployment/scripts/mongod/1.0.0/03_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/03_application_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('{{ mongodb.iam.db }}')
 
 db.applications.remove({});
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "CUSTOMERS_APP",
 {% if vitamui.identity_admin.base_url is defined %}
 	"url": "{{ vitamui.identity_admin.base_url }}/customer",
@@ -20,7 +20,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "USERS_APP",
 {% if vitamui.identity.base_url is defined %}
 	"url": "{{ vitamui.identity.base_url }}/user",
@@ -38,7 +38,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "GROUPS_APP",
 {% if vitamui.identity.base_url is defined %}
 	"url": "{{ vitamui.identity.base_url }}/group",
@@ -56,7 +56,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "PROFILES_APP",
 {% if vitamui.identity.base_url is defined %}
 	"url": "{{ vitamui.identity.base_url }}/profile",
@@ -74,7 +74,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "SUBROGATIONS_APP",
 {% if vitamui.identity_admin.base_url is defined %}
 	"url": "{{ vitamui.identity_admin.base_url }}/subrogation",
@@ -92,7 +92,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "HIERARCHY_PROFILE_APP",
 {% if vitamui.identity.base_url is defined %}
     "url": "{{ vitamui.identity.base_url }}/profile-hierarchy",
@@ -110,7 +110,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "ACCOUNTS_APP",
     "url": "{{ vitamui.portal.base_url|default(url_prefix) }}/account",
     "icon": "vitamui-icon vitamui-icon-user",

--- a/deployment/scripts/mongod/1.0.0/04_cas_services_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/04_cas_services_ref.js.j2
@@ -3,7 +3,7 @@ db = db.getSiblingDB('{{ mongodb.cas.db }}')
 print("START cas_services_ref.js");
 
 // Added a Z in the Name to ensure the regex is used last because CAS order them by 'Name' field
-db.services.insert({
+db.services.insertOne({
 	"_id": NumberInt(1),
 	"_class": "org.apereo.cas.services.RegexRegisteredService",
 	"serviceId": "^{{ vitamui.portal.base_url|default(url_prefix) }}/.*",
@@ -15,7 +15,7 @@ db.services.insert({
 	}
 });
 
-db.services.insert({
+db.services.insertOne({
 	"_id" : NumberInt(2),
 	"_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.identity.base_url is defined %}
@@ -35,7 +35,7 @@ db.services.insert({
 	}
 });
 
-db.services.insert({
+db.services.insertOne({
 	"_id" : NumberInt(3),
 	"_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.identity_admin.base_url is defined %}

--- a/deployment/scripts/mongod/1.0.0/05_security.populate_certificates_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/05_security.populate_certificates_ref.js.j2
@@ -3,7 +3,7 @@ db = db.getSiblingDB('{{ mongodb.security.db }}')
 print("START security.populate_certificates_ref.js");
 
 {% macro insertCertificate(pemFile, contextId, host) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/scripts/mongod/1.0.0/05_security.populate_certificates_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/05_security.populate_certificates_ref.js.j2
@@ -7,7 +7,7 @@ db.certificates.remove(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/scripts/mongod/1.0.0/101_iam_client1_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_client1_demo.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 101_iam_client1_demo.js");
 
-db.customers.insert({
+db.customers.insertOne({
 	"_id": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"identifier": "11",
 	"code": "654852",
@@ -30,7 +30,7 @@ db.customers.insert({
 	"_class": "customers"
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "5c7927af7884583d1ebb6e7bc40d999675514044b20ead59978775930bf8e00e",
 	"identifier": "52",
 	"name": "Client 1",
@@ -44,7 +44,7 @@ db.owners.insert({
 	"_class": "owners"
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "5c7927d57884583d1ebb6e925dd54c14cd7544cc807a32d1e2c64e27d4b86731",
 	"identifier": "53",
 	"name": "Propriétaire 1",
@@ -58,7 +58,7 @@ db.owners.insert({
 	"_class": "owners"
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "5c7927e37884583d1ebb6ea6907e15b8d3a747f6af027d6418557344a6606ae2",
 	"identifier": "54",
 	"name": "Propriétaire 2",
@@ -72,7 +72,7 @@ db.owners.insert({
 	"_class": "owners"
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "5c7927af7884583d1ebb6e7ea256dede38354ecba085d10543289322e6fdfd76",
 	"enabled": true,
 	"proof": true,
@@ -88,7 +88,7 @@ db.tenants.insert({
 	"_class": "tenants"
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "5c7927d57884583d1ebb6e9448db1139c8824b81b95b5ca808c22e0ec4ce8099",
 	"enabled": true,
 	"proof": false,
@@ -103,7 +103,7 @@ db.tenants.insert({
 	"_class": "tenants"
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "5c7927e47884583d1ebb6ea892e497b59b47466fad00e3a8ee337ea450b1499c",
 	"enabled": true,
 	"proof": false,
@@ -118,7 +118,7 @@ db.tenants.insert({
 	"_class": "tenants"
 });
 
-db.providers.insert({
+db.providers.insertOne({
 	"_id": "5c7927af7884583d1ebb6e7ddda2807afe234014846b3f4b0c68fdc49261f881",
 	"identifier": "51",
 	"name": "default",
@@ -132,7 +132,7 @@ db.providers.insert({
 	"_class": "providers"
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927af7884583d1ebb6e7f17e5db9b937b469e93fc87b62f56ddafb179ca53",
 	"identifier": "217",
 	"name": "USERS 102",
@@ -171,7 +171,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927af7884583d1ebb6e80c0149571ac9e424aad530a9f87ed2fc32d226c63",
 	"identifier": "218",
 	"name": "GROUPS 102",
@@ -204,7 +204,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927af7884583d1ebb6e8141952c6fa39c4f858a951aad767e453d4ddb3974",
 	"identifier": "219",
 	"name": "PROFILES 102",
@@ -234,7 +234,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927af7884583d1ebb6e83a608d8eaf01041bbb45c33ac9b862d1716af01fd",
 	"identifier": "221",
 	"name": "ACCOUNTS 102",
@@ -252,7 +252,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927af7884583d1ebb6e8ae004eb3dc6d6476d964a4f079ad2bdbe06eb0465",
 	"identifier": "228",
 	"name": "Hierarchy Profiles 102",
@@ -279,7 +279,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927d57884583d1ebb6ea2a26b9d609a1440e397b39684e9209c662d9a81d4",
 	"identifier": "244",
 	"name": "Hierarchy Profiles 103",
@@ -306,7 +306,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927e47884583d1ebb6eb64c7e540032924ed797da29054add06f32cb8e718",
 	"identifier": "260",
 	"name": "Hierarchy Profiles 104",
@@ -333,7 +333,7 @@ db.profiles.insert({
 	"customerId": "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
     "_id" : "5c7e63347884583d1ebb6fea7caf6cf786214ae1835ff6277c3a0ca35aefb13d",
     "identifier" : "306",
     "name" : "GROUPS 102",
@@ -366,7 +366,7 @@ db.profiles.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
     "_id" : "5c7e633c7884583d1ebb6fed93bc936892c44dd8a6875d78292e63badcec2376",
     "identifier" : "307",
     "name" : "GROUPS 102",
@@ -399,7 +399,7 @@ db.profiles.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
     "_id" : "5c7e7473788458585c0ccb48a5b9e48a0eb448aab40893d9010b8df80f2f34b2",
     "identifier" : "314",
     "name" : "Profil Admin France",
@@ -435,7 +435,7 @@ db.profiles.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
     "_id" : "5c7e748f788458585c0ccb4b93ed9fed6e634c9da9ce0bf064d107713ef32ce2",
     "identifier" : "315",
     "name" : "Profil Admin Italie",
@@ -472,7 +472,7 @@ db.profiles.insert({
     "_class": "profiles"
 });
 
-db.groups.insert({
+db.groups.insertOne({
     "_id" : "5c7927af7884583d1ebb6e8b3ccccdb5d1a64684aa6cb24df41aa6736bc9e5c0",
     "identifier" : "229",
     "name" : "ADMIN_CLIENT_ROOT 654852",
@@ -492,7 +492,7 @@ db.groups.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "groups"
 });
-db.groups.insert({
+db.groups.insertOne({
     "_id" : "5c7e64c17884583d1ebb7002f268e1d589294a70996ffbb859979cc8bd27766d",
     "identifier" : "129",
     "name" : "Groupe Admin Users France",
@@ -507,7 +507,7 @@ db.groups.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "groups"
 });
-db.groups.insert({
+db.groups.insertOne({
     "_id" : "5c7e64fc7884583d1ebb70041fdaa849d74c4eb8b8ee42a1ae83f42be85ba171",
     "identifier" : "130",
     "name" : "Groupe Admin Users Italie",
@@ -523,7 +523,7 @@ db.groups.insert({
     "_class": "groups"
 });
 
-db.users.insert({
+db.users.insertOne({
     "_id" : "5c7927af7884583d1ebb6e8c05d5356889264b248f082e269e67cb9a8af7941e",
     "email" : "admin@gmail.com",
     "firstname" : "Admin",
@@ -542,7 +542,7 @@ db.users.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "users"
 });
-db.users.insert({
+db.users.insertOne({
     "_id" : "5c7e65367884583d1ebb700572a02a0978b84b8883396a7a53ebb787fcd6e9ce",
     "email" : "adminfrance@gmail.com",
     "firstname" : "Admin",
@@ -561,7 +561,7 @@ db.users.insert({
     "customerId" : "5c7927af7884583d1ebb6e7a74547a15e35d431599d976a9708eb12d6c5e56c9",
     "_class": "users"
 });
-db.users.insert({
+db.users.insertOne({
     "_id" : "5c7e65427884583d1ebb7007e0d6d611bd254f809fab5b39dd71f465e6270fe0",
     "email" : "adminitalie@gmail.com",
     "firstname" : "Admin",

--- a/deployment/scripts/mongod/1.0.0/101_iam_client2_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_client2_demo.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 101_iam_client2_demo.js");
 
-db.customers.insert({
+db.customers.insertOne({
 	"_id": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"identifier": "12",
 	"code": "659845",
@@ -31,7 +31,7 @@ db.customers.insert({
 	"_class": "customers"
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "5c7928337884583d1ebb6ebb5be6372ef9394a8691874ef993e013ab5da0e42f",
 	"identifier": "55",
 	"name": "Client 2",
@@ -45,7 +45,7 @@ db.owners.insert({
 	"_class": "owners"
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "5c7928597884583d1ebb6ed24e893dcfc5cc4d0a9a69f63dbfa2a7ebd08f6ed8",
 	"identifier": "56",
 	"name": "Propriétaire 1",
@@ -59,7 +59,7 @@ db.owners.insert({
 	"_class": "owners"
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "5c7928337884583d1ebb6ebe056678aa36364074b97135c2b372270949f60e1a",
 	"enabled": true,
 	"proof": true,
@@ -75,7 +75,7 @@ db.tenants.insert({
 	"_class": "tenants"
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "5c7928597884583d1ebb6ed48b92969264764e55a61db10314aa8633cd0c6fc4",
 	"enabled": true,
 	"proof": false,
@@ -90,7 +90,7 @@ db.tenants.insert({
 	"_class": "tenants"
 });
 
-db.providers.insert({
+db.providers.insertOne({
 	"_id": "5c7928337884583d1ebb6ebd3b672beb39d04beda4c55d70d5352184d926ed31",
 	"identifier": "52",
 	"name": "default",
@@ -104,7 +104,7 @@ db.providers.insert({
 	"_class": "providers"
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7928337884583d1ebb6ebf1843c77a02554d35b902ced3aa65c0aa58899b72",
 	"identifier": "263",
 	"name": "USERS 105",
@@ -143,7 +143,7 @@ db.profiles.insert({
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7928337884583d1ebb6ec030ebc4100c8646208c3014c96e4f74e6c2432352",
 	"identifier": "264",
 	"name": "GROUPS 105",
@@ -176,7 +176,7 @@ db.profiles.insert({
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
-db.profiles.insert(
+db.profiles.insertOne(
 {
 	"_id": "5c7928337884583d1ebb6ec1eeb9cd5cb44b4110a512abde58fd04307a395f14",
 	"identifier": "265",
@@ -207,7 +207,7 @@ db.profiles.insert(
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
-db.profiles.insert(
+db.profiles.insertOne(
 {
 	"_id": "5c7928337884583d1ebb6ec33fdeff1270174f37bb32afa3c2ca36f41c304120",
 	"identifier": "267",
@@ -226,7 +226,7 @@ db.profiles.insert(
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
-db.profiles.insert(
+db.profiles.insertOne(
 {
 	"_id": "5c7928337884583d1ebb6eca27b70a0b0e7f4d6ea8723fa5c577804f6da5da3d",
 	"identifier": "274",
@@ -254,7 +254,7 @@ db.profiles.insert(
 	"customerId": "5c7928337884583d1ebb6ebaa3f3eb30bc0542178127d1572b8f70c7c0b0cb68",
 	"_class": "profiles"
 });
-db.profiles.insert(
+db.profiles.insertOne(
 {
 	"_id": "5c79285a7884583d1ebb6ee28433459e0e414e3983bc96f8d5604f52adf34266",
 	"identifier": "290",
@@ -284,7 +284,7 @@ db.profiles.insert(
 });
 
 
-db.groups.insert(
+db.groups.insertOne(
 {
 	"_id" : "5c7928337884583d1ebb6ecbee8ed316ea5546bf92500eb136afa905d237233b",
 	"identifier" : "275",
@@ -305,7 +305,7 @@ db.groups.insert(
 	"_class": "groups"
 });
 
-db.users.insert({
+db.users.insertOne({
     "_id" : "5c7928337884583d1ebb6ecc1e146e10286647b9a195349483f8f09b1628721c",
     "email" : "admin@client2.fr",
     "firstname" : "Admin",

--- a/deployment/scripts/mongod/1.0.0/101_iam_system_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_system_demo.js
@@ -74,7 +74,7 @@ db.owners.insertOne({
 	"_class": "owners"
 });
 
-db.tenants.update({"identifier": 1},{"$set" : {"itemIngestContractIdentifier" : "IC-000005"}});
+db.tenants.updateOne({"identifier": 1},{"$set" : {"itemIngestContractIdentifier" : "IC-000005"}});
 
 db.tenants.insertOne({
 	"_id": "5c7927537884583d1ebb6e682b0f33f74d9c4483b7b3b12c8a075dc2e21fa771",

--- a/deployment/scripts/mongod/1.0.0/101_iam_system_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_system_demo.js
@@ -60,7 +60,7 @@ db.sequences.updateOne({
 	}
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "5c7927537884583d1ebb6e66aaacceedbb0541fb97538964f8fc26f58085b92b",
 	"identifier": "51",
 	"name": "VitamUI",
@@ -76,7 +76,7 @@ db.owners.insert({
 
 db.tenants.update({"identifier": 1},{"$set" : {"itemIngestContractIdentifier" : "IC-000005"}});
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "5c7927537884583d1ebb6e682b0f33f74d9c4483b7b3b12c8a075dc2e21fa771",
 	"enabled": true,
 	"proof": false,
@@ -91,7 +91,7 @@ db.tenants.insert({
 	"_class": "tenants"
 });
 
-db.owners.insert({
+db.owners.insertOne({
 	"_id": "system_owner_externe",
 	"identifier" : NumberInt(5),
 	"enabled": true,
@@ -108,7 +108,7 @@ db.owners.insert({
 	}
 });
 
-db.tenants.insert({
+db.tenants.insertOne({
 	"_id": "tenant_20",
 	"name": "Tenant Externe",
 	"proof" : false,
@@ -126,7 +126,7 @@ db.tenants.insert({
 
 //----------------------------------------- PROFILES TENANT 9 ------------------------------------
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id": "5c7927537884583d1ebb6e769fcbc58f86f148a3ba96a58759b4befcdadb171c",
 	"identifier": "214",
 	"name": "Hierarchy Profiles 9",
@@ -170,7 +170,7 @@ db.groups.updateOne( {
 
 // ========================================= GROUPS =========================================
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c79022e7884583d1ebb6e5d0bc0121822684250a3fd2996fd93c04634363363",
 	"identifier": "101",
 	"name": "Groupe acces complet",
@@ -206,7 +206,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5caf30f57884585a1dcedc36759ce99393a94722aa3698482ec8fa95a12732d4",
 	"identifier": "133",
 	"name": "Groupe acces complet EMO",
@@ -228,7 +228,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c79026f7884583d1ebb6e5f3c1910a7420244e7ac4638c42383831b2c64ed46",
 	"identifier": "102",
 	"name": "Groupe de l'utilisateur Démo",
@@ -251,7 +251,7 @@ db.groups.insert({
 
 // ========================================= USERS =========================================
 
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7902ee7884583d1ebb6e6063569f12508f46e293f99e31a96c6b4449a7574f",
 	"email": "demo@{{ vitamui_platform_informations.default_email_domain }}",

--- a/deployment/scripts/mongod/1.0.0/101_iam_system_plus_demo.js
+++ b/deployment/scripts/mongod/1.0.0/101_iam_system_plus_demo.js
@@ -3,7 +3,7 @@ db = db.getSiblingDB('iam')
 print("START 101_iam_system_plus_demo.js");
 
 // ========================================= GROUPS =========================================
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4edf7884583d1ebb6f891c55c325bb7a4a768d18a01cb68b9530e65d07c0",
 	"identifier": "114",
 	"name": "Groupe Groupe de profils",
@@ -18,7 +18,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4ef07884583d1ebb6f8bc378561a559341bc83936231b69696eca8a51192",
 	"identifier": "115",
 	"name": "Groupe Hierarchisation",
@@ -34,7 +34,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4f517884583d1ebb6f9195ce6dee372d4da4b7b26274268df1296e29e787",
 	"identifier": "118",
 	"name": "Groupe Mon compte",
@@ -49,7 +49,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4f617884583d1ebb6f9373fb764c414941ec9d4a7f93d9a83e244d1400e9",
 	"identifier": "119",
 	"name": "Groupe Organisations",
@@ -64,7 +64,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4f987884583d1ebb6f97fdb1292186984af49662d4d235bd6f8ddfdae99c",
 	"identifier": "121",
 	"name": "Groupe Profils user",
@@ -79,7 +79,7 @@ db.groups.insert({
 	"_class": "groups"
 });
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4fba7884583d1ebb6f9b68989a2357ab44f2bfa8f53b40e829a303a3ef86",
 	"identifier": "123",
 	"name": "Groupe Subrogation",
@@ -95,7 +95,7 @@ db.groups.insert({
 });
 
 
-db.groups.insert({
+db.groups.insertOne({
 	"_id": "5c7e4ff77884583d1ebb6fa1b6f6542a91fd44a29b0afcec6ca062b02f664677",
 	"identifier": "126",
 	"name": "Groupe Utilisateur",
@@ -113,7 +113,7 @@ db.groups.insert({
 
 // ========================================= USERS =========================================
 
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7e50e47884583d1ebb6fb63e29ffa861654af3b758f05902471f810cb2263d",
 	"email": "demohierarchisation@{{ vitamui_platform_informations.default_email_domain }}",
@@ -134,7 +134,7 @@ db.users.insert(
 	"customerId": "system_customer",
 	"_class": "users"
 });
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7e512b7884583d1ebb6fbcf7d480e06d3748a3b36cc55ad9b2d0e242e673fe",
 	"email": "demomoncompte@{{ vitamui_platform_informations.default_email_domain }}",
@@ -155,7 +155,7 @@ db.users.insert(
 	"customerId": "system_customer",
 	"_class": "users"
 });
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7e513d7884583d1ebb6fbe48233e218ee64c79bb76a688fba02877c588618c",
 	"email": "demoorganisations@{{ vitamui_platform_informations.default_email_domain }}",
@@ -176,7 +176,7 @@ db.users.insert(
 	"customerId": "system_customer",
 	"_class": "users"
 });
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7e515e7884583d1ebb6fc29a46e429db5f47d0b9ae210ce2d710b3675c2cec",
 	"email": "demoprofilsusers@{{ vitamui_platform_informations.default_email_domain }}",
@@ -197,7 +197,7 @@ db.users.insert(
 	"customerId": "system_customer",
 	"_class": "users"
 });
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7e51a27884583d1ebb6fca0a6d9782f103447bbfe799d10fc615c73520b7d8",
 	"email": "demosubrogation@{{ vitamui_platform_informations.default_email_domain }}",
@@ -218,7 +218,7 @@ db.users.insert(
 	"customerId": "system_customer",
 	"_class": "users"
 });
-db.users.insert(
+db.users.insertOne(
 {
 	"_id": "5c7e51b77884583d1ebb6fccb8dfe9dbca1f40e0aa9d3ee8c46e6a834fc56067",
 	"email": "demoutilisateurs@{{ vitamui_platform_informations.default_email_domain }}",

--- a/deployment/scripts/mongod/1.0.0/17_VITAMUI-2800_init_user_address_ref.js
+++ b/deployment/scripts/mongod/1.0.0/17_VITAMUI-2800_init_user_address_ref.js
@@ -3,7 +3,7 @@ db = db.getSiblingDB('iam')
 print("START VITAMUI-2800_init_user_address_ref.js");
 
 // Update all users without address : add an empty address
-db.users.update({ "address": { $exists: false } }, {
+db.users.updateMany({ "address": { $exists: false } }, {
   $set: {
     "address":
     {
@@ -13,6 +13,6 @@ db.users.update({ "address": { $exists: false } }, {
       "country": ""
     }
   }
-}, {multi: true});
+});
 
 print("END VITAMUI-2800_init_user_address_ref.js");

--- a/deployment/scripts/mongod/1.0.0/206_test_data_dev.js
+++ b/deployment/scripts/mongod/1.0.0/206_test_data_dev.js
@@ -4,7 +4,7 @@ print("START 206_test_data_dev.js");
 
 // ========================================= TOKENS =========================================
 
-db.tokens.insert({
+db.tokens.insertOne({
   "_id": "tokenadmin",
   "updatedDate": "May 15, 2008 6:30:47 PM",
   "refId": "admin_user"

--- a/deployment/scripts/mongod/1.0.0/207_TRTL_357_rename_logoDataBase64_set_colors_ref.js
+++ b/deployment/scripts/mongod/1.0.0/207_TRTL_357_rename_logoDataBase64_set_colors_ref.js
@@ -15,7 +15,7 @@ db.customers.find(
     }
 ).forEach(function (customer) {
     if (customer.graphicIdentity && customer.graphicIdentity.themeColors && customer.graphicIdentity.themeColors['vitamui-primary']) {
-        db.customers.update(
+        db.customers.updateOne(
             { _id: customer._id },
             {
               $set: {

--- a/deployment/scripts/mongod/1.0.0/207_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/207_iam_ref.js.j2
@@ -7,7 +7,7 @@ print("START 207_iam_ref.js");
 // ----------------------------------------- LEVEL "0" -----------------------------------------
 
 var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identifier'}).sequence;
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_access_contract",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Access Profile",
@@ -31,7 +31,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_ingest_contract",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Ingest Profile",
@@ -58,7 +58,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_ontology",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Ontology Profile",
@@ -82,7 +82,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_agencies",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Agencies Profile",
@@ -112,7 +112,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_file_format",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "File Formats Profile",
@@ -142,7 +142,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_context",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Context Profile",
@@ -166,7 +166,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_security_profile",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Security Profiles Profile",
@@ -193,7 +193,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_audit",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Audit Profile",
@@ -214,7 +214,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_secure",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Secure Profile",
@@ -232,7 +232,7 @@ db.profiles.insert({
 	]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_dsl",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Requêtes DSL",
@@ -250,7 +250,7 @@ db.profiles.insert({
 	]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_probative_value",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Probative Value Profile",
@@ -271,7 +271,7 @@ db.profiles.insert({
 	 ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_logbook_operation",
   "identifier" : NumberInt(maxIdProfile++),
   "name": "Journal des Opérations",
@@ -289,7 +289,7 @@ db.profiles.insert({
    ]
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_holding_filling_scheme_profile",
   "identifier" : NumberInt(maxIdProfile++),
   "name": "Arbres et Plans",

--- a/deployment/scripts/mongod/1.0.0/208_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/208_application_ref.js.j2
@@ -4,7 +4,7 @@ print("START 208_application_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "INGEST_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/ingest-contract",
@@ -22,7 +22,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "ACCESS_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/access-contract",
@@ -40,7 +40,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "AGENCIES_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/agency",
@@ -58,7 +58,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "FILE_FORMATS_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/file-format",
@@ -76,7 +76,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "CONTEXTS_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/context",
@@ -94,7 +94,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "SECURITY_PROFILES_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/security-profile",
@@ -112,7 +112,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "ONTOLOGY_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/ontology",
@@ -130,7 +130,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "AUDIT_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/audit",
@@ -148,7 +148,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "SECURE_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/securisation",
@@ -166,7 +166,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "DSL_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/dsl",
@@ -184,7 +184,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "PROBATIVE_VALUE_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/probative-value",
@@ -202,7 +202,7 @@ db.applications.insert({
     "target" : "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "LOGBOOK_OPERATION_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/logbook-operation",
@@ -220,7 +220,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "HOLDING_FILLING_SCHEME_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.ingest.base_url }}/holding-filling-scheme",

--- a/deployment/scripts/mongod/1.0.0/209_cas_services_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/209_cas_services_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('cas')
 
 print("START 209_cas_services_ref.js");
 
-db.services.insert({
+db.services.insertOne({
 	"_id" : NumberInt(4),
 	"_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.referential.base_url is defined %}

--- a/deployment/scripts/mongod/1.0.0/210_security_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/210_security_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('security')
 
 print("START 210_security_ref.js");
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_referential_context",
     "name": "Contexte UI Referential",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/1.0.0/212_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/212_application_ref.js.j2
@@ -4,7 +4,7 @@ print("START 212_application_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "INGEST_MANAGEMENT_APP",
 {% if vitamui.ingest.base_url is defined %}
     "url": "{{ vitamui.ingest.base_url }}/ingest",
@@ -22,7 +22,7 @@ db.applications.insert({
     "target": "_self"
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_ingest_profile",
   "identifier" : NumberInt(22),
   "name": "Ingest Profile",

--- a/deployment/scripts/mongod/1.0.0/213_cas_services_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/213_cas_services_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('cas')
 
 print("START 213_cas_services_ref.js");
 
-var nbInsert = db.services.insert({
+var nbInsert = db.services.insertOne({
    "_id" : NumberInt(5),
    "_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.ingest.base_url is defined %}

--- a/deployment/scripts/mongod/1.0.0/214_security_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/214_security_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('security')
 
 print("START 214_security_ref.js");
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_ingest_context",
     "name": "Contexte UI Ingest",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/1.0.0/216_application_archive_search_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/216_application_archive_search_ref.js.j2
@@ -5,7 +5,7 @@ print("START 216_application_archive_search_ref.js");
 
 // ========================================= partie archive search ============================================
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_archive_search_profile",
   "identifier" : NumberInt(23),
   "name": "Archive Search Profile",
@@ -34,7 +34,7 @@ db.profiles.insert({
 
 // -------- VITAM ADMINISTRATION  -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "ARCHIVE_SEARCH_MANAGEMENT_APP",
 {% if vitamui.archive_search.base_url is defined %}
     "url": "{{ vitamui.archive_search.base_url }}/archive-search",

--- a/deployment/scripts/mongod/1.0.0/217_security_archive_search_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/217_security_archive_search_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('security')
 
 print("START 217_security_archive_search_ref.js");
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_archive_search_context",
     "name": "Contexte UI Archive Search",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/1.0.0/218_cas_services_archive_search_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/218_cas_services_archive_search_ref.js.j2
@@ -3,7 +3,7 @@ db = db.getSiblingDB('cas')
 
 print("START 218_cas_services_archive_search_ref.js");
 
-var nbInsert = db.services.insert({
+var nbInsert = db.services.insertOne({
    "_id" : NumberInt(6),
    "_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.archive_search.base_url is defined %}

--- a/deployment/scripts/mongod/1.0.0/220_cas_services_pastis_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/220_cas_services_pastis_ref.js.j2
@@ -4,7 +4,7 @@ db = db.getSiblingDB('cas')
 
 print("START 218_cas_services_pastis_ref.js");
 
-var nbInsert = db.services.insert({
+var nbInsert = db.services.insertOne({
    "_id" : NumberInt(8),
    "_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.pastis.base_url is defined %}

--- a/deployment/scripts/mongod/1.0.0/221_pastis_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/221_pastis_application_ref.js.j2
@@ -4,7 +4,7 @@ print("START 221_pastis_application_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "PASTIS_APP",
 {% if vitamui.pastis.base_url is defined %}
     "url": "{{ vitamui.pastis.base_url }}/pastis",

--- a/deployment/scripts/mongod/1.0.0/222_pastis_profiles_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/222_pastis_profiles_ref.js.j2
@@ -5,7 +5,7 @@ print("START 222_pastis_profiles_ref.js");
 // -------- VITAM ADMINISTRATION -----
 
 
-db.profiles.insert({
+db.profiles.insertOne({
   "_id": "system_pastis",
   "identifier" : NumberInt(maxIdProfile++),
   "name": "Pastis-Gestion des profils documentaires",

--- a/deployment/scripts/mongod/1.0.0/223_security_pastis_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/223_security_pastis_ref.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('security')
 
 print("START 223_security_pastis_ref.js");
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_pastis_context",
     "name": "Contexte UI Pastis",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/1.0.0/224_security.populate_certificates_pastis.js.j2
+++ b/deployment/scripts/mongod/1.0.0/224_security.populate_certificates_pastis.js.j2
@@ -11,7 +11,7 @@ db.certificates.remove(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/scripts/mongod/1.0.0/224_security.populate_certificates_pastis.js.j2
+++ b/deployment/scripts/mongod/1.0.0/224_security.populate_certificates_pastis.js.j2
@@ -3,11 +3,11 @@ db = db.getSiblingDB('{{ mongodb.security.db }}')
 print("START 224_security.populate_certificates_pastis.js.j2");
 
 {% macro insertCertificate(pemFile, contextId, host) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/scripts/mongod/1.0.0/307_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/307_iam_ref.js.j2
@@ -8,7 +8,7 @@ print("START 307_iam_ref.js");
 
 var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identifier'}).sequence;
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_rules",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Rules Profile",

--- a/deployment/scripts/mongod/1.0.0/308_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/308_application_ref.js.j2
@@ -4,7 +4,7 @@ print("START 308_application_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "RULES_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/rule",

--- a/deployment/scripts/mongod/1.0.0/311_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/311_iam_ref.js.j2
@@ -5,33 +5,33 @@ print("START 311_iam_ref.js");
 // ========================================= PROFILES =========================================
 
 // ----------------------------------------- LEVEL "0" -----------------------------------------
-db.profiles.update(
+db.profiles.updateOne(
 {"_id" : "system_context"},
-{$set: {"roles" : [ 
+{$set: {"roles" : [
 	{
     	"name" : "ROLE_GET_CONTEXTS"
-    }, 
+    },
     {
     	"name" : "ROLE_CREATE_CONTEXTS"
-   	}, 
+   	},
     {
     	"name" : "ROLE_UPDATE_CONTEXTS"
-    }, 
+    },
     {
     	"name" : "ROLE_GET_CUSTOMERS"
-    }, 
+    },
     {
     	"name" : "ROLE_GET_TENANTS"
-   	}, 
+   	},
     {
     	"name" : "ROLE_GET_ALL_TENANTS"
   	}
 ]}
 });
 
-db.profiles.update(
+db.profiles.updateOne(
 {"_id" : "system_agencies"},
-{$set: {"roles" : [ 
+{$set: {"roles" : [
     {
         "name": "ROLE_GET_AGENCIES"
     },
@@ -53,9 +53,9 @@ db.profiles.update(
 ]}
 });
 
-db.profiles.update(
+db.profiles.updateOne(
 {"_id" : "system_file_format"},
-{$set: {"roles" : [ 
+{$set: {"roles" : [
     {
         "name": "ROLE_GET_FILE_FORMATS"
     },
@@ -75,9 +75,9 @@ db.profiles.update(
 });
 
 
-db.profiles.update(
+db.profiles.updateOne(
 {"_id" : "system_ontology"},
-{$set: {"roles" : [ 
+{$set: {"roles" : [
     {
         "name": "ROLE_GET_ONTOLOGIES"
     },

--- a/deployment/scripts/mongod/1.0.0/315_security.populate_certificates_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/315_security.populate_certificates_ref.js.j2
@@ -5,11 +5,11 @@ db = db.getSiblingDB('{{ mongodb.security.db }}')
 print("START 315_security.populate_certificates_ref.js");
 
 {% macro insertCertificate(pemFile, contextId, host) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/scripts/mongod/1.0.0/315_security.populate_certificates_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/315_security.populate_certificates_ref.js.j2
@@ -13,7 +13,7 @@ db.certificates.remove(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/scripts/mongod/1.0.0/316_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/316_application_ref.js.j2
@@ -4,7 +4,7 @@ print("START 316_application_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "EXTERNAL_PARAM_PROFILE_APP",
 {% if vitamui.identity.base_url is defined %}
     "url": "{{ vitamui.identity.base_url }}/externalparamprofile",

--- a/deployment/scripts/mongod/1.0.0/318_application_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/318_application_ref.js.j2
@@ -4,7 +4,7 @@ print("START 318_application_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "ACCESSION_REGISTER_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/accession-register",

--- a/deployment/scripts/mongod/1.0.0/320_iam_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/320_iam_ref.js.j2
@@ -6,7 +6,7 @@ print("START 320_iam_ref.js");
 
 var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identifier'}).sequence;
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "system_accession_register",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Accession register Profile",

--- a/deployment/scripts/mongod/2.0.0/010_TRTL-936_migration_of_userinfo_ref.js
+++ b/deployment/scripts/mongod/2.0.0/010_TRTL-936_migration_of_userinfo_ref.js
@@ -19,14 +19,14 @@ db.users.find({"userInfoId" : {$exists : false}}).forEach(user => {
         "_class": "userInfos"
     });
 
-    db.users.update(
+    db.users.updateOne(
         {_id: user._id},
         {
             "$set": {"userInfoId": userInfoId},
         }
     );
 
-    db.users.update(
+    db.users.updateOne(
         {_id: user._id},
         {
             $unset: {"language": ""},

--- a/deployment/scripts/mongod/2.0.0/010_TRTL-936_migration_of_userinfo_ref.js
+++ b/deployment/scripts/mongod/2.0.0/010_TRTL-936_migration_of_userinfo_ref.js
@@ -13,7 +13,7 @@ db.users.find({"userInfoId" : {$exists : false}}).forEach(user => {
 
     var userInfoId = new ObjectId().valueOf() + new ObjectId().valueOf();
 
-    db.userInfos.insert({
+    db.userInfos.insertOne({
         "_id": userInfoId,
         "language": language,
         "_class": "userInfos"

--- a/deployment/scripts/mongod/2.0.0/011_TRTL-1107_add_identifier_to_userinfos_ref.js
+++ b/deployment/scripts/mongod/2.0.0/011_TRTL-1107_add_identifier_to_userinfos_ref.js
@@ -2,12 +2,12 @@ db = db.getSiblingDB('iam')
 
 print("START 011_TRTL-1107_add_identifier_to_userinfos_ref");
 
-db.sequences.insert({
+db.sequences.insertOne({
     "_id": "user_infos_identifier",
     "name": "userInfosIdentifier",
     "sequence": NumberInt(100)
 });
-  
+
 var maxIdentifier = db.getCollection('sequences').findOne({'_id': 'user_infos_identifier'}).sequence;
 
 db.userInfos.find({identifier: {$eq: null}}).forEach(userInfos => {

--- a/deployment/scripts/mongod/2.0.0/011_TRTL-1107_add_identifier_to_userinfos_ref.js
+++ b/deployment/scripts/mongod/2.0.0/011_TRTL-1107_add_identifier_to_userinfos_ref.js
@@ -12,7 +12,7 @@ var maxIdentifier = db.getCollection('sequences').findOne({'_id': 'user_infos_id
 
 db.userInfos.find({identifier: {$eq: null}}).forEach(userInfos => {
 
-    var result = db.userInfos.update(
+    var result = db.userInfos.updateOne(
         {_id: userInfos._id},
         {
             "$set": {"identifier": NumberInt(maxIdentifier+1)},

--- a/deployment/scripts/mongod/2.0.0/013_REC-385_fix_user_info_role_duplication_ref.js
+++ b/deployment/scripts/mongod/2.0.0/013_REC-385_fix_user_info_role_duplication_ref.js
@@ -11,7 +11,7 @@ db.profiles.find({ applicationName: "USERS_APP" }).forEach((profile) => {
 
   // Update only roles whith duplication
   if (distinct_roles.length !== profile.roles.length) {
-    db.profiles.update(
+    db.profiles.updateOne(
       { _id: profile._id },
       { $set: { roles: distinct_roles } }
     );

--- a/deployment/scripts/mongod/2.0.0/02_TRTL_449_update_application_categories_ref.js
+++ b/deployment/scripts/mongod/2.0.0/02_TRTL_449_update_application_categories_ref.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("Start 06_TRTL_449_update_application_categories_ref.js");
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "ACCOUNTS_APP",
     "category": "users",
 }, {
@@ -11,7 +11,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "PROFILES_APP",
     "category": "settings",
 }, {
@@ -20,7 +20,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "USERS_APP",
     "category": "administrators",
 }, {
@@ -29,7 +29,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "GROUPS_APP",
     "category": "settings",
 }, {
@@ -38,7 +38,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "CUSTOMERS_APP",
     "category": "settings",
 }, {
@@ -47,7 +47,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "SUBROGATIONS_APP",
     "category": "administrators",
 }, {
@@ -57,7 +57,7 @@ db.applications.update({
 });
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "HIERARCHY_PROFILE_APP",
     "category": "settings",
 }, {
@@ -66,7 +66,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "INGEST_APP",
     "category": "referential",
 }, {
@@ -75,7 +75,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "ACCESS_APP",
     "category": "referential",
 }, {
@@ -84,7 +84,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "SECURITY_PROFILES_APP",
     "category": "referential",
 }, {
@@ -93,7 +93,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "AUDIT_APP",
     "category": "opaudit",
 }, {
@@ -102,7 +102,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "PROBATIVE_VALUE_APP",
     "category": "opaudit",
 }, {
@@ -111,7 +111,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "SECURE_APP",
     "category": "opaudit",
 }, {
@@ -120,7 +120,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "LOGBOOK_OPERATION_APP",
     "category": "referential",
 }, {
@@ -129,7 +129,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier": "DSL_APP",
     "category": "techadmin",
 }, {

--- a/deployment/scripts/mongod/2.0.0/03_TRTL_683_translate_portalTitle_and_portalMessage_ref.js
+++ b/deployment/scripts/mongod/2.0.0/03_TRTL_683_translate_portalTitle_and_portalMessage_ref.js
@@ -11,7 +11,7 @@ db.customers.find(
     var dict = {};
     dict[customer.language] = customer.graphicIdentity.portalTitle;
 
-    db.customers.update(
+    db.customers.updateOne(
       { _id: customer._id },
       { $set: { "graphicIdentity.portalTitle": dict } }
     );
@@ -20,7 +20,7 @@ db.customers.find(
     var dict = {};
     dict[customer.language] = customer.graphicIdentity.portalMessage;
 
-    db.customers.update(
+    db.customers.updateOne(
       { _id: customer._id },
       { $set: { "graphicIdentity.portalMessage": dict } }
     );

--- a/deployment/scripts/mongod/2.0.0/03_update_application_for_new_portal_ref.js
+++ b/deployment/scripts/mongod/2.0.0/03_update_application_for_new_portal_ref.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("Start 03_update_application_for_new_portal_ref.js");
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "INGEST_MANAGEMENT_APP",
     "category": "ingests"
 }, {
@@ -11,7 +11,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "INGEST_MANAGEMENT_APP",
     "hasTenantList": false,
 }, {
@@ -20,7 +20,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "AGENCIES_APP",
     "hasTenantList": false,
 }, {
@@ -29,7 +29,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "SECURE_APP",
     "hasTenantList": false,
 }, {
@@ -39,7 +39,7 @@ db.applications.update({
 });
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "DSL_APP",
     "hasTenantList": false,
 }, {
@@ -48,7 +48,7 @@ db.applications.update({
     },
 });
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "LOGBOOK_OPERATION_APP",
     "hasTenantList": false,
 }, {

--- a/deployment/scripts/mongod/2.0.0/04_TRTL-734_update_system_customer_portal_info_ref.js
+++ b/deployment/scripts/mongod/2.0.0/04_TRTL-734_update_system_customer_portal_info_ref.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 04_TRTL-734_update_system_customer_portal_info_ref.js");
 
-db.customers.update({
+db.customers.updateOne({
   "_id": "system_customer",
 }, {
   $set: {

--- a/deployment/scripts/mongod/2.0.0/04_add_default_external_parameters_profile.js.j2
+++ b/deployment/scripts/mongod/2.0.0/04_add_default_external_parameters_profile.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 04_add_default_external_parameters_profile.js.j2");
 
-db.externalParameters.remove({});
+db.externalParameters.deleteMany({});
 db.createCollection('externalParameters', { autoIndexId: true });
 
 var maxIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;

--- a/deployment/scripts/mongod/2.0.0/04_add_default_external_parameters_profile.js.j2
+++ b/deployment/scripts/mongod/2.0.0/04_add_default_external_parameters_profile.js.j2
@@ -13,7 +13,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     // EXTERNAL_PARAMS
     var externalParamId = "DEFAULT_EXT_PARAM_" + tenant.identifier;
 
-    db.externalParameters.insert({
+    db.externalParameters.insertOne({
         "_id": externalParamId,
         "identifier": externalParamId,
         "name": "Liste des paramétrages externes du tenant " + tenant.identifier,
@@ -25,7 +25,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
         ]
     });
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-EXTERNAL_PARAMS-DEFAULT",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Profil pour la gestion des paramétrages externes du tenant " + tenant.identifier,

--- a/deployment/scripts/mongod/2.0.0/05_TRTL-859_update_account_app_category_ref.js
+++ b/deployment/scripts/mongod/2.0.0/05_TRTL-859_update_account_app_category_ref.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 05_TRTL-859_update_account_app_category.js");
 
-db.applications.update({
+db.applications.updateOne({
   "identifier" : "ACCOUNTS_APP",
   "category": "ingest_and_consultation"
 }, {

--- a/deployment/scripts/mongod/2.0.0/06_TRTL-895_update_system_customer_read_only_ref.js
+++ b/deployment/scripts/mongod/2.0.0/06_TRTL-895_update_system_customer_read_only_ref.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 06_TRTL-895_update_system_customer_read_only_ref.js");
 
-db.customers.update({
+db.customers.updateOne({
   "_id": "system_customer",
 }, {
   $set: {

--- a/deployment/scripts/mongod/2.0.0/06_add_external_application.js.j2
+++ b/deployment/scripts/mongod/2.0.0/06_add_external_application.js.j2
@@ -4,7 +4,7 @@ print("START 06_add_external_application.js.j2");
 
 // -------- VITAM ADMINISTRATION add EXTERNAL_PARAMS fictif application without category -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "EXTERNAL_PARAMS",
     "url": "{{ vitamui.portal.base_url|default(url_prefix) }}",
     "icon": "vitamui-icon vitamui-icon-user",

--- a/deployment/scripts/mongod/2.0.0/06_create_search_criteria_history.js.j2
+++ b/deployment/scripts/mongod/2.0.0/06_create_search_criteria_history.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('{{ mongodb.archivesearch.db }}')
 
 print("START 06_create_search_criteria_history.js");
 
-db.searchCriteriaHistories.remove({});
+db.searchCriteriaHistories.deleteMany({});
 db.createCollection('searchCriteriaHistories', {autoIndexId: true});
 
 print("END 06_create_search_criteria_history.js");

--- a/deployment/scripts/mongod/2.0.0/07_insert_serviceid_to_applications_ref.js
+++ b/deployment/scripts/mongod/2.0.0/07_insert_serviceid_to_applications_ref.js
@@ -4,7 +4,7 @@ print("Start 07_insert_serviceid_to_applications_ref.js");
 
 // =============== INGEST ==========
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "INGEST_MANAGEMENT_APP"
 }, {
     $set: {
@@ -17,7 +17,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "HOLDING_FILLING_SCHEME_APP",
 }, {
     $set: {
@@ -32,7 +32,7 @@ db.applications.update({
 
 // =============== ARCHIVE-SEARCH ==========
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "ARCHIVE_SEARCH_MANAGEMENT_APP"
 }, {
     $set: {
@@ -47,7 +47,7 @@ db.applications.update({
 
 // =============== IDENTITY ==========
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "ACCOUNTS_APP",
 }, {
     $set: {
@@ -56,7 +56,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
         "identifier" : "HIERARCHY_PROFILE_APP",
 }, {
     $set: {
@@ -70,7 +70,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
         "identifier" : "SUBROGATIONS_APP",
 }, {
     $set: {
@@ -83,7 +83,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "PROFILES_APP",
 }, {
     $set: {
@@ -97,7 +97,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "GROUPS_APP",
 }, {
     $set: {
@@ -111,7 +111,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "USERS_APP",
 }, {
     $set: {
@@ -125,7 +125,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "CUSTOMERS_APP",
 }, {
     $set: {
@@ -141,7 +141,7 @@ db.applications.update({
 
 // =============== REFERENTIAL ==========
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "LOGBOOK_OPERATION_APP",
 }, {
     $set: {
@@ -154,7 +154,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "PROBATIVE_VALUE_APP",
 }, {
     $set: {
@@ -168,7 +168,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "DSL_APP",
 }, {
     $set: {
@@ -182,7 +182,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "SECURE_APP",
 }, {
     $set: {
@@ -196,7 +196,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "AUDIT_APP",
 }, {
     $set: {
@@ -210,7 +210,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "ONTOLOGY_APP",
 }, {
     $set: {
@@ -224,7 +224,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "SECURITY_PROFILES_APP",
 }, {
     $set: {
@@ -238,7 +238,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "CONTEXTS_APP",
 }, {
     $set: {
@@ -252,7 +252,7 @@ db.applications.update({
 );
 
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "FILE_FORMATS_APP",
 }, {
     $set: {
@@ -265,7 +265,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "AGENCIES_APP",
 }, {
     $set: {
@@ -278,7 +278,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "ACCESS_APP",
 }, {
     $set: {
@@ -291,7 +291,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "INGEST_APP",
 }, {
     $set: {
@@ -304,7 +304,7 @@ db.applications.update({
     }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "RULES_APP",
 }, {
     $set: {

--- a/deployment/scripts/mongod/2.0.0/08_TRTL-952_update_super_admin_group_name_ref.js
+++ b/deployment/scripts/mongod/2.0.0/08_TRTL-952_update_super_admin_group_name_ref.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START 01_TRTL-952_update_super_admin_group_name_and_description_ref.js");
 
-db.groups.update({
+db.groups.updateOne({
   "_id": "super_admin_group",
 }, {
   $set: {

--- a/deployment/scripts/mongod/2.0.0/10_insert_serviceid_to_ingest_application_ref.js
+++ b/deployment/scripts/mongod/2.0.0/10_insert_serviceid_to_ingest_application_ref.js
@@ -7,7 +7,7 @@ db.applications.updateMany(
    { $unset: { serviceId2: "" } }
 );
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "INGEST_MANAGEMENT_APP"
 }, {
     $set: {

--- a/deployment/scripts/mongod/2.0.0/20_logbook_operation_management_application.js.j2
+++ b/deployment/scripts/mongod/2.0.0/20_logbook_operation_management_application.js.j2
@@ -4,7 +4,7 @@ print("START_08_logbook_operation_management_application.js");
 
 // -------- LOGBOOK_MANAGEMENT_OPERATION APPLICATION -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "LOGBOOK_MANAGEMENT_OPERATION_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/logbook-management-operation",
@@ -31,7 +31,7 @@ db.applications.insert({
 // Get sequence for profiles
 var maxIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;
 
-db.profiles.insert({
+db.profiles.insertOne({
     "_id": "system_logbook_management_operation",
     "identifier" : NumberInt(maxIdProfile++),
     "name": "Gestion des Logbook Opérations",

--- a/deployment/scripts/mongod/2.0.0/21_update_context_application_category.js
+++ b/deployment/scripts/mongod/2.0.0/21_update_context_application_category.js
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("Start 08_update_context_application_category.js");
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "CONTEXTS_APP",
     "category": "referential",
 }, {

--- a/deployment/scripts/mongod/2.0.0/24_update_logbook_operation_tooltip.js.j2
+++ b/deployment/scripts/mongod/2.0.0/24_update_logbook_operation_tooltip.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START_24_update_logbook_operation_tooltip.js");
 
-db.applications.update({
+db.applications.updateOne({
       "identifier" : "LOGBOOK_MANAGEMENT_OPERATION_APP"},
 {
      $set : {

--- a/deployment/scripts/mongod/2.0.0/25_update_and_create_profiles_archive_search.js.j2
+++ b/deployment/scripts/mongod/2.0.0/25_update_and_create_profiles_archive_search.js.j2
@@ -32,7 +32,7 @@ db.profiles.update({
 // -------- ARCHIVE_SEARCH PROFILE WITHOUT RULES MANAGEMENT -----
 
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_without_rules",
    "identifier":NumberInt(26),
    "name":"Profil pour la recherche et consultation des archives sans mises à jour des règles",

--- a/deployment/scripts/mongod/2.0.0/25_update_and_create_profiles_archive_search.js.j2
+++ b/deployment/scripts/mongod/2.0.0/25_update_and_create_profiles_archive_search.js.j2
@@ -19,7 +19,7 @@ db.profiles.updateOne({
    }
 });
 
-db.profiles.update({
+db.profiles.updateOne({
    "_id":"system_archive_search_profile"
 },
 {

--- a/deployment/scripts/mongod/2.0.0/25_update_iam_rules.js.j2
+++ b/deployment/scripts/mongod/2.0.0/25_update_iam_rules.js.j2
@@ -22,7 +22,7 @@ db.profiles.update( {
 
 var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identifier'}).sequence;
 
-db.profiles.insert({
+db.profiles.insertOne({
 	"_id" : "auto_system_rules",
 	"identifier" : NumberInt(maxIdProfile++),
 	"name" : "Auto Rules Profile",

--- a/deployment/scripts/mongod/2.0.0/25_update_iam_rules.js.j2
+++ b/deployment/scripts/mongod/2.0.0/25_update_iam_rules.js.j2
@@ -4,7 +4,7 @@ print("START 25_update_iam_rules.js");
 
 // ========================================= PROFILES =========================================
 
-db.profiles.update( {
+db.profiles.updateOne( {
 	"_id": "system_rules"
 }, {
     $addToSet: {

--- a/deployment/scripts/mongod/2.0.0/28_update_create_profiles_archive_search.js.j2
+++ b/deployment/scripts/mongod/2.0.0/28_update_create_profiles_archive_search.js.j2
@@ -32,7 +32,7 @@ db.profiles.update({
 
 // -------- ARCHIVE_SEARCH PROFILE WITH RULES MANAGEMENT AND WITHOUT DIP EXPORT -----
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_with_rules_without_export",
    "identifier":NumberInt(27),
    "name":"Profil pour la recherche et consultation des archives avec mises à jour des règles et sans export DIP",
@@ -62,7 +62,7 @@ db.profiles.insert({
 
 // -------- ARCHIVE_SEARCH PROFILE WITH DIP EXPORT AND WITHOUT RULES MANAGEMENT -----
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_without_rules_with_export",
    "identifier":NumberInt(29),
    "name":"Profil pour la recherche et consultation des archives avec export DIP et sans mises à jour des règles",

--- a/deployment/scripts/mongod/2.0.0/28_update_create_profiles_archive_search.js.j2
+++ b/deployment/scripts/mongod/2.0.0/28_update_create_profiles_archive_search.js.j2
@@ -19,7 +19,7 @@ db.profiles.updateOne({
    }
 });
 
-db.profiles.update({
+db.profiles.updateOne({
    "_id":"system_archive_search_profile"
 },
 {
@@ -91,7 +91,7 @@ db.profiles.insertOne({
 
 // -------- ARCHIVE_SEARCH PROFILE WITHOUT RULES MANAGEMENT AND WITHOUT DIP EXPORT-----
 
-db.profiles.update({
+db.profiles.updateOne({
    "_id":"system_archive_search_profile_without_rules"
 },
 {

--- a/deployment/scripts/mongod/2.0.0/33_update_create_profiles_archive_search_to_add_elimination.js.j2
+++ b/deployment/scripts/mongod/2.0.0/33_update_create_profiles_archive_search_to_add_elimination.js.j2
@@ -19,7 +19,7 @@ db.profiles.updateOne({
    }
 });
 
-db.profiles.update({
+db.profiles.updateOne({
    "_id":"system_archive_search_profile"
 },
 {
@@ -46,7 +46,7 @@ db.profiles.updateOne({
    }
 });
 
-db.profiles.update({
+db.profiles.updateOne({
    "_id":"system_archive_search_profile_with_rules_without_export"
 },
 {

--- a/deployment/scripts/mongod/2.0.0/33_update_create_profiles_archive_search_to_add_elimination.js.j2
+++ b/deployment/scripts/mongod/2.0.0/33_update_create_profiles_archive_search_to_add_elimination.js.j2
@@ -74,7 +74,7 @@ db.profiles.updateOne({
    }
 });
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_without_rules_with_export_and_with_elimination",
    "identifier":NumberInt(30),
    "name":"Profil pour la recherche et consultation des archives avec export DIP et opérations d'éliminations et sans mises à jour des règles",

--- a/deployment/scripts/mongod/2.0.0/36_create_new_archive_search_profiles.js.j2
+++ b/deployment/scripts/mongod/2.0.0/36_create_new_archive_search_profiles.js.j2
@@ -4,7 +4,7 @@ print("START_36_create_new_archive_search_profiles.js");
 
 // -------- ARCHIVE_SEARCH PROFILE : CONSULTATION -----
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_consultation",
    "identifier":NumberInt(34),
    "name":"Consultation",
@@ -33,7 +33,7 @@ db.profiles.insert({
 
 // -------- ARCHIVE_SEARCH PROFILE : ARCHIVISTE -----
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_archiviste",
    "identifier":NumberInt(35),
    "name":"Archiviste",
@@ -65,7 +65,7 @@ db.profiles.insert({
 
 // -------- ARCHIVE_SEARCH PROFILE : ARCHIVISTE ADMINISTRATEUR-----
 
-db.profiles.insert({
+db.profiles.insertOne({
    "_id":"system_archive_search_profile_archiviste_administrator",
    "identifier":NumberInt(36),
    "name":"Archiviste administrateur",

--- a/deployment/scripts/mongod/2.0.0/37_update_admin_group.js.j2
+++ b/deployment/scripts/mongod/2.0.0/37_update_admin_group.js.j2
@@ -29,7 +29,7 @@ db.groups.updateOne({
 });
 
 
-db.groups.update({
+db.groups.updateOne({
     "_id": "5c79022e7884583d1ebb6e5d0bc0121822684250a3fd2996fd93c04634363363"
   }, {
     $pull: {
@@ -37,7 +37,7 @@ db.groups.update({
     }
   });
 
-db.groups.update({
+db.groups.updateOne({
     "_id": "admin_group"
   }, {
     $pull: {

--- a/deployment/scripts/mongod/2.0.0/38_update_external_params_profiles_app_multi_tenant_flag.js.j2
+++ b/deployment/scripts/mongod/2.0.0/38_update_external_params_profiles_app_multi_tenant_flag.js.j2
@@ -4,7 +4,7 @@ print("START_38_update_external_params_profiles_app_multi_tenant_flag.js");
 
 // -------- EXTERNAL_PARAM_PROFILE_APP  -----
 
-db.applications.update({
+db.applications.updateOne({
    "identifier":"EXTERNAL_PARAM_PROFILE_APP"
 },
 {

--- a/deployment/scripts/mongod/2.0.0/39_update_external_params_profiles_app_multi_tenant_flag.js.j2
+++ b/deployment/scripts/mongod/2.0.0/39_update_external_params_profiles_app_multi_tenant_flag.js.j2
@@ -4,7 +4,7 @@ print("START_39_update_external_params_profiles_app_multi_tenant_flag.js");
 
 // -------- EXTERNAL_PARAM_PROFILE_APP  -----
 
-db.profiles.update({
+db.profiles.updateOne({
    "applicationName":"EXTERNAL_PARAM_PROFILE_APP"
 },
 {

--- a/deployment/scripts/mongod/2.0.0/40_update_application_file_format_app_ref_to_be_multi_tenant.js.j2
+++ b/deployment/scripts/mongod/2.0.0/40_update_application_file_format_app_ref_to_be_multi_tenant.js.j2
@@ -4,7 +4,7 @@ print("START_40_update_application_file_format_app_ref_to_be_multi_tenant.js");
 
 // =============== REFERENTIAL : FILE_FORMATS_APP ==========
 
-db.applications.update(
+db.applications.updateOne(
   {
     identifier: "FILE_FORMATS_APP",
   },

--- a/deployment/scripts/mongod/2.0.0/41_add_search_with_rules_role_to_old_system_archive_profile.js.j2
+++ b/deployment/scripts/mongod/2.0.0/41_add_search_with_rules_role_to_old_system_archive_profile.js.j2
@@ -20,7 +20,7 @@ db.profiles.updateOne({
 });
 
 // ---- DELETE EXISTING ROLES ROLE_EXPORT_DIP AND ROLE_ELIMINATION TO BE CONFORM WITH CONSULTATION PROFILE FOR EXISTING USERS
-db.profiles.update({
+db.profiles.updateOne({
     "_id": "system_archive_search_profile"
   }, {
     $pull: {
@@ -30,7 +30,7 @@ db.profiles.update({
     }
   });
 
-db.profiles.update({
+db.profiles.updateOne({
     "_id": "system_archive_search_profile"
   }, {
     $pull: {

--- a/deployment/scripts/mongod/2.0.0/47_create_new_profiles_during_upgrade.js.j2
+++ b/deployment/scripts/mongod/2.0.0/47_create_new_profiles_during_upgrade.js.j2
@@ -11,7 +11,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     //= CREATE NEW PROFILES FOR ARCHIVE_SEARCH_MANAGEMENT_APP DURING UPGRADE =//
 
     // ARCHIVE_SEARCH_MANAGEMENT_APP : CONSULTATION
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-ARCHIVE_SEARCH_MANAGEMENT_APP-CONSULTATION",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Consultation",
@@ -39,7 +39,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     });
 
     // ARCHIVE_SEARCH_MANAGEMENT_APP : ARCHIVISTE
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-ARCHIVE_SEARCH_MANAGEMENT_APP-ARCHIVISTE",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Archiviste",
@@ -70,7 +70,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     });
 
     // ARCHIVE_SEARCH_MANAGEMENT_APP : ARCHIVISTE ADMINISTRATEUR
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-ARCHIVE_SEARCH_MANAGEMENT_APP-ADMIN",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Archiviste administrateur",
@@ -106,7 +106,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     //=============== ADD PROFILES FOR NEW APPS DURING UPGRADE ===============//
 
     // ACCESSION_REGISTER_APP
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-ACCESSION_REGISTER_APP-DEFAULT",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Profil complet du registre des fonds",
@@ -125,7 +125,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     });
 
     // LOGBOOK_MANAGEMENT_OPERATION_APP
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-LOGBOOK_MANAGEMENT_OPERATION_APP-DEFAULT",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Profil complet de gestion des opérations",
@@ -150,7 +150,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
     });
 
     // EXTERNAL_PARAM_PROFILE_APP
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-EXTERNAL_PARAM_PROFILE_APP-DEFAULT",
         "identifier": NumberInt(maxIdProfile++),
         "name": "Profil complet de gestion des profils paramétrage externe",

--- a/deployment/scripts/mongod/2.0.0/48_create_new_profiles_pastis_during_upgrade.js.j2
+++ b/deployment/scripts/mongod/2.0.0/48_create_new_profiles_pastis_during_upgrade.js.j2
@@ -10,7 +10,7 @@ db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
 
     //= CREATE NEW PROFILES FOR PASTIS_APP DURING UPGRADE =//
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-PASTIS_APP-DEFAULT",
     	"identifier" : NumberInt(maxIdProfile++),
     	"name" : "Pastis Profile",

--- a/deployment/scripts/mongod/2.0.0/48_migrate_archivesearch_profiles.js.j2
+++ b/deployment/scripts/mongod/2.0.0/48_migrate_archivesearch_profiles.js.j2
@@ -43,7 +43,7 @@ db.groups.aggregate([
 });
 
 //======== DELETE OLD PROFILES FOR APP ARCHIVE_SEARCH_MANAGEMENT_APP ========//
-db.profiles.remove(
+db.profiles.deleteMany(
     {
         $and: [
             { "applicationName": "ARCHIVE_SEARCH_MANAGEMENT_APP" },

--- a/deployment/scripts/mongod/2.0.0/54_update_archive_search_application_informations.js.j2
+++ b/deployment/scripts/mongod/2.0.0/54_update_archive_search_application_informations.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START_54_update_archive_search_application_informations.js");
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "ARCHIVE_SEARCH_MANAGEMENT_APP"
 }, {
     $set: {

--- a/deployment/scripts/mongod/5.4.0/001_RABB-1262_add_iam_internal_context_ref.js.j2
+++ b/deployment/scripts/mongod/5.4.0/001_RABB-1262_add_iam_internal_context_ref.js.j2
@@ -3,7 +3,7 @@ print("START 001_RABB-1262_add_iam_internal_context_ref.js");
 db = db.getSiblingDB('security')
 
 // Add context
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "iam_internal_context",
     "name": "Context Iam Internal",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/5.4.0/002_RABB-1262_add_iam_internal.populate_certificates_ref.js.j2
+++ b/deployment/scripts/mongod/5.4.0/002_RABB-1262_add_iam_internal.populate_certificates_ref.js.j2
@@ -7,7 +7,7 @@ db.certificates.remove(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/scripts/mongod/5.4.0/002_RABB-1262_add_iam_internal.populate_certificates_ref.js.j2
+++ b/deployment/scripts/mongod/5.4.0/002_RABB-1262_add_iam_internal.populate_certificates_ref.js.j2
@@ -3,7 +3,7 @@ print("START 002_RABB-1262_add_iam_internal.populate_certificates_ref.js");
 db = db.getSiblingDB('security')
 
 {% macro insertCertificate(pemFile, contextId, host) -%}
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/scripts/mongod/6.rc.0/01_add_consult_agencies_profil.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/01_add_consult_agencies_profil.js.j2
@@ -8,7 +8,7 @@ var lastIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_iden
 
 db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-AGENCIES_APP-CONSULTATION",
         "identifier": NumberInt(lastIdProfile++),
         "name": "Profil consultation des services agents",

--- a/deployment/scripts/mongod/6.rc.0/02_add_collect_module_application.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/02_add_collect_module_application.js.j2
@@ -4,7 +4,7 @@ print("START 6.rc.0/02_add_collect_module_application.js");
 
 //============================ CREATE COLLECT APP ==============================
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "COLLECT_APP",
 {% if vitamui.collect.base_url is defined %}
     "url": "{{ vitamui.collect.base_url }}/collect",
@@ -30,7 +30,7 @@ var lastIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_iden
 
 db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-COLLECT_APP-ARCHIVISTE",
         "identifier": NumberInt(lastIdProfile++),
         "name": "Collect Profile",

--- a/deployment/scripts/mongod/6.rc.0/03_update_cas_services_with_collect_application.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/03_update_cas_services_with_collect_application.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('cas')
 
 print("START 6.rc.0/03_update_cas_services_with_collect_application.js");
 
-var nbInsert = db.services.insert({
+var nbInsert = db.services.insertOne({
    "_id" : NumberInt(7),
    "_class": "org.apereo.cas.services.RegexRegisteredService",
 {% if vitamui.collect.base_url is defined %}

--- a/deployment/scripts/mongod/6.rc.0/04_update_certificates_collection_with_collect_certificate.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/04_update_certificates_collection_with_collect_certificate.js.j2
@@ -4,11 +4,11 @@ print("START 6.rc.0/04_update_certificates_collection_with_collect_certificate.j
 
 {% macro insertCertificate(pemFile, contextId, host) -%}
 
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.remove(
+db.certificates.deleteOne(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )

--- a/deployment/scripts/mongod/6.rc.0/04_update_certificates_collection_with_collect_certificate.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/04_update_certificates_collection_with_collect_certificate.js.j2
@@ -12,7 +12,7 @@ db.certificates.remove(
     {"_id" : "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}"},
     { justOne: true }
 )
-db.certificates.insert({
+db.certificates.insertOne({
     "_id": "{{ host }}_{{ pemFile | basename | replace('.pem','_cert')}}",
     "contextId": "{{ contextId }}",
     "subjectDN": "subjectDN",

--- a/deployment/scripts/mongod/6.rc.0/05_update_contexts_with_collect_roles.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/05_update_contexts_with_collect_roles.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('security')
 
 print("START 6.rc.0/05_update_contexts_with_collect_roles.js");
 
-db.contexts.insert({
+db.contexts.insertOne({
     "_id" : "ui_collect_context",
     "name": "Contexte UI Collect",
     "fullAccess" : true,

--- a/deployment/scripts/mongod/6.rc.0/07_add_consult_rules_profil.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/07_add_consult_rules_profil.js.j2
@@ -8,7 +8,7 @@ var lastIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_iden
 
 db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-RULES_APP-CONSULTATION",
         "identifier": NumberInt(lastIdProfile++),
         "name": "Profil consultation des règles de gestion",

--- a/deployment/scripts/mongod/6.rc.0/08_create_search_criteria_history_collect.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/08_create_search_criteria_history_collect.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('{{ mongodb.archivesearch.db }}')
 
 print("START 08_create_search_criteria_history_collect.js");
 
-db.searchCriteriaHistoriesCollect.remove({});
+db.searchCriteriaHistoriesCollect.deleteMany({});
 db.createCollection('searchCriteriaHistoriesCollect', {autoIndexId: true});
 
 print("END 08_create_search_criteria_history_collect.js");

--- a/deployment/scripts/mongod/6.rc.0/24_update_hasTenantList_application_COLLECT_APP.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/24_update_hasTenantList_application_COLLECT_APP.js.j2
@@ -2,7 +2,7 @@ db = db.getSiblingDB('iam')
 
 print("START_24_update_hasTenantList_application_COLLECT_APP.js");
 
-db.applications.update({
+db.applications.updateOne({
     "identifier" : "COLLECT_APP"
 }, {
     $set: {

--- a/deployment/scripts/mongod/6.rc.0/35_add_consult_ingest_contract_profil.js.j2
+++ b/deployment/scripts/mongod/6.rc.0/35_add_consult_ingest_contract_profil.js.j2
@@ -8,7 +8,7 @@ var lastIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_iden
 
 db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id": "PROFIL_" + tenant.identifier + "-INGEST_APP-CONSULTATION",
         "identifier": NumberInt(lastIdProfile++),
         "name": "Profil pour la consultation des contrats d'entrée",

--- a/deployment/scripts/mongod/v6.0/21_create_profile_MANAGEMENT_CONTRACT_APP.js.j2
+++ b/deployment/scripts/mongod/v6.0/21_create_profile_MANAGEMENT_CONTRACT_APP.js.j2
@@ -8,7 +8,7 @@ var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identi
 
 db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
 
-    db.profiles.insert({
+    db.profiles.insertOne({
         "_id" : "PROFIL_" + tenant.identifier + "-MANAGEMENT_CONTRACT_APP-ADMIN",
         "identifier" : NumberInt(maxIdProfile++),
         "name" : "Contrats de gestion",

--- a/deployment/scripts/mongod/v6.0/22_create_application_MANAGEMENT_CONTRACT_APP.js.j2
+++ b/deployment/scripts/mongod/v6.0/22_create_application_MANAGEMENT_CONTRACT_APP.js.j2
@@ -4,7 +4,7 @@ print("START_22_create_application_MANAGEMENT_CONTRACT_APP.js");
 
 // -------- CREATE NEW VITAMUI APPLICATION : MANAGEMENT CONTRACT -----
 
-db.applications.insert({
+db.applications.insertOne({
     "identifier" : "MANAGEMENT_CONTRACT_APP",
 {% if vitamui.referential.base_url is defined %}
     "url": "{{ vitamui.referential.base_url }}/management-contract",

--- a/docs/fr/exploitation/sections/procedure.md
+++ b/docs/fr/exploitation/sections/procedure.md
@@ -162,7 +162,7 @@ Se connecter à la base de données via l'utilitaire mongo.
 Exemple de commande:
 
 ~~~console
-mongo --host <ip machine> --port 27017 admin --username=<user> --password=<password>
+mongosh --host <ip machine> --port 27017 admin --username=<user> --password=<password>
 ~~~
 
 ---

--- a/docs/fr/migration/index.rst
+++ b/docs/fr/migration/index.rst
@@ -14,4 +14,5 @@ Documentation de montée de version Vitam-UI
    upgrade_v5rc.md
    upgrade_v5.md
    upgrade_v6rc.md
-
+   upgrade_v6.md
+   upgrade_v7_1.md

--- a/docs/fr/migration/upgrade_v7_1.md
+++ b/docs/fr/migration/upgrade_v7_1.md
@@ -1,0 +1,77 @@
+# Procédure de Montée de version VitamUI V7.1
+
+> Attention: Veuillez appliquer les procédures spécifiques à chacune des versions précédentes en fonction de la version de départ selon la suite suivante: V5 -> V6RC -> V6 -> V7.0.
+
+## Adaptation des sources de déploiement ansible
+
+N/A
+
+---
+
+## Procédures à exécuter AVANT la montée de version
+
+### Mise à jour des dépôts (YUM/APT)
+
+> Cette opération doit être effectuée AVANT la montée de version
+
+Afin de pouvoir déployer la nouvelle version, vous devez mettre à jour la variable ``vitam_repositories`` sous ``environments/group_vars/all/repositories.yml`` afin de renseigner les dépôts à la version cible.
+
+Puis exécutez le playbook suivant :
+
+```sh
+ansible-playbook -i environments/<inventaire> ansible-vitamui-extra/bootstrap.yml --ask-vault-pass
+```
+
+### Montée de version vers mongo 6.0
+
+> Attention: Cette montée de version doit être effectuée AVANT la montée de version V7.1 de VitamUI.
+> Cette opération doit être effectuée après avoir mis à jour les dépôts Vitam en V7.1.
+> Il est recommandé d'effectuer un backup de la base de données à l'aide de mongodump avant de poursuivre.
+
+Exécutez le playbook suivant à partir de l'ansiblerie de la V7.1 :
+
+```sh
+ansible-playbook -i environments/<inventaire> ansible-vitamui-migration/migration_mongodb_60.yml --ask-vault-pass
+```
+
+### Montée de version vers mongo 7.0
+
+> Attention: Cette montée de version doit être effectuée AVANT la montée de version V7.1 de VitamUI et après la montée de version de MongoDB 6.0 ci-dessus.
+> Cette opération doit être effectuée après avoir mis à jour les dépôts Vitam en V7.1.
+
+Exécutez le playbook suivant à partir de l'ansiblerie de la V7.1 :
+
+```sh
+ansible-playbook -i environments/<inventaire> ansible-vitamui-migration/migration_mongodb_70.yml --ask-vault-pass
+```
+
+Une fois les montées de version de MongoDB réalisées, la montée de version Vitam peut être réalisée.
+
+### Arrêt complet de VitamUI
+
+> Cette opération doit être effectuée AVANT la montée de version vers la V7.1.
+> Cette opération doit être effectuée avec les sources de déploiement de l'ancienne version.
+
+VitamUI doit être arrêté :
+
+```sh
+ansible-playbook -i environments/<inventaire> ansible-vitamui-exploitation/stop_vitamui.yml --ask-vault-pass
+```
+
+---
+
+## Application de la montée de version
+
+### Lancement du master playbook vitam
+
+> Cette opération doit être effectuée avec les sources de déploiement de la V7.1.
+
+```sh
+ansible-playbook -i environments/<inventaire> ansible-vitamui/vitamui.yml --ask-vault-pass
+```
+
+---
+
+## Procédures à exécuter APRÈS la montée de version
+
+N/A

--- a/tools/docker/mongo/database_scripts/1.0.0/207_TRTL_357_rename_logoDataBase64_set_colors_ref.js
+++ b/tools/docker/mongo/database_scripts/1.0.0/207_TRTL_357_rename_logoDataBase64_set_colors_ref.js
@@ -15,7 +15,7 @@ db.customers.find(
     }
 ).forEach(function (customer) {
     if (customer.graphicIdentity && customer.graphicIdentity.themeColors && customer.graphicIdentity.themeColors['vitamui-primary']) {
-        db.customers.update(
+        db.customers.updateOne(
             { _id: customer._id },
             {
               $set: {


### PR DESCRIPTION
## Description

* Remove deprecated packages: mongodb-org-tools & mongodb-org-shell.
* Update scripts and commands for using mongosh instead of former mongo shell.
* Fix mongo services that restart always (can cause errors during upgrade).
* Add migration playbooks to upgrade to MongoDB 6.0 then 7.0.
* Add migration documentation for VitamUI V7.1.

## Type de changement

* Ansiblerie
* Documentation

## Contributeur

* VAS (Vitam Accessible en Service)