### PR TITLE
Story #11567: Fix mongo-tools for AlmaLinux.

### DIFF
--- a/deployment/roles/mongo_common/tasks/main.yml
+++ b/deployment/roles/mongo_common/tasks/main.yml
@@ -5,29 +5,13 @@
     name:
       - mongodb-org-shell
       - mongodb-mongosh
-      - mongodb-org-tools
+      - mongodb-database-tools
     state: present
   register: result
   retries: "{{ packages_install_retries_number }}"
   until: result is succeeded
   delay: "{{ packages_install_retries_delay }}"
-  when: ansible_distribution == "CentOS" or ansible_distribution == "Debian"
 
-### WIP: Temporary solution
-## mongodb-org-tools is currently incompatible with AlmaLinux.
-## compat-openssl10 is mandatory to allow usage of SSLv1.0 with mongodb.
-- name: Install common mongodb packages
-  package:
-    name:
-      - compat-openssl10
-      - mongodb-org-shell
-      - mongodb-mongosh
-    state: present
-  register: result
-  retries: "{{ packages_install_retries_number }}"
-  until: result is succeeded
-  delay: "{{ packages_install_retries_delay }}"
-  when: ansible_distribution == "AlmaLinux"
 ### System tuning best practices ####
 
 # next steps in order to disable Transparent HugePages

--- a/deployment/roles/mongodb_upgrade_package/tasks/main.yml
+++ b/deployment/roles/mongodb_upgrade_package/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 
-# Upgrade mongo packages
-- name: Update mongosh and tools packages
+- name: Remove deprecated mongodb packages
+  package:
+    name:
+      - mongodb-org-tools
+      - mongodb-org-database-tools-extra
+    state: absent
+
+- name: Update common mongodb packages
   package:
     name:
       - mongodb-mongosh

--- a/deployment/roles/mongodb_upgrade_package/tasks/update_packages_mongod.yml
+++ b/deployment/roles/mongodb_upgrade_package/tasks/update_packages_mongod.yml
@@ -48,7 +48,6 @@
       name:
         - "mongodb-org-server-{{ mongo_version }}"
         - "mongodb-org-shell-{{ mongo_version }}"
-        - "mongodb-org-tools-{{ mongo_version }}"
       state: present
       update_cache: yes   # make sure cache is up to date for upgrade
     register: result
@@ -62,7 +61,6 @@
       name:
         - "mongodb-org-server={{ mongo_version }}"
         - "mongodb-org-shell={{ mongo_version }}"
-        - "mongodb-org-tools={{ mongo_version }}"
       state: present
       update_cache: yes   # make sure cache is up to date for upgrade
     register: result


### PR DESCRIPTION
## Description

* Install proper mongodb-database-tools instead of deprecated mongodb-org-tools to allow proper usage on AlmaLinux 9.

## Type de changement

* Ansiblerie

## Contributeur

* VAS (Vitam Accessible en Service)