### PR TITLE
CP 6RC - DS 11927: Bind to the proper host for VitamUI services in consul.

### DIFF
--- a/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
@@ -3,7 +3,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/collect-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect-external/application.yml.j2
@@ -3,7 +3,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/collect-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect-internal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/iam-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-external/application.yml.j2
@@ -3,7 +3,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-external/application.yml.j2
@@ -3,7 +3,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/pastis-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis-external/application.yml.j2
@@ -16,7 +16,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/referential-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-external/application.yml.j2
@@ -3,7 +3,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/security-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/security-internal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-archive-search/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-collect/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity-admin/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-identity/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-ingest/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-pastis/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-pastis/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.consul
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-portal/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}

--- a/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ui-referential/application.yml.j2
@@ -2,7 +2,6 @@ spring:
   cloud:
     consul:
       enabled: true
-      host: consul.service.{{ consul_domain }}
       discovery:
         preferIpAddress: true
         tags: {{ consul_tags }}


### PR DESCRIPTION
## Description

Permet d'associer le bon host aux services VitamUI dans Consul.

Autrement les services semblent démarrés sur le consul-server.

## Type de changement

* Ansiblerie

## Tests

* Tests manuel et intégration sur environnement Vitam.

## Contributeur

* CEA (Commissariat à l'énergie atomique et aux énergies alternatives)
  * Contribution from Bénédicte Martinez.