### PR TITLE
Bug 11935 & Story 11979: Fix for cluster replicaset deployement & add is_small and arbiter parameters.

### DIFF
--- a/deployment/ansible-vitamui/mongo.yml
+++ b/deployment/ansible-vitamui/mongo.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: hosts_vitamui_mongod
+  any_errors_fatal: true
   roles:
     - mongo_common
     - mongo

--- a/deployment/environments/hosts-ui.example
+++ b/deployment/environments/hosts-ui.example
@@ -149,14 +149,19 @@ hosts_vitamui_mongod
 
 [hosts_vitamui_mongod]
 # EDIT: Mandatory
-# Mandatory params
-#  - mongo_rs_bootstrap=true (default: false)
 # Optional params
+#  - mongo_rs_bootstrap=true (default: false); mandatory for 1 node of the shard, some init commands will be executed on it
 #  - mongo_cluster_name=mongo-vitamui (default: mongo-vitamui)
 #  - mongo_shard_id=0 (default: 0)
+#  - mongo_arbiter=true ; the node will be only an arbiter, it will not store data ; do not add this parameter on a mongo_rs_bootstrap node, maximum 1 node per shard
+#  - mongod_memory=x (default: unset); this will force the wiredtiger cache size to x (unit is GB)
+#  - is_small=true (default: false); this will force the priority for this server to be lower when electing master ; hardware can be downgraded for this machine
 #  - mongo_express_enabled=true to deploy mongo_express (default: false)
-# Example:
-# vm-mongo-ui mongo_rs_bootstrap=true mongo_express_enabled=true
+# Recommended practice in production: use 3 instances per shard
+# Example for a PSSmin deployment:
+# vm1-mongo-ui mongo_rs_bootstrap=true mongo_express_enabled=true
+# vm2-mongo-ui
+# vm3-mongo-ui mongod_memory=1 is_small=true
 
 
 ################################################################################

--- a/deployment/environments/hosts.local
+++ b/deployment/environments/hosts.local
@@ -165,16 +165,20 @@ hosts_vitamui_mongod
 
 [hosts_vitamui_mongod]
 # EDIT: Mandatory
-# WARNING: put only one server for this service, not more !
-# Mandatory params
-#  - mongo_rs_bootstrap=true (default: false)
 # Optional params
+#  - mongo_rs_bootstrap=true (default: false); mandatory for 1 node of the shard, some init commands will be executed on it
 #  - mongo_cluster_name=mongo-vitamui (default: mongo-vitamui)
 #  - mongo_shard_id=0 (default: 0)
-#  - mongo_express=true to deploy mongo_express (default: false)
-# Example:
-# vm-mongo-ui mongo_rs_bootstrap=true mongo_express=true
-localhost mongo_rs_bootstrap=true mongo_express=true
+#  - mongo_arbiter=true ; the node will be only an arbiter, it will not store data ; do not add this parameter on a mongo_rs_bootstrap node, maximum 1 node per shard
+#  - mongod_memory=x (default: unset); this will force the wiredtiger cache size to x (unit is GB)
+#  - is_small=true (default: false); this will force the priority for this server to be lower when electing master ; hardware can be downgraded for this machine
+#  - mongo_express_enabled=true to deploy mongo_express (default: false)
+# Recommended practice in production: use 3 instances per shard
+# Example for a PSSmin deployment:
+# vm1-mongo-ui mongo_rs_bootstrap=true mongo_express_enabled=true
+# vm2-mongo-ui
+# vm3-mongo-ui mongod_memory=1 is_small=true
+localhost mongo_rs_bootstrap=true mongo_express_enabled=true
 
 ################################################################################
 # ZONE INFRA

--- a/deployment/roles/mongo/tasks/check_auth.yml
+++ b/deployment/roles/mongo/tasks/check_auth.yml
@@ -5,29 +5,21 @@
   register: mongo_authent_enabled
   failed_when: false
   no_log: "{{ hide_passwords_during_deploy }}"
-  tags:
-    - update_mongodb_configuration
-
-# Set mongo_no_auth facts
-
-- name: Set default mongo facts
-  set_fact:
-    mongo_credentials: ""
-    mongo_no_auth: false
-  tags:
-    - update_mongodb_configuration
+  tags: update_mongodb_configuration
 
 - name: Set mongo_no_auth fact to true
   set_fact:
+    mongo_credentials: ""
     mongo_no_auth: true
   when: "mongo_authent_enabled.rc != 0"
-  tags:
-    - update_mongodb_configuration
+  tags: update_mongodb_configuration
 
 # When authentication is required, we set mongodb admin credentials
 - name: Set mongodb authentication credentials
   set_fact:
     mongo_credentials: "-u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }}"
+    mongo_no_auth: false
   when: "mongo_authent_enabled.rc == 0"
   no_log: "{{ hide_passwords_during_deploy }}"
+  tags: update_mongodb_configuration
 

--- a/deployment/roles/mongo/tasks/main.yml
+++ b/deployment/roles/mongo/tasks/main.yml
@@ -145,6 +145,10 @@
 
 - block:
 
+    - fail:
+        msg: "ERROR: mongo_rs_bootstrap node can't be mongo_arbiter !"
+      when: mongo_arbiter | default(false) | bool == true
+
     - name: Wait for the service port to be open on all members of the replica
       wait_for:
         host: "{{ hostvars[item]['ip_service'] }}"
@@ -152,8 +156,7 @@
         timeout: "{{ vitamui_defaults.services.start_timeout }}"
       with_items:
         - "{{ groups['hosts_vitamui_mongod'] }}"
-      tags:
-        - update_mongodb_configuration
+      tags: update_mongodb_configuration
 
     - name: Copy the script which initiate the replica set
       template:
@@ -162,23 +165,11 @@
         owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
         group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
         mode: "{{ vitamui_defaults.folder.conf_permission | default('0440') }}"
-      tags:
-        - update_mongodb_configuration
-
-    # - name: Copy script that restore configuration of mongod sharded cluster
-    #   template:
-    #     src: "restore-mongod.js.j2"
-    #     dest: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/restore-mongod.js"
-    #     owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
-    #     group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
-    #     mode: "{{ vitamui_defaults.folder.conf_permission | default('0440') }}"
-    #   tags:
-    #     - update_mongodb_configuration
+      tags: update_mongodb_configuration
 
     - name: Initiate the replica set
       command: "mongosh --host {{ ip_service }} --port {{ mongodb.mongod_port }} --quiet --file {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/init-replica.js"
-      tags:
-        - update_mongodb_configuration
+      tags: update_mongodb_configuration
 
     - import_tasks: check_auth.yml
 
@@ -190,12 +181,10 @@
         owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
         group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
         mode: "{{ vitamui_defaults.folder.conf_permission | default('0440') }}"
-      tags:
-        - update_mongodb_configuration
+      tags: update_mongodb_configuration
 
     - name: Create the local shard user
       command: "mongosh --host {{ ip_service }} --port {{ mongodb.mongod_port }} {{ mongo_credentials }} --quiet --file {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/local-user.js"
-      tags:
-        - update_mongodb_configuration
+      tags: update_mongodb_configuration
 
-  when: mongo_rs_bootstrap is defined and mongo_rs_bootstrap|lower == "true"
+  when: mongo_rs_bootstrap | default(false) | bool == true

--- a/deployment/roles/mongo/templates/init-replica.js.j2
+++ b/deployment/roles/mongo/templates/init-replica.js.j2
@@ -101,7 +101,7 @@ function waitForReplicaSetPrimaryElection() {
             throw "ERROR : Cannot get mongod replica set status";
         }
 
-        if (status.myState === 1) {
+        if (status.members.find(member => member.stateStr === 'PRIMARY')) {
             print("OK : mongod replica set elected primary node");
             return;
         }

--- a/deployment/roles/mongo/templates/init-replica.js.j2
+++ b/deployment/roles/mongo/templates/init-replica.js.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: True
 /*
  * IMPORTANT :
  * - This script creates mongod replica set on first Vitam installation.
@@ -8,7 +9,7 @@
  */
 
 function checkExistingReplicaSet() {
-
+    print("INFO: checkExistingReplicaSet");
     try {
         var rsStatus = rs.status();
 
@@ -32,6 +33,7 @@ function checkExistingReplicaSet() {
 }
 
 function checkExistingReplicaSetMembers() {
+    print("INFO: checkExistingReplicaSetMembers");
     try {
         var rsConfig = rs.config();
 
@@ -59,21 +61,25 @@ function checkExistingReplicaSetMembers() {
 }
 
 function buildTargetReplicaSetMemberConfiguration() {
+    print("INFO: buildTargetReplicaSetMemberConfiguration");
     var idCpt = 0;
-    let members = [ { _id: idCpt++, host: "{{ ip_service }}:{{ mongodb.mongod_port }}" } ];
+    let members = [];
 {% for host in groups['hosts_vitamui_mongod'] %}
-    {% if hostvars[host]['mongo_rs_bootstrap'] is not defined or hostvars[host]['mongo_rs_bootstrap'] | lower != "true" %}
     members.push({
         _id: idCpt++,
-        host: "{{ hostvars[host]['ip_service'] }}:{{ mongodb.mongod_port }}"
+        host: "{{ hostvars[host]['ip_service'] }}:{{ mongodb.mongod_port }}",
+        {% if (hostvars[host]['mongo_rs_bootstrap'] | default(false) | bool != true) and (hostvars[host]['mongo_arbiter'] | default(false) | bool == true) %}
+        arbiterOnly: true
+        {% else %}
+        priority: {{ '1' if (hostvars[host]['is_small'] | default(false) | bool == true) else '10' }}
+        {% endif %}
     });
-    {% endif %}
 {% endfor %}
     return members;
 }
 
 function initReplicaSetPrimary() {
-
+    print("INFO: initReplicaSetPrimary");
     let members = buildTargetReplicaSetMemberConfiguration();
 
     let rsInit = rs.initiate(
@@ -90,7 +96,7 @@ function initReplicaSetPrimary() {
 }
 
 function waitForReplicaSetPrimaryElection() {
-
+    print("INFO: waitForReplicaSetPrimaryElection");
     var status;
     for (let i = 0; i < 60; i++) {
 
@@ -115,7 +121,7 @@ function waitForReplicaSetPrimaryElection() {
 }
 
 function waitForWritablePrimary() {
-
+    print("INFO: waitForWritablePrimary");
     var instanceStatus;
     for (let i = 0; i < 60; i++) {
 
@@ -127,7 +133,7 @@ function waitForWritablePrimary() {
         }
 
         if (instanceStatus.isWritablePrimary) {
-            print("OK : Primary node is writable");
+            print("OK : Primary node " + instanceStatus.primary + " is writable");
             return;
         }
 

--- a/deployment/roles/mongo_init/tasks/check_auth.yml
+++ b/deployment/roles/mongo_init/tasks/check_auth.yml
@@ -7,7 +7,7 @@
 
 - block:
     - name: Check if authent is enabled
-      command: "mongosh --host \"mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }}\" -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
+      command: "mongosh mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
       register: mongo_authent_enabled
       failed_when: false
       no_log: "{{ hide_passwords_during_deploy }}"
@@ -20,7 +20,7 @@
 
 - block:
     - name: Load script in database (docker)
-      shell: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh --host mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'\""
+      shell: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'\""
 
       failed_when: false
       register: mongo_authent_enabled

--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -1,110 +1,114 @@
 ---
 
-- fail: msg="Variable '{{ mongod_source_template_dir }}' is not defined"
-  when: mongod_source_template_dir is undefined
+- block:
 
-- name: Compute list of mongo nodes
-  set_fact:
-    mongo_nodes: "{{ mongo_nodes | default([]) + [ hostvars[item]['ip_service'] + ':'+ mongodb.mongod_port | string ] }}"
-  loop: "{{ groups['hosts_vitamui_mongod'] }}"
+  - fail: msg="Variable '{{ mongod_source_template_dir }}' is not defined"
+    when: mongod_source_template_dir is undefined
 
-- name: Set Mongo URI
-  set_fact:
-    mongod_uri: "{{ mongo_nodes| join(',') }}"
+  - name: Compute list of mongo nodes
+    set_fact:
+      mongo_nodes: "{{ mongo_nodes | default([]) + [ hostvars[item]['ip_service'] + ':'+ mongodb.mongod_port | string ] }}"
+    loop: "{{ groups['hosts_vitamui_mongod'] }}"
 
-- name: Set mongod_output_dir_entry_point
-  set_fact:
-    mongod_output_dir_entry_point: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/"
+  - name: Set Mongo URI
+    set_fact:
+      mongod_uri: "{{ mongo_nodes| join(',') }}"
 
-- import_tasks: check_auth.yml
+  - name: Set mongod_output_dir_entry_point
+    set_fact:
+      mongod_output_dir_entry_point: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/app/mongod/"
 
-- name: Initialize directory if it doesn't exist.
-  file:
-    path: "{{ mongod_output_dir_entry_point }}"
-    state: directory
+  - import_tasks: check_auth.yml
 
-- name: "Clean directory {{ mongod_output_dir_entry_point }}"
-  shell: "rm -Rf {{ mongod_output_dir_entry_point }}/*"
+  - name: Initialize directory if it doesn't exist.
+    file:
+      path: "{{ mongod_output_dir_entry_point }}"
+      state: directory
 
-# We sort directories by theirs versions
-- name: List script files versions in the directory {{ mongod_source_template_dir }}
-  delegate_to: localhost
-  shell:
-    cmd: find * -maxdepth 1 -type d | sort -V
-    chdir: "{{ mongod_source_template_dir }}"
-  register: versions
+  - name: "Clean directory {{ mongod_output_dir_entry_point }}"
+    shell: "rm -Rf {{ mongod_output_dir_entry_point }}/*"
 
-# For each version, we apply a second sort on the index of the script file.
-- name: List script files in the directory {{ mongod_source_template_dir }}
-  delegate_to: localhost
-  shell:
-    cmd: find {{ version }}/* -type f -print | sort -V -t '_' -k1
-    chdir: "{{ mongod_source_template_dir }}"
-  register: output
-  loop: "{{ versions.stdout_lines }}"
-  loop_control:
-    loop_var: version
+  # We sort directories by theirs versions
+  - name: List script files versions in the directory {{ mongod_source_template_dir }}
+    delegate_to: localhost
+    shell:
+      cmd: find * -maxdepth 1 -type d | sort -V
+      chdir: "{{ mongod_source_template_dir }}"
+    register: versions
 
-- name: "Compute file scripts"
-  delegate_to: localhost
-  set_fact:
-    mongod_files: "{{ (mongod_files| default([])) + item.stdout_lines }}"
-  loop: "{{ output.results }}"
+  # For each version, we apply a second sort on the index of the script file.
+  - name: List script files in the directory {{ mongod_source_template_dir }}
+    delegate_to: localhost
+    shell:
+      cmd: find {{ version }}/* -type f -print | sort -V -t '_' -k1
+      chdir: "{{ mongod_source_template_dir }}"
+    register: output
+    loop: "{{ versions.stdout_lines }}"
+    loop_control:
+      loop_var: version
 
-# We apply regex for included and excluded files in order to compute the eligible scripts.
-- name: Compute list of excluded files
-  delegate_to: localhost
-  set_fact:
-    mongod_excluded_files : "{{ (mongod_excluded_files| default([])) + [ item.0 ] }}"
-  when: item.0 is not match(item.1) or item.0 is match(item.2)
-  with_nested:
-    - "{{ mongod_files }}"
-    - "{{ mongodb.included_scripts }}"
-    - "{{ mongodb.excluded_scripts }}"
+  - name: "Compute file scripts"
+    delegate_to: localhost
+    set_fact:
+      mongod_files: "{{ (mongod_files| default([])) + item.stdout_lines }}"
+    loop: "{{ output.results }}"
 
-- name: Compute list of eligible files
-  delegate_to: localhost
-  set_fact:
-    mongod_eligible_files : "{{ (mongod_eligible_files| default([])) + [ {'name': item, 'version': item | regex_replace('^(.+)/(.+)$', '\\1') ,'finalname': 'vitamui_' + item | regex_replace('/', '_') | basename | regex_replace('\\.j2$')} ] }}"
-  loop: "{{ mongod_files | difference(mongod_excluded_files| default([])) }}"
+  # We apply regex for included and excluded files in order to compute the eligible scripts.
+  - name: Compute list of excluded files
+    delegate_to: localhost
+    set_fact:
+      mongod_excluded_files : "{{ (mongod_excluded_files| default([])) + [ item.0 ] }}"
+    when: item.0 is not match(item.1) or item.0 is match(item.2)
+    with_nested:
+      - "{{ mongod_files }}"
+      - "{{ mongodb.included_scripts }}"
+      - "{{ mongodb.excluded_scripts }}"
 
-# We generate scripts and upload on remote host
-- name: Compute and copy script files
-  template:
-    src: "{{ mongod_source_template_dir }}/{{ item.name }}"
-    dest: "{{ mongod_output_dir_entry_point }}/{{ item.finalname }}"
-    owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
-    group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
-    mode: 0755
-  loop: "{{ mongod_eligible_files | unique }}"
+  - name: Compute list of eligible files
+    delegate_to: localhost
+    set_fact:
+      mongod_eligible_files : "{{ (mongod_eligible_files| default([])) + [ {'name': item, 'version': item | regex_replace('^(.+)/(.+)$', '\\1') ,'finalname': 'vitamui_' + item | regex_replace('/', '_') | basename | regex_replace('\\.j2$')} ] }}"
+    loop: "{{ mongod_files | difference(mongod_excluded_files| default([])) }}"
 
-- name: "Prepare file"
-  include_tasks: "prepare_script.yml"
-  when: mongodb.versioning is defined and mongodb.versioning.enable
-  loop: "{{ mongod_eligible_files | unique }}"
-  loop_control:
-    loop_var: mongo_file
+  # We generate scripts and upload on remote host
+  - name: Compute and copy script files
+    template:
+      src: "{{ mongod_source_template_dir }}/{{ item.name }}"
+      dest: "{{ mongod_output_dir_entry_point }}/{{ item.finalname }}"
+      owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
+      group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
+      mode: 0755
+    loop: "{{ mongod_eligible_files | unique }}"
 
-- name: Compute main script file
-  template:
-    src: "main_script.js.j2"
-    dest: "{{ mongod_output_dir_entry_point }}/main_script.js"
-    owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
-    group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
-    mode: 0755
+  - name: "Prepare file"
+    include_tasks: "prepare_script.yml"
+    when: mongodb.versioning is defined and mongodb.versioning.enable
+    loop: "{{ mongod_eligible_files | unique }}"
+    loop_control:
+      loop_var: mongo_file
 
-- name: Load script in database
-  shell: "mongosh \"mongodb://{{ mongod_uri }}/admin\" {{ mongo_credentials }} --quiet --file {{ mongod_output_dir_entry_point }}/main_script.js"
-#  no_log: "{{ hide_passwords_during_deploy }}"
-  when: mongodb.docker is not defined or not mongodb.docker.enable
+  - name: Compute main script file
+    template:
+      src: "main_script.js.j2"
+      dest: "{{ mongod_output_dir_entry_point }}/main_script.js"
+      owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
+      group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
+      mode: 0755
 
-- name: Load script in database test (docker)
-  command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh \\\"mongodb://{{ mongod_uri }}/admin\\\" {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js \""
-  #no_log: "{{ hide_passwords_during_deploy }}"
-  when: mongodb.docker is defined and mongodb.docker.enable
+  - name: Load script in database
+    shell: "mongosh \"mongodb://{{ mongod_uri }}/admin\" {{ mongo_credentials }} --quiet --file {{ mongod_output_dir_entry_point }}/main_script.js"
+  #  no_log: "{{ hide_passwords_during_deploy }}"
+    when: mongodb.docker is not defined or not mongodb.docker.enable
 
-# - name: "Execute file"
-#   include_tasks: "execute_script.yml"
-#   loop: "{{ mongod_eligible_files | unique }}"
-#   loop_control:
-#     loop_var: mongo_file
+  - name: Load script in database test (docker)
+    command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh \\\"mongodb://{{ mongod_uri }}/admin\\\" {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js \""
+    #no_log: "{{ hide_passwords_during_deploy }}"
+    when: mongodb.docker is defined and mongodb.docker.enable
+
+  # - name: "Execute file"
+  #   include_tasks: "execute_script.yml"
+  #   loop: "{{ mongod_eligible_files | unique }}"
+  #   loop_control:
+  #     loop_var: mongo_file
+
+  run_once: true

--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -96,13 +96,13 @@
       mode: 0755
 
   - name: Load script in database
-    shell: "mongosh \"mongodb://{{ mongod_uri }}/admin\" {{ mongo_credentials }} --quiet --file {{ mongod_output_dir_entry_point }}/main_script.js"
-  #  no_log: "{{ hide_passwords_during_deploy }}"
+    shell: "mongosh mongodb://{{ mongod_uri }}/admin {{ mongo_credentials }} --quiet --file {{ mongod_output_dir_entry_point }}/main_script.js"
+    no_log: "{{ hide_passwords_during_deploy }}"
     when: mongodb.docker is not defined or not mongodb.docker.enable
 
   - name: Load script in database test (docker)
-    command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh \\\"mongodb://{{ mongod_uri }}/admin\\\" {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js \""
-    #no_log: "{{ hide_passwords_during_deploy }}"
+    command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh mongodb://{{ mongod_uri }}/admin {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js\""
+    no_log: "{{ hide_passwords_during_deploy }}"
     when: mongodb.docker is defined and mongodb.docker.enable
 
   # - name: "Execute file"


### PR DESCRIPTION
## Description

* Bug 11935: Fix init-replica script
    Handle that the node that executes this script is not necessarily the primary.
* Story 11979: Fix replicaset cluster deployment for mongo-vitamui.
    Run once mongo_init tasks to avoid multiple execution on multi cluster node for mongo-vitamui.
* Story 11979: Add `is_small` & `mongo_arbiter` parameters.
    Avoid bootstrap execution on arbiter node & various cleanup.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)