### PR TITLE
Story #12165 fix: do not use detected hostname in CAS ticket name

### DIFF
--- a/cas/cas-server/src/main/config/cas-server-application-dev.yml
+++ b/cas/cas-server/src/main/config/cas-server-application-dev.yml
@@ -65,6 +65,7 @@ cas.authn.accept.users:
 cas.message-bundle.base-names: classpath:overriden_messages,classpath:messages
 
 
+cas.host.name: cas
 cas.tgc.path: /cas
 cas.tgc.secure: true
 cas.tgc.crypto.enabled: false

--- a/cas/cas-server/src/main/config/cas-server-application-recette.yml
+++ b/cas/cas-server/src/main/config/cas-server-application-recette.yml
@@ -44,6 +44,7 @@ cas.authn.accept.users:
 cas.message-bundle.base-names: classpath:overriden_messages,classpath:messages
 
 
+cas.host.name: cas
 cas.tgc.path: /cas
 cas.tgc.secure: true
 cas.tgc.crypto.enabled: false

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -68,6 +68,7 @@ cas.authn.accept.users:
 cas.message-bundle.base-names: classpath:overriden_messages,classpath:messages
 
 
+cas.host.name: cas
 {% if vitamui.cas_server.base_url is undefined %}
 cas.tgc.path: /cas
 {% endif %}


### PR DESCRIPTION
## Description

According to CAS documentation, a CAS host is automatically appended to the ticket ids generated by CAS. If none is specified by using the `cas.host.name` property, the hostname is automatically detected and used.

The solution is to define the `cas.host.name` property.

## Type de changement:

* Ansiblerie

* Correction

## Tests:

manuel

## Contributeur

Vitam