### PR TITLE
Bug #12370: keep automaticIngest when converting DTOs

### DIFF
--- a/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/service/converters/ProjectConverter.java
+++ b/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/service/converters/ProjectConverter.java
@@ -65,6 +65,7 @@ public class ProjectConverter {
             .lastModifyOn(projectDto.getLastUpdate())
             .status(projectDto.getStatus())
             .name(projectDto.getName())
+            .automaticIngest(projectDto.getAutomaticIngest())
             .build();
     }
 
@@ -104,6 +105,7 @@ public class ProjectConverter {
         externalDto.setCreationDate(collectProjectDto.getCreatedOn());
         externalDto.setLastUpdate(collectProjectDto.getLastModifyOn());
         externalDto.setName(collectProjectDto.getName());
+        externalDto.setAutomaticIngest(collectProjectDto.getAutomaticIngest());
         return externalDto;
     }
 

--- a/api/api-collect/collect-internal/src/test/java/fr/gouv/vitamui/collect/internal/server/service/ProjectInternalServiceTest.java
+++ b/api/api-collect/collect-internal/src/test/java/fr/gouv/vitamui/collect/internal/server/service/ProjectInternalServiceTest.java
@@ -116,6 +116,7 @@ class ProjectInternalServiceTest {
         assertEquals(projectDto.getAcquisitionInformation(), resultedProject.getAcquisitionInformation());
         assertEquals(projectDto.getUnitUp(), resultedProject.getUnitUp());
         assertEquals(projectDto.getTenant(), resultedProject.getTenant());
+        assertEquals(projectDto.getAutomaticIngest(), resultedProject.getAutomaticIngest());
         // TODO : This is a bug in BackEnd : should get the correct status OPEN and not a random one sended in request!
         //        assertEquals("OPEN", resultedProject.getStatus());
     }
@@ -163,12 +164,11 @@ class ProjectInternalServiceTest {
 
         // THEN
         assertNotNull(resultedTransaction);
-        assertEquals(resultedTransaction.getName(), resultedTransaction.getName());
-        assertEquals(resultedTransaction.getArchivalAgreement(), resultedTransaction.getArchivalAgreement());
-        assertEquals(resultedTransaction.getLegalStatus(), resultedTransaction.getLegalStatus());
-        assertEquals(resultedTransaction.getAcquisitionInformation(), resultedTransaction.getAcquisitionInformation());
-        assertEquals(resultedTransaction.getUnitUp(), resultedTransaction.getUnitUp());
-        assertEquals(resultedTransaction.getProjectId(), resultedTransaction.getProjectId());
+        assertEquals(transactionDto.getName(), resultedTransaction.getName());
+        assertEquals(transactionDto.getArchivalAgreement(), resultedTransaction.getArchivalAgreement());
+        assertEquals(transactionDto.getLegalStatus(), resultedTransaction.getLegalStatus());
+        assertEquals(transactionDto.getAcquisitionInformation(), resultedTransaction.getAcquisitionInformation());
+        assertEquals(transactionDto.getProjectId(), resultedTransaction.getProjectId());
     }
 
     @Test
@@ -315,11 +315,11 @@ class ProjectInternalServiceTest {
 
         // THEN
         assertNotNull(updatedProject);
-        assertEquals(updatedProject.getName(), updatedProject.getName());
-        assertEquals(updatedProject.getArchivalAgreement(), updatedProject.getArchivalAgreement());
-        assertEquals(updatedProject.getLegalStatus(), updatedProject.getLegalStatus());
-        assertEquals(updatedProject.getAcquisitionInformation(), updatedProject.getAcquisitionInformation());
-        assertEquals(updatedProject.getUnitUp(), updatedProject.getUnitUp());
+        assertEquals(projectDto.getName(), updatedProject.getName());
+        assertEquals(projectDto.getArchivalAgreement(), updatedProject.getArchivalAgreement());
+        assertEquals(projectDto.getLegalStatus(), updatedProject.getLegalStatus());
+        assertEquals(projectDto.getAcquisitionInformation(), updatedProject.getAcquisitionInformation());
+        assertEquals(projectDto.getUnitUp(), updatedProject.getUnitUp());
     }
 
     @Test
@@ -363,11 +363,11 @@ class ProjectInternalServiceTest {
 
         // THEN
         assertNotNull(updatedProject);
-        assertEquals(updatedProject.getName(), updatedProject.getName());
-        assertEquals(updatedProject.getArchivalAgreement(), updatedProject.getArchivalAgreement());
-        assertEquals(updatedProject.getLegalStatus(), updatedProject.getLegalStatus());
-        assertEquals(updatedProject.getAcquisitionInformation(), updatedProject.getAcquisitionInformation());
-        assertEquals(updatedProject.getUnitUp(), updatedProject.getUnitUp());
+        assertEquals(projectDto.getName(), updatedProject.getName());
+        assertEquals(projectDto.getArchivalAgreement(), updatedProject.getArchivalAgreement());
+        assertEquals(projectDto.getLegalStatus(), updatedProject.getLegalStatus());
+        assertEquals(projectDto.getAcquisitionInformation(), updatedProject.getAcquisitionInformation());
+        assertEquals(projectDto.getUnitUp(), updatedProject.getUnitUp());
     }
 
     @Test
@@ -484,12 +484,12 @@ class ProjectInternalServiceTest {
 
         // THEN
         assertNotNull(lastTransaction);
-        assertEquals(lastTransaction.getName(), lastTransaction.getName());
-        assertEquals(lastTransaction.getArchivalAgreement(), lastTransaction.getArchivalAgreement());
-        assertEquals(lastTransaction.getLegalStatus(), lastTransaction.getLegalStatus());
-        assertEquals(lastTransaction.getAcquisitionInformation(), lastTransaction.getAcquisitionInformation());
-        assertEquals(lastTransaction.getUnitUp(), lastTransaction.getUnitUp());
-        assertEquals(lastTransaction.getProjectId(), lastTransaction.getProjectId());
+        final TransactionDto lastTransactionDto = transactionDtos.get(transactionDtos.size() - 1);
+        assertEquals(lastTransactionDto.getName(), lastTransaction.getName());
+        assertEquals(lastTransactionDto.getArchivalAgreement(), lastTransaction.getArchivalAgreement());
+        assertEquals(lastTransactionDto.getLegalStatus(), lastTransaction.getLegalStatus());
+        assertEquals(lastTransactionDto.getAcquisitionInformation(), lastTransaction.getAcquisitionInformation());
+        assertEquals(lastTransactionDto.getProjectId(), lastTransaction.getProjectId());
     }
 
     @Test

--- a/api/api-collect/collect-internal/src/test/java/fr/gouv/vitamui/collect/internal/server/service/converters/ProjectConverterTest.java
+++ b/api/api-collect/collect-internal/src/test/java/fr/gouv/vitamui/collect/internal/server/service/converters/ProjectConverterTest.java
@@ -67,6 +67,7 @@ class ProjectConverterTest {
             .lastModifyOn("lastModifyOn_lastUpdate")
             .status("status")
             .name("name")
+            .automaticIngest(true)
             .build();
     }
 
@@ -102,6 +103,7 @@ class ProjectConverterTest {
         externalDto.setCreationDate("createdOn_creationDate");
         externalDto.setLastUpdate("lastModifyOn_lastUpdate");
         externalDto.setName("name");
+        externalDto.setAutomaticIngest(true);
         return externalDto;
     }
 


### PR DESCRIPTION
## Description

Correction d'un bug qui ne conservait pas la valeur du booléen automaticIngest lors de la création ou la récupération d'un projet de versement.

Les Tests Unitaires ont été mis à jour. Certains tests voisins ont été corrigés. 

## Type de changement:

* Correction

## Tests:

manuel

TU

## Checklist:

*Sélectionner les éléments de la checklist*

[ ] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

VAS (Vitam Accessible en Service)