### PR TITLE
Bug #12434: fix impossibility to create a management contract with persistant identifier

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-create/management-contract-create.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-create/management-contract-create.component.html
@@ -26,18 +26,18 @@
                 placeholder="{{ 'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.IDENTIFIER' | translate }}"
                 required
               >
-                <ng-container *ngIf="form.get('identifier')?.touched">
-                  <vitamui-common-input-error *ngIf="!!form.get('identifier')?.errors?.required">
+                <ng-container *ngIf="identifier?.touched">
+                  <vitamui-common-input-error *ngIf="!!identifier?.errors?.required">
                     {{ 'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.MANDATORY_FIELD' | translate }}
                   </vitamui-common-input-error>
-                  <vitamui-common-input-error *ngIf="!!form?.get('identifier')?.errors?.identifierExists">
+                  <vitamui-common-input-error *ngIf="!!identifier?.errors?.identifierExists">
                     {{ 'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.IDENTIFIER_ALREADY_EXIST' | translate }}
                   </vitamui-common-input-error>
-                  <vitamui-common-input-error *ngIf="!!form?.get('identifier')?.errors?.minlength">
-                    {{ 'COMMON.MIN_LENGTH' | translate: form?.get('identifier')?.errors }}
+                  <vitamui-common-input-error *ngIf="!!identifier?.errors?.minlength">
+                    {{ 'COMMON.MIN_LENGTH' | translate: identifier?.errors }}
                   </vitamui-common-input-error>
-                  <vitamui-common-input-error *ngIf="!!form?.get('identifier')?.errors?.maxlength">
-                    {{ 'COMMON.MAX_LENGTH' | translate: form?.get('identifier')?.errors }}
+                  <vitamui-common-input-error *ngIf="!!identifier?.errors?.maxlength">
+                    {{ 'COMMON.MAX_LENGTH' | translate: identifier?.errors }}
                   </vitamui-common-input-error>
                 </ng-container>
               </vitamui-common-input>
@@ -49,18 +49,18 @@
                 placeholder="{{ 'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.NAME' | translate }}"
                 required
               >
-                <ng-container *ngIf="form.get('name')?.touched">
-                  <vitamui-common-input-error *ngIf="!!form.get('name')?.errors?.required">{{
+                <ng-container *ngIf="name?.touched">
+                  <vitamui-common-input-error *ngIf="!!name?.errors?.required">{{
                     'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.MANDATORY_FIELD' | translate
                   }}</vitamui-common-input-error>
-                  <vitamui-common-input-error *ngIf="!!form?.get('name')?.errors?.nameExists">
+                  <vitamui-common-input-error *ngIf="!!name?.errors?.nameExists">
                     {{ 'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.NAME_ALREADY_EXIST' | translate }}
                   </vitamui-common-input-error>
-                  <vitamui-common-input-error *ngIf="!!form?.get('name')?.errors?.minlength">
-                    {{ 'COMMON.MIN_LENGTH' | translate: form?.get('name')?.errors }}
+                  <vitamui-common-input-error *ngIf="!!name?.errors?.minlength">
+                    {{ 'COMMON.MIN_LENGTH' | translate: name?.errors }}
                   </vitamui-common-input-error>
-                  <vitamui-common-input-error *ngIf="!!form?.get('name')?.errors?.maxlength">
-                    {{ 'COMMON.MAX_LENGTH' | translate: form?.get('name')?.errors }}
+                  <vitamui-common-input-error *ngIf="!!name?.errors?.maxlength">
+                    {{ 'COMMON.MAX_LENGTH' | translate: name?.errors }}
                   </vitamui-common-input-error>
                 </ng-container>
               </vitamui-common-input>
@@ -72,8 +72,8 @@
                 placeholder="{{ 'CONTRACT_MANAGEMENT.CONTRACTS_CREATION.DESCRIPTION' | translate }}"
                 [rows]="4"
               >
-                <ng-container *ngIf="form.get('description')?.touched">
-                  <vitamui-common-input-error *ngIf="!!form.get('description')?.errors?.required">
+                <ng-container *ngIf="description?.touched">
+                  <vitamui-common-input-error *ngIf="!!description?.errors?.required">
                     {{ 'COMMON.REQUIRED' | translate }}
                   </vitamui-common-input-error>
                 </ng-container>

--- a/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-create/management-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-create/management-contract-create.component.ts
@@ -235,4 +235,16 @@ export class ManagementContractCreateComponent implements OnInit, OnDestroy {
 
     return managementContract;
   }
+
+  get identifier(): AbstractControl | null {
+    return this.form.get('identifier');
+  }
+
+  get name(): AbstractControl | null {
+    return this.form.get('name');
+  }
+
+  get description(): AbstractControl | null {
+    return this.form.get('description');
+  }
 }

--- a/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-create/management-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-create/management-contract-create.component.ts
@@ -92,11 +92,15 @@ export class ManagementContractCreateComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.form = this.formBuilder.group({
       // Step 1
-      identifier: [
-        null,
-        [Validators.required, Validators.minLength(5), Validators.maxLength(100)],
-        this.managementContractCreateValidators.uniqueIdentifier(),
-      ],
+      ...(this.isSlaveMode
+        ? {
+            identifier: [
+              null,
+              [Validators.required, Validators.minLength(5), Validators.maxLength(100)],
+              this.managementContractCreateValidators.uniqueIdentifier(),
+            ],
+          }
+        : {}),
       status: [true],
       name: [
         null,


### PR DESCRIPTION
## Description

La création d'un contrat de gestion avec identifiant pérenne était impossible car le formulaire était considéré comme invalide.

La raison est que le champ "identifier", non présent dans l'interface lorsque le "slave mode" est inactif, était présent dans le formGroup, rendant la validation du formulaire impossible du fait que ce champ est obligatoire et ne peut pas être saisi dans l'interface.

Il s'agit donc de ne mettre le champ "identifier" dans le formGroup que lorsque le "slave mode" est actif, c'est à dire lorsqu'il est affiché dans l'interface.

Cette PR contient également du clean code et la mise à jour des tests unitaires (qui étaient KO et testaient mal).

## Type de changement:

* Correction

* Refactorisation de code

## Tests:

manuel

TU

## Checklist:

[X] Mon code suit le style de code de ce projet.

[X] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[X] Les tests unitaires nouveaux et existants passent avec succès localement.

## Contributeur

VAS (Vitam Accessible en Service)