### PR TITLE
Fix #12457: call expects id, not identifier

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/archive-profile-api.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/archive-profile-api.service.ts
@@ -82,7 +82,7 @@ export class ArchiveProfileApiService extends BaseHttpClient<Profile> {
 
   updateProfilePa(profile: Profile, headers?: HttpHeaders): Observable<Profile> {
     profile.path = null;
-    return this.http.put<Profile>(this.apiUrl + this.pastisConfig.archiveProfileApiPath + '/' + profile.identifier, profile, { headers });
+    return this.http.put<Profile>(this.apiUrl + this.pastisConfig.archiveProfileApiPath + '/' + profile.id, profile, { headers });
   }
 
   patch(partialAgency: { id: string; [key: string]: any }, headers?: HttpHeaders) {


### PR DESCRIPTION
Call to the fr.gouv.vitamui.referential.external.server.rest.ProfileExternalController#update expects id, not identifier. Previously, the conversion was made inside ui-pastis.