### PR TITLE
Bugs #12423 - update archive unit editor to deal with 2.3 only

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/archive/components/archive-unit-editor/archive-unit-editor.service.ts
+++ b/ui/ui-frontend-common/src/app/modules/archive/components/archive-unit-editor/archive-unit-editor.service.ts
@@ -20,7 +20,7 @@ import { JsonPatch, JsonPatchDto } from '../../models/json-patch';
 @Injectable()
 export class ArchiveUnitEditorService {
   private collection = new BehaviorSubject<Collection>(Collection.ARCHIVE_UNIT);
-  private sedaVersions = new BehaviorSubject<SedaVersion[]>(['INTERNE', '2.1']);
+  private sedaVersions = new BehaviorSubject<SedaVersion[]>(['INTERNE', '2.3']);
   private category = new BehaviorSubject<SchemaElement['Category']>('DESCRIPTION');
   private data = new BehaviorSubject<any>(null);
   private editObject = new BehaviorSubject<EditObject>(null);


### PR DESCRIPTION
## Description

Configure l'éditeur d'unité d'archive pour ne traiter que les éléments de schéma du SEDA ~2.2~ 2.3.