### PR TITLE
Fix: do not fail when downloading DIP with no filename set in content-disposition header

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/utils/download.utils.ts
+++ b/ui/ui-frontend-common/src/app/modules/utils/download.utils.ts
@@ -39,8 +39,10 @@ export class DownloadUtils {
   static getFilenameFromContentDisposition(contentDisposition: string): string {
     const regex = /filename[^;\n=]*=((['"]).*?\2|[^;\n]*)/g;
     const match = regex.exec(contentDisposition);
-    const filename = match[1];
-    return filename;
+    if (!match || match.length <= 1) {
+      return 'attachment';
+    }
+    return match[1];
   }
 
   static isSurroundedByDoubleQuotes(charSequence: string): boolean {


### PR DESCRIPTION
When downloading DIP from logbook operations, filename is not set in content-disposition header and the javascript then crashes. Avoid that.