### PR TITLE
Fix #12589: default portal homepage should show tenant and language selection

### DIFF
--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -95,9 +95,9 @@ vitamui:
     vitamui_component_type: "ui"
     port_service: 8003
     port_admin: 7003
-    has_tenant_list: false
-    has_lang_selection: false
-    has_site_selection: true
+    has_tenant_list: true
+    has_lang_selection: true
+    has_site_selection: false
 
   referential_external:
     host: "vitamui-referential-external.service.{{ consul_domain }}"


### PR DESCRIPTION
Change defaults for deployments.