### PR TITLE
Bugs #12601: fix transfer acknowledgment

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
@@ -379,7 +379,7 @@ export class ArchiveService extends SearchService<any> implements SearchArchiveU
     let headers = new HttpHeaders();
     headers = headers.append('X-Tenant-Id', tenantIdentifier);
     headers = headers.append('Content-Type', 'application/octet-stream');
-    headers = headers.append('fileName', fileName);
+    headers = headers.append('X-Original-Filename', fileName);
 
     return this.archiveApiService.transferAcknowledgment(xmlFile, headers);
   }


### PR DESCRIPTION
## Description

Fix transfer acknowledgement. Expected parameter name for file name was converted from "fileName" to "X-Original-Filename" in ui-archive-search. We now directly send "X-Original-Filename" from Angular.

## Type de changement:

* Correction

## Tests:

manuel
