### PR TITLE
Bug #12596: show attachment nodes if there is result and no facets

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.ts
+++ b/ui/ui-frontend-common/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.ts
@@ -40,6 +40,7 @@ export class VitamuiTreeNodeComponent implements AfterContentChecked {
   @Input() disabled: boolean;
   @Input() hasCheckBox = true;
   @Input() labelIsLinkedToCheckbox = false;
+
   @Output() nodeToggle = new EventEmitter<void>();
   @Output() checkboxClick = new EventEmitter<void>();
   @Output() labelClick = new EventEmitter<void>();

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.ts
@@ -118,8 +118,7 @@ export class FilingHoldingSchemeComponent implements OnInit, OnDestroy {
   private subscribeOnFacetsChangesToResetCounts(): void {
     this.subscriptions.add(
       this.archiveSharedDataService.getFacets().subscribe((facets) => {
-        this.hasMatchesInSearch = facets && facets.length > 0;
-        if (this.hasMatchesInSearch) {
+        if (facets && facets.length > 0) {
           this.requestResultFacets = facets;
           FilingHoldingSchemeHandler.setCountRecursively(this.nestedDataSourceFull.data, facets);
           this.requestResultsInFilingPlan = FilingHoldingSchemeHandler.getCountSum(this.nestedDataSourceFull.data);
@@ -224,6 +223,7 @@ export class FilingHoldingSchemeComponent implements OnInit, OnDestroy {
   private subscribeOnTotalResultsChange(): void {
     this.subscriptions.add(
       this.archiveSharedDataService.getTotalResults().subscribe((totalResults) => {
+        this.hasMatchesInSearch = totalResults > 0;
         this.requestTotalResults = totalResults;
         this.addOrRemoveOrphansNode();
       }),


### PR DESCRIPTION
## Description

Les positions de rattachement ne s'affiche pas alors que la recherche a des résultats

## Type de changement:

* Correction

## Tests:

manuel

## Contributeur

VAS (Vitam Accessible en Service)
