### PR TITLE
Bug #12656: disable form fields even when they're empty

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/object-editor/services/edit-object.service.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-editor/services/edit-object.service.ts
@@ -31,8 +31,6 @@ export class EditObjectService {
     let control: AbstractControl = this.formBuilder.control(data);
     let actions: { [key: string]: Action } = {};
 
-    if (data === null) return { ...baseEditObject, control, children } as EditObject;
-
     if (this.typeService.isList(data)) {
       if (baseEditObject.kind === 'object-array') {
         children = data.map((value: any, index: number) => this.editObject(`${path}[${index}]`, value, template, schema));


### PR DESCRIPTION
## Description

Correction d'anomalie : un champ sensé être désactivé mais n'ayant aucune donnée n'était pas réellement désactivé. La raison est qu'un "if" dans le code sortait de la fonction trop tôt pour y appliquer la désactivation du champ.

## Type de changement:

* Correction

## Tests:

manuel

## Checklist:

[X] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

VAS (Vitam Accessible en Service)