### PR TITLE
Fix #12660: display internationalized md descriptives (Title_ & Description_)

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/archive/archive-unit-template.ts
+++ b/ui/ui-frontend-common/src/app/modules/archive/archive-unit-template.ts
@@ -103,9 +103,9 @@ export const customTemplate: DisplayRule[] = [
     },
   },
   {
-    Path: 'Description_.*',
+    Path: 'Description_',
     ui: {
-      Path: 'Generalities.Description_.*',
+      Path: 'Generalities.Description_',
       component: 'select+textarea',
       layout: {
         columns: 2,

--- a/ui/ui-frontend-common/src/app/modules/object-viewer/components/group/group.component.html
+++ b/ui/ui-frontend-common/src/app/modules/object-viewer/components/group/group.component.html
@@ -1,4 +1,17 @@
-<vitamui-common-accordion *ngIf="displayObject.key; else content" [opened]="displayObject.open">
+<ng-container *ngIf="display === 'KEY-VALUE-OBJECTS'">
+  <vitamui-common-data
+    *ngFor="let entry of entries(displayObject.value)"
+    [label]="displayObject.displayRule.ui.label + ' [' + entry[0] + ']'"
+    [value]="entry[1]"
+  >
+  </vitamui-common-data>
+</ng-container>
+
+<ng-container *ngIf="display === 'ROWS'">
+  <div *ngTemplateOutlet="content"></div>
+</ng-container>
+
+<vitamui-common-accordion *ngIf="display === 'ACCORDION'" [opened]="displayObject.open">
   <span class="title">{{ displayObject.displayRule.ui.label | empty }}</span>
   <div *ngIf="favoriteEntry" class="title-extra v-col align-items-center favorite-entry">
     {{ favoritePath | translate }}: {{ favoriteEntry[1] | empty }}

--- a/ui/ui-frontend-common/src/app/modules/object-viewer/components/group/group.component.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-viewer/components/group/group.component.ts
@@ -36,6 +36,7 @@
  */
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DisplayObject } from '../../models';
+import { internationalizedKeys } from '../../services/display-object-helper.service';
 import { FavoriteEntryService } from '../../services/favorite-entry.service';
 import { LayoutService } from '../../services/layout.service';
 import { DisplayObjectType } from '../../types';
@@ -48,12 +49,13 @@ import { DisplayObjectType } from '../../types';
 export class GroupComponent implements OnChanges {
   @Input() displayObject: DisplayObject;
 
-  entries: [key: string, value: any][] = [];
   favoriteEntry: [key: string, value: any];
   favoritePath: string;
   rows: DisplayObject[][] = [[]];
+  display: 'ACCORDION' | 'KEY-VALUE-OBJECTS' | 'ROWS';
 
   readonly DisplayObjectType = DisplayObjectType;
+  readonly entries = Object.entries;
 
   constructor(
     private layoutService: LayoutService,
@@ -64,6 +66,12 @@ export class GroupComponent implements OnChanges {
     const { displayObject } = changes;
 
     if (displayObject) {
+      this.display = this.displayObject.key
+        ? internationalizedKeys.includes(this.displayObject.key)
+          ? 'KEY-VALUE-OBJECTS'
+          : 'ACCORDION'
+        : 'ROWS';
+
       this.favoriteEntry = this.favoriteEntryService.favoriteEntry(this.displayObject);
       this.favoritePath = this.favoriteEntryService.favoritePath(this.displayObject);
       this.rows = this.layoutService.compute(this.displayObject);

--- a/ui/ui-frontend-common/src/app/modules/object-viewer/object-viewer.component.spec.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-viewer/object-viewer.component.spec.ts
@@ -146,9 +146,9 @@ const template: DisplayRule[] = [
     },
   },
   {
-    Path: 'Title_.*',
+    Path: 'Title_',
     ui: {
-      Path: 'Generalities.Title_.*',
+      Path: 'Generalities.Title_',
       component: 'select+textfield',
       layout: { columns: 2, size: 'medium' },
     },
@@ -162,9 +162,9 @@ const template: DisplayRule[] = [
     },
   },
   {
-    Path: 'Description_.*',
+    Path: 'Description_',
     ui: {
-      Path: 'Generalities.Description_.*',
+      Path: 'Generalities.Description_',
       component: 'select+textarea',
       layout: { columns: 2, size: 'large' },
     },

--- a/ui/ui-frontend-common/src/app/modules/object-viewer/services/display-object-helper.service.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-viewer/services/display-object-helper.service.ts
@@ -41,6 +41,8 @@ import { DataStructureService } from './data-structure.service';
 import { DisplayRuleHelperService } from './display-rule-helper.service';
 import { TypeService } from './type.service';
 
+export const internationalizedKeys = ['Title_', 'Description_'];
+
 @Injectable()
 export class DisplayObjectHelperService {
   constructor(
@@ -139,7 +141,7 @@ export class DisplayObjectHelperService {
 
       template.push(current.displayRule);
 
-      if (current.children && current.children.length > 0) {
+      if (current.children && current.children.length > 0 && !internationalizedKeys.includes(current.key)) {
         for (let i = current.children.length - 1; i >= 0; i--) {
           stack.push(current.children[i]);
         }

--- a/ui/ui-frontend/package-lock.json
+++ b/ui/ui-frontend/package-lock.json
@@ -19293,7 +19293,7 @@
     "node_modules/ui-frontend-common": {
       "version": "2.1.58",
       "resolved": "file:../ui-frontend-common/ui-frontend-common-2.1.58.tgz",
-      "integrity": "sha512-SQL4s39XPqWNzepeZnrelHOognGREA3OARj7+7EymEZh5eMXLsDCvp1ZEs6by5f7ZnWuAHT47jVT9rMy55gO/A==",
+      "integrity": "sha512-7EqAGpXeW9UF9GAs538klupDdgB3apcJIWrWVQRybRNJDAWyV/puZXrL+ZmQvb5LQU8L/ZflMTdpLwvI2bwhKA==",
       "dependencies": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "13.0.0",
@@ -24223,13 +24223,11 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -24830,8 +24828,7 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.2",
-      "requires": {}
+      "version": "4.6.2"
     },
     "boxen": {
       "version": "5.1.2",
@@ -25237,8 +25234,7 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -25417,13 +25413,11 @@
       "dependencies": {
         "@angular/compiler": {
           "version": "9.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@angular/core": {
           "version": "9.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -26222,8 +26216,7 @@
       "version": "3.5.17"
     },
     "d3-svg-legend": {
-      "version": "1.13.0",
-      "requires": {}
+      "version": "1.13.0"
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -31117,8 +31110,7 @@
       "dev": true
     },
     "nvd3": {
-      "version": "1.8.6",
-      "requires": {}
+      "version": "1.8.6"
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -34929,8 +34921,7 @@
     },
     "tsickle": {
       "version": "0.39.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tslib": {
       "version": "2.6.2"
@@ -35086,7 +35077,7 @@
     },
     "ui-frontend-common": {
       "version": "file:../ui-frontend-common/ui-frontend-common-2.1.58.tgz",
-      "integrity": "sha512-SQL4s39XPqWNzepeZnrelHOognGREA3OARj7+7EymEZh5eMXLsDCvp1ZEs6by5f7ZnWuAHT47jVT9rMy55gO/A==",
+      "integrity": "sha512-7EqAGpXeW9UF9GAs538klupDdgB3apcJIWrWVQRybRNJDAWyV/puZXrL+ZmQvb5LQU8L/ZflMTdpLwvI2bwhKA==",
       "requires": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "13.0.0",
@@ -36923,8 +36914,7 @@
     },
     "ws": {
       "version": "8.11.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",


### PR DESCRIPTION
## Description

Affichage des métadonnées descriptives internationalisées.
Seules les MD "Title_" et "Description_" sont des MD internationalisées.

Dépends de https://gitlab.dev.programmevitam.fr/vitam/vitam/-/merge_requests/10000 qui change la Category dans le schéma de OTHER à DESCRIPTION (nécessaire pour que les MD soient affichées dans l'onglet Description)

## Type de changement:

* Nouveau Code

* Correction

## Tests:

manuel

## Checklist:

*Sélectionner les éléments de la checklist*

[X] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

VAS (Vitam Accessible en Service)