### PR TITLE
Bugs #12676: fix ordering by deposit identifier

### DIFF
--- a/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-list/ingest-list.component.html
+++ b/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-list/ingest-list.component.html
@@ -4,7 +4,12 @@
       <div class="row col-1"><i class="vitamui-icon vitamui-icon-ingest vitamui-row-icon"></i></div>
       <div class="col-5" i18n="ingest identifier column header@@ingestListIdentifierHeader">
         <span>{{ 'INGEST_LIST.ID' | translate }}</span>
-        <vitamui-common-order-by-button orderByKey="#id" [(orderBy)]="orderBy" [(direction)]="direction" (orderChange)="emitOrderChange()">
+        <vitamui-common-order-by-button
+          orderByKey="obIdIn.keyword"
+          [(orderBy)]="orderBy"
+          [(direction)]="direction"
+          (orderChange)="emitOrderChange()"
+        >
         </vitamui-common-order-by-button>
       </div>
       <div class="col-2" i18n="ingest createdDate column header@@ingestListCreatedDateHeader">


### PR DESCRIPTION
## Description

Permet de réparer le tri sur la première colonne dans la liste des ingests, "Identifiant du message". La colonne était auparavant configurée pour trier sur #id.

## Type de changement:

* Correction

## Documentation:

*Indiquer la documentation mise à jour*

[ ] Quels sont les nouvelles documentations ?

[ ] Quels sont les modifications existantes ?

[ ] Quels sont les documentations ou sections de documentations supprimés ?

## Tests:

manuel

## Migration:

*Indiquer si les modifications apportées impliquent une migration sur l'existant et comment la faire*

## Checklist:

*Sélectionner les éléments de la checklist*

[ ] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

VAS (Vitam Accessible en Service)

CEA (Commissariat à l'énergie atomique et aux énergies alternatives)
