### PR TITLE
Bugs #12686: missing confirmation on close, tab change and on item change for MD

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.html
@@ -26,6 +26,7 @@
     [selectedIndex]="selectedIndex"
     [ngClass]="isPanelextended ? 'extended-preview-tab-group' : 'preview-tab-group'"
     (selectedTabChange)="selectedTabChangeEvent($event)"
+    #tabs
   >
     <mat-tab label="{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.TABS.INFORMATIONS' | translate }}">
       <app-archive-unit-information-tab
@@ -37,7 +38,11 @@
     </mat-tab>
 
     <mat-tab label="{{ 'TAB.DESCRIPTION' | translate }}">
-      <app-archive-unit-description-tab [archiveUnit]="archiveUnit" [(editMode)]="updateStarted"></app-archive-unit-description-tab>
+      <app-archive-unit-description-tab
+        [archiveUnit]="archiveUnit"
+        [(editMode)]="updateStarted"
+        #descriptionTab
+      ></app-archive-unit-description-tab>
     </mat-tab>
 
     <mat-tab label="{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.TABS.RULES' | translate }}">

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.ts
@@ -35,18 +35,19 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
-import { MatTabChangeEvent } from '@angular/material/tabs';
+import { AfterViewInit, Component, EventEmitter, HostListener, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { MatTab, MatTabChangeEvent, MatTabGroup, MatTabHeader } from '@angular/material/tabs';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Unit, unitToVitamuiIcon } from 'ui-frontend-common';
+import { ArchiveUnitDescriptionTabComponent } from './archive-unit-description-tab/archive-unit-description-tab.component';
 
 @Component({
   selector: 'app-archive-preview',
   templateUrl: './archive-preview.component.html',
   styleUrls: ['./archive-preview.component.scss'],
 })
-export class ArchivePreviewComponent implements OnChanges {
+export class ArchivePreviewComponent implements OnChanges, AfterViewInit {
   @Input() archiveUnit: Unit;
   @Input() accessContract: string;
   @Input() isPopup: boolean;
@@ -63,6 +64,9 @@ export class ArchivePreviewComponent implements OnChanges {
   updateStarted = false;
   hasAccessContractManagementPermissionsMessage = this.translateService.instant('UNIT_UPDATE.NO_PERMISSION');
 
+  @ViewChild('tabs', { static: false }) tabs: MatTabGroup;
+  @ViewChild('descriptionTab', { static: false }) descriptionTab: ArchiveUnitDescriptionTabComponent;
+
   constructor(
     private route: ActivatedRoute,
     private translateService: TranslateService,
@@ -72,11 +76,22 @@ export class ArchivePreviewComponent implements OnChanges {
     });
   }
 
-  emitClose() {
+  ngAfterViewInit(): void {
+    this.tabs._handleClick = this.interceptTabChange.bind(this);
+  }
+
+  async emitClose() {
+    if (this.descriptionTab.isModified()) {
+      await this.checkBeforeExit();
+    }
     this.previewClose.emit();
     this.isPanelextended = false;
     this.backToNormalLateralPanel.emit();
     this.selectedIndex = 0;
+  }
+
+  async checkBeforeExit() {
+    await this.descriptionTab.onCancel();
   }
 
   selectedTabChangeEvent($event: MatTabChangeEvent) {
@@ -94,6 +109,22 @@ export class ArchivePreviewComponent implements OnChanges {
     this.selectedIndex = $event.index;
   }
 
+  @HostListener('window:beforeunload', ['$event'])
+  async beforeunloadHandler(event: any) {
+    if (this.descriptionTab.isModified()) {
+      event.preventDefault();
+      await this.checkBeforeExit();
+    }
+  }
+
+  private async interceptTabChange(tab: MatTab, tabHeader: MatTabHeader, idx: number) {
+    if (this.descriptionTab.isModified()) {
+      await this.checkBeforeExit();
+    }
+    this.updateStarted = false;
+    return MatTabGroup.prototype._handleClick.apply(this.tabs, [tab, tabHeader, idx]);
+  }
+
   showNormalPanel() {
     this.updateStarted = false;
     this.selectedTabChangeEvent({ index: this.selectedIndex, tab: null });
@@ -106,8 +137,14 @@ export class ArchivePreviewComponent implements OnChanges {
     this.updateStarted = true;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  async ngOnChanges(changes: SimpleChanges): Promise<void> {
     if (changes.archiveUnit) {
+      if (this.descriptionTab?.isModified()) {
+        this.archiveUnit = changes.archiveUnit.previousValue;
+        await this.checkBeforeExit().then(() => {
+          this.archiveUnit = changes.archiveUnit.currentValue;
+        });
+      }
       this.showNormalPanel();
     }
   }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-description-tab/archive-unit-description-tab.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-description-tab/archive-unit-description-tab.component.html
@@ -2,7 +2,7 @@
 
 <div *ngIf="editMode">
   <vitamui-common-editor-banner [title]="'ARCHIVE_UNIT.EDITOR_BANNER.TITLE' | translate: { sedaVersion: '2.2' }" class="editor-banner">
-    <button (click)="onSave()" [disabled]="editObject?.control?.pristine" class="btn primary save">
+    <button (click)="onSave()" [disabled]="!isModified()" class="btn primary save">
       {{ 'COMMON.SAVE' | translate }}
     </button>
     <button (click)="onCancel()" class="btn primary cancel">

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
@@ -26,6 +26,7 @@
     [selectedIndex]="selectedIndex"
     [ngClass]="isPanelextended ? 'extended-preview-tab-group' : 'preview-tab-group'"
     (selectedTabChange)="selectedTabChangeEvent($event)"
+    #tabs
   >
     <mat-tab label="{{ 'COLLECT.ARCHIVE_UNIT_PREVIEW.TABS.INFORMATIONS' | translate }}">
       <app-archive-unit-information-tab
@@ -39,6 +40,7 @@
         [archiveUnit]="archiveUnit"
         [(editMode)]="updateStarted"
         [transactionId]="transactionId"
+        #descriptionTab
       ></app-archive-unit-description-tab>
     </mat-tab>
 

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-unit-description-tab/archive-unit-description-tab.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-unit-description-tab/archive-unit-description-tab.component.html
@@ -2,7 +2,7 @@
 
 <div *ngIf="editMode">
   <vitamui-common-editor-banner [title]="'ARCHIVE_UNIT.EDITOR_BANNER.TITLE' | translate: { sedaVersion: '2.2' }" class="editor-banner">
-    <button (click)="onSave()" [disabled]="editObject?.control?.pristine" class="btn primary save">
+    <button (click)="onSave()" [disabled]="!isModified()" class="btn primary save">
       {{ 'COMMON.SAVE' | translate }}
     </button>
     <button (click)="onCancel()" class="btn primary cancel">

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -420,7 +420,7 @@
                     [checked]="isAllChecked"
                   />
                 </div>
-                <div class="col-1 d-flex align-items-center clickable" (click)="openPanel(archiveUnit)">
+                <div class="col-1 d-flex align-items-center clickable" (click)="showPreviewArchiveUnit(archiveUnit)">
                   <span class="table-filter-icon" [ngSwitch]="getArchiveUnitType(archiveUnit)">
                     <ng-container *ngSwitchCase="UnitType.INGEST">
                       <span class="table-filter-icon">
@@ -440,19 +440,19 @@
                     </ng-container>
                   </span>
                 </div>
-                <div class="col-4 d-flex align-items-center clickable" (click)="openPanel(archiveUnit)">
+                <div class="col-4 d-flex align-items-center clickable" (click)="showPreviewArchiveUnit(archiveUnit)">
                   <p matTooltip="{{ archiveUnit | unitI18n: 'Description' }}" matTooltipClass="vitamui-tooltip" [matTooltipShowDelay]="300">
                     <b> {{ archiveUnit | unitI18n: 'Title' }}</b> <br />
                     {{ archiveUnit | unitI18n: 'Description' | truncate: 100 }}
                   </p>
                 </div>
-                <div class="col-2 d-flex align-items-center clickable" (click)="openPanel(archiveUnit)">
+                <div class="col-2 d-flex align-items-center clickable" (click)="showPreviewArchiveUnit(archiveUnit)">
                   {{ archiveUnit.StartDate | dateTime: 'dd/MM/yyyy' }}
                 </div>
-                <div class="col-2 d-flex align-items-center clickable" (click)="openPanel(archiveUnit)">
+                <div class="col-2 d-flex align-items-center clickable" (click)="showPreviewArchiveUnit(archiveUnit)">
                   {{ archiveUnit.EndDate | dateTime: 'dd/MM/yyyy' }}
                 </div>
-                <div class="col-2 d-flex align-items-center clickable" (click)="openPanel(archiveUnit)">
+                <div class="col-2 d-flex align-items-center clickable" (click)="showPreviewArchiveUnit(archiveUnit)">
                   <p
                     matTooltip="{{ archiveUnit['#originating_agency'] }}   ({{ archiveUnit['#originating_agencies'] }})"
                     matTooltipClass="vitamui-tooltip"


### PR DESCRIPTION
Show confirmation popup on:
- tab change
- panel close
- selecting another item
- page refresh

when there has been changes in the MD form.

Available for Collect and Archive Search.