### PR TITLE
Bugs #12703: call expects id, not identifier

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/archival-profile-unit-api.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/archival-profile-unit-api.service.ts
@@ -67,7 +67,7 @@ export class ArchivalProfileUnitApiService extends BaseHttpClient<ArchivalProfil
   }
 
   updateProfilePua(archivalUnitProfile: ArchivalProfileUnit, headers?: HttpHeaders): Observable<ArchivalProfileUnit> {
-    return this.http.put<ArchivalProfileUnit>(this.apiUrl + archivalUnitProfile.identifier, archivalUnitProfile, { headers });
+    return this.http.put<ArchivalProfileUnit>(this.apiUrl + archivalUnitProfile.id, archivalUnitProfile, { headers });
   }
 
   patch(partialAgency: { id: string; [key: string]: any }, headers?: HttpHeaders) {


### PR DESCRIPTION
Similar problem as #12457.
The fix (send id instead of identifier) is also similar, see https://github.com/ProgrammeVitam/vitam-ui/pull/1688
Previously the conversion from identifier to id was done inside ui-pastis.