### PR TITLE
Bug #12711: Fix role migration for collect_app.

### DIFF
--- a/deployment/scripts/mongod/v7.1/57_migration_collect_profiles_roles.js.j2
+++ b/deployment/scripts/mongod/v7.1/57_migration_collect_profiles_roles.js.j2
@@ -3,10 +3,9 @@ dbSecurity = db.getSiblingDB('security')
 
 print("START 57_migration_collect_profiles_roles.js");
 
-// ---- le role ROLE_UPDATE_UNIT_DESC_METADATA sera ajouté pour le profil Collecte --- //
+// ---- ROLE_UPDATE_UNIT_DESC_METADATA will be added to profiles including COLLECT_APP --- //
 
 db.profiles.updateMany({
-   "name": "Collect Profile",
    "applicationName": "COLLECT_APP"
 },
 {


### PR DESCRIPTION
## Description

Les profils existant n'avaient pas le nouveau rôle associé pour l'application collecte.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)