### PR TITLE
Bugs #12714: operationId and actionId parameters are mixed up

### DIFF
--- a/api/api-referential/referential-external/src/main/java/fr/gouv/vitamui/referential/external/server/rest/LogbookManagementOperationExternalController.java
+++ b/api/api-referential/referential-external/src/main/java/fr/gouv/vitamui/referential/external/server/rest/LogbookManagementOperationExternalController.java
@@ -94,7 +94,7 @@ public class LogbookManagementOperationExternalController {
         LOGGER.debug("Update the operation id={} with actionId={}", operationId, actionId);
 
         VitamUIProcessDetailResponseDto operationResponseDto = new VitamUIProcessDetailResponseDto();
-        ProcessDetailDto processDetailDto = logbookManagementOperationExternalService.updateOperationActionProcess(actionId, operationId);
+        ProcessDetailDto processDetailDto = logbookManagementOperationExternalService.updateOperationActionProcess(operationId, actionId);
         if (processDetailDto != null) {
             operationResponseDto = processDetailDto.getOperations();
         }


### PR DESCRIPTION
Inversion des paramètres operationId et actionId dans l'appel à Logbook internal.