### PR TITLE
Bug #12649 : update ontology deletion message

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology.service.ts
@@ -109,7 +109,7 @@ export class OntologyService extends SearchService<Ontology> {
       tap(
         () => {
           this.snackBarService.open({
-            message: 'SNACKBAR.ONTOLOGY_DELETED',
+            message: 'SNACKBAR.VOCABULARY_DELETED',
             icon: 'vitamui-icon-ontologie',
           });
         },

--- a/ui/ui-frontend/projects/referential/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/referential/src/assets/i18n/en.json
@@ -1083,6 +1083,7 @@
     "ONTOLOGY_CREATED": "The ontology has been successfully created",
     "ONTOLOGY_UPDATED": "The ontology has been updated successfully",
     "ONTOLOGY_DELETED": "Ontology has been successfully deleted",
+    "VOCABULARY_DELETED": "Vocabulary has been successfully deleted",
     "AUDIT_RUN": "The audit \"{{type}}\" has been launched",
     "PROBATIVE_VALUE_RUN": "The probative value statement has been launched",
     "FORMAT_INVALID": "Invalid request format",

--- a/ui/ui-frontend/projects/referential/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/referential/src/assets/i18n/fr.json
@@ -1083,6 +1083,7 @@
     "ONTOLOGY_CREATED": "L'ontologie a bien été créé",
     "ONTOLOGY_UPDATED": "L'ontologie a bien été mis à jour",
     "ONTOLOGY_DELETED": "L'ontologie a bien été supprimé",
+    "VOCABULARY_DELETED": "Le vocabulaire a été supprimé avec succès",
     "AUDIT_RUN": "L'audit \"{{type}}\" a bien été lancé",
     "PROBATIVE_VALUE_RUN": "Le relevé de valeur probante a été lancé",
     "FORMAT_INVALID": "Format de la requête invalide",


### PR DESCRIPTION
## Description

Modification du message de suppression d'ontologie : "Le vocabulaire a été supprimé avec succès"

## Type de changement:

* Correction

## Contributeur

VAS (Vitam Accessible en Service)
