### PR TITLE
bug #12641 : no error message when duration not valid

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-information-tab/rule-information-tab.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-information-tab/rule-information-tab.component.html
@@ -38,6 +38,9 @@
         <vitamui-common-input-error *ngIf="!!form.get('ruleDuration')?.errors?.required">
           {{ 'COMMON.REQUIRED' | translate }}
         </vitamui-common-input-error>
+        <vitamui-common-input-error *ngIf="!!form.get('ruleDuration')?.errors?.pattern">
+          {{ 'RULES_APP.TAB.ERROR.INTEGER_REQUIRED' | translate }}
+        </vitamui-common-input-error>
       </ng-container>
     </vitamui-common-input>
   </div>

--- a/ui/ui-frontend/projects/referential/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/referential/src/assets/i18n/en.json
@@ -677,6 +677,9 @@
       },
       "HISTORY": {
         "TITLE": "History"
+      },
+      "ERROR": {
+        "INTEGER_REQUIRED": "Duration must be an integer"
       }
     }
   },

--- a/ui/ui-frontend/projects/referential/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/referential/src/assets/i18n/fr.json
@@ -677,6 +677,9 @@
       },
       "HISTORY": {
         "TITLE": "Historique"
+      },
+      "ERROR": {
+        "INTEGER_REQUIRED": "La durée doit être un nombre entier"
       }
     }
   },


### PR DESCRIPTION
## Description

Sur l'app Règles de gestion, lorsque l'on cherche à modifier la durée, aucun message d'erreur ne s'affiche lorsque la durée n'est pas un nombre entier

## Type de changement:

* Correction

## Contributeur

VAS (Vitam Accessible en Service)
