### PR TITLE
Bug #12749: Remove useless vitamuidb group and users from package installation.

### DIFF
--- a/tools/packaging/templates/before-install.sh
+++ b/tools/packaging/templates/before-install.sh
@@ -1,8 +1,5 @@
-# Init vitamui system groups
-getent group  vitamui >/dev/null || groupadd -g 4000 vitamui
-getent group  vitamuidb >/dev/null || groupadd -g 5000 vitamui
-getent group  vitamuidb-admin >/dev/null || groupadd -g 5001 vitamuidb-admin
+# Init vitamui system group
+getent group vitamui >/dev/null || groupadd -g 4000 vitamui
 
-# Init vitamui system users
+# Init vitamui system user
 getent passwd vitamui >/dev/null || useradd -u 4000 -g 4000 -s /bin/bash -c "vitamui service user" vitamui
-getent passwd vitamuidb >/dev/null || useradd -u 4001 -g 4000 -s /bin/bash -c "vitamuidb database user" vitamuidb


### PR DESCRIPTION
## Description

It shouldn't be created by default and causes problem during package installation.

By default, this group was created with ansible's `users` role but a new condition was added to avoid creating vitamuidb user on all nodes that causes this issue.

See: https://github.com/ProgrammeVitam/vitam-ui/pull/1740/commits/b8233afdf86f2666e36d6d1c1513c41023624d89

## Type de changement

* Build
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)