### PR TITLE
Bugs #11662: Fix apigw mapping and missing header on units search

### DIFF
--- a/api/api-gateway/src/main/resources/application-dev.yml
+++ b/api/api-gateway/src/main/resources/application-dev.yml
@@ -194,6 +194,7 @@ spring:
           filters:
             - RewritePath=/referential-api/fileformat(?<segment>.*),/referential/v1/fileformats$\{segment}
             - RewritePath=/referential-api/operation(?<segment>.*),/referential/v1/operations$\{segment}
+            - RewritePath=/referential-api/search/units(?<segment>.*),/units$\{segment}
             - RewritePath=/referential-api/search/filingplan(?<segment>.*),/units/filingplan$\{segment}
             - RewritePath=/referential-api/search/units(?<segment>.*),/units$\{segment}
             - RewritePath=/referential-api/static(?<segment>.*), $\{segment}

--- a/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/rest/UnitInternalController.java
+++ b/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/rest/UnitInternalController.java
@@ -88,12 +88,10 @@ public class UnitInternalController {
     @GetMapping(CommonConstants.PATH_ID)
     public JsonNode findUnitById(
         @RequestHeader(value = CommonConstants.X_TENANT_ID_HEADER) final Integer tenantId,
-        @RequestHeader(value = CommonConstants.X_ACCESS_CONTRACT_ID_HEADER) final String accessContractId,
         @PathVariable final String id) throws VitamClientException, InvalidParseOperationException,
         PreconditionFailedException {
-        final VitamContext vitamContext = securityService.buildVitamContext(tenantId, accessContractId);
+        final VitamContext vitamContext = externalParametersService.buildVitamContextFromExternalParam();
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);
-        SanityChecker.checkSecureParameter(id, accessContractId);
         return unitInternalService.findUnitById(id, vitamContext);
     }
 

--- a/deployment/roles/vitamui/templates/api-gateway/application.yml.j2
+++ b/deployment/roles/vitamui/templates/api-gateway/application.yml.j2
@@ -251,6 +251,7 @@ spring:
 
             # Collect Referential API
             - RewritePath=/collect-api/schemas,/schemas
+            - RewritePath=/collect-api/search/units(?<segment>.*),/units$\{segment}
             - RewritePath=/collect-api/search/filingplan(?<segment>.*),/units/filingplan$\{segment}
             - RewritePath=/collect-api(?<segment>.*),/referential/v1$\{segment}
 

--- a/ui/ui-frontend/proxy-gateway.conf.js
+++ b/ui/ui-frontend/proxy-gateway.conf.js
@@ -288,7 +288,7 @@ const PROXY_CONFIG = [
   },
   {
     // collect to Referential External Backend
-    context: ['/collect-api/ontology', '/collect-api/search/filingplan', '/collect-api/schemas', '/collect-api/rules'],
+    context: ['/collect-api/ontology', '/collect-api/search', '/collect-api/schemas', '/collect-api/rules'],
     target: {
       protocol: 'https:',
       host: 'localhost',
@@ -301,6 +301,7 @@ const PROXY_CONFIG = [
     logLevel: 'debug',
     pathRewrite: {
       '^/collect-api/ontology': '/referential/v1/ontology',
+      '^/collect-api/search/units': '/units',
       '^/collect-api/search/filingplan': '/units/filingplan',
       '^/collect-api/schemas': '/schemas',
       '^/collect-api/rules': '/referential/v1/rules',


### PR DESCRIPTION
Correction de deux problèmes :
 - 404 sur /collect-api/search/units/{id} lié à un mauvais mapping sur l'api gateway
 - 400 sur l'appel lié au header X-Access-Contract-Id manquant (apparaît une fois la 404 corrigée)

Sera à CP (sauf correction API GW) jusqu'en 6.0