### PR TITLE
Fix #12742: handle non-string values in repeatable input

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/components/vitamui-repeatable-input/vitamui-repeatable-input.component.ts
+++ b/ui/ui-frontend-common/src/app/modules/components/vitamui-repeatable-input/vitamui-repeatable-input.component.ts
@@ -43,7 +43,7 @@ export const REPEATABLE_INPUT_VALUE_ACCESSOR: any = {
   multi: true,
 };
 
-type InternalValue = { id: number; value: string };
+type InternalValue = { id: number; value: string | number | boolean };
 
 @Component({
   selector: 'vitamui-common-repeatable-input',
@@ -86,8 +86,8 @@ export class VitamuiRepeatableInputComponent implements ControlValueAccessor {
 
   constructor(private elRef: ElementRef) {}
 
-  writeValue(values: string[]) {
-    this.items = (values && values.length ? values : ['']).map((v, i) => ({ id: i, value: v }));
+  writeValue(values: InternalValue['value'][]) {
+    this.items = (values && values.length ? values : ['']).map((v, i) => ({ id: i, value: v.toString() }));
   }
 
   addInput() {
@@ -128,8 +128,8 @@ export class VitamuiRepeatableInputComponent implements ControlValueAccessor {
     this.onTouched();
   }
 
-  isEmpty(s: string): boolean {
-    return !s?.replace(/\s/g, '');
+  isEmpty(s: InternalValue['value']): boolean {
+    return !s?.toString().replace(/\s/g, '');
   }
 
   trackBy(_: number, item: InternalValue) {

--- a/ui/ui-frontend/package-lock.json
+++ b/ui/ui-frontend/package-lock.json
@@ -19293,7 +19293,7 @@
     "node_modules/ui-frontend-common": {
       "version": "2.1.58",
       "resolved": "file:../ui-frontend-common/ui-frontend-common-2.1.58.tgz",
-      "integrity": "sha512-/51GSEc2jVRGCItDqfcZrlbpfCQb1yHYUp9eQjU8Opktph0JGk2iihR9Ko0+17IIh3bjA9vsWTtt3gCyTf7UKw==",
+      "integrity": "sha512-VmaNxVve5WU+pmnRnTSfyPWRTnorR7qITCNUvTHir+MTi1o8EyUaRNfPp/c/a+QWN4vtmfk3ugR0LXZfNg2+sw==",
       "dependencies": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "13.0.0",
@@ -35077,7 +35077,7 @@
     },
     "ui-frontend-common": {
       "version": "file:../ui-frontend-common/ui-frontend-common-2.1.58.tgz",
-      "integrity": "sha512-/51GSEc2jVRGCItDqfcZrlbpfCQb1yHYUp9eQjU8Opktph0JGk2iihR9Ko0+17IIh3bjA9vsWTtt3gCyTf7UKw==",
+      "integrity": "sha512-VmaNxVve5WU+pmnRnTSfyPWRTnorR7qITCNUvTHir+MTi1o8EyUaRNfPp/c/a+QWN4vtmfk3ugR0LXZfNg2+sw==",
       "requires": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "13.0.0",


### PR DESCRIPTION
## Description

Le composant repeatable-input ne prenait en compte que les listes de `string` en entrée alors qu'il peut recevoir des listes de `number` ou de `boolean`, notamment dans le cas de métadonnées descriptives externes de Cardinality MANY.

## Type de changement:

* Correction

## Documentation:

*Indiquer la documentation mise à jour*

[ ] Quels sont les nouvelles documentations ?

[ ] Quels sont les modifications existantes ?

[ ] Quels sont les documentations ou sections de documentations supprimés ?

## Tests:

manuel

## Migration:

*Indiquer si les modifications apportées impliquent une migration sur l'existant et comment la faire*

## Checklist:

*Sélectionner les éléments de la checklist*

[ ] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

VAS (Vitam Accessible en Service)