### PR TITLE
Fix #11960: previous MR was breaking CI build

### DIFF
--- a/commons/commons-test/pom.xml
+++ b/commons/commons-test/pom.xml
@@ -87,9 +87,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <classifier>tests</classifier>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Fix #11960: previous MR (https://github.com/ProgrammeVitam/vitam-ui/pull/1569) was breaking CI build