### PR TITLE
bugs #12739 fix(datepicker): truncate by default time part

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/components/datepicker/datepicker.component.ts
+++ b/ui/ui-frontend-common/src/app/modules/components/datepicker/datepicker.component.ts
@@ -6,7 +6,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
   template: `
     <div class="vitamui-input" [ngClass]="{ filled: !!value }" (click)="picker.open()">
       <span class="search-date-label">{{ label }}</span>
-      <input matInput [matDatepicker]="picker" [(ngModel)]="value" (ngModelChange)="onChange($event)" [disabled]="disabled" />
+      <input matInput [matDatepicker]="picker" [ngModel]="value" (ngModelChange)="onChange($event)" [disabled]="disabled" />
       <i class="vitamui-icon vitamui-icon-calendar primary"></i>
       <mat-datepicker #picker></mat-datepicker>
     </div>
@@ -23,6 +23,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 export class DatepickerComponent implements ControlValueAccessor {
   @Input() label!: string;
   @Input() value: string;
+  @Input() onlyDate = true;
   disabled = false;
 
   propagateChange = (_: any) => {};
@@ -49,8 +50,15 @@ export class DatepickerComponent implements ControlValueAccessor {
     this.disabled = isDisabled;
   }
 
-  onChange(value: Date): void {
-    this.value = value && value.toISOString();
+  onChange(date: Date): void {
+    const isoDatetime = date?.toISOString();
+
+    if (this.onlyDate) {
+      this.value = isoDatetime && isoDatetime.split('T')[0];
+    } else {
+      this.value = isoDatetime;
+    }
+
     this.propagateChange(this.value);
   }
 }

--- a/ui/ui-frontend-common/src/app/modules/object-viewer/components/primitive/primitive.component.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-viewer/components/primitive/primitive.component.ts
@@ -60,7 +60,7 @@ export class PrimitiveComponent implements OnInit {
     switch (uiComponent) {
       case 'datepicker':
       case 'datetime':
-        const dateFormat = this.dateDisplayService.getFormat(uiComponent);
+        const dateFormat = this.dateDisplayService.getFormat('datepicker'); // 'datetime' format is not supported, see #12739, #12744
         this.value = this.datePipe.transform(this.displayObject.value, dateFormat);
         break;
       default:

--- a/ui/ui-frontend/package-lock.json
+++ b/ui/ui-frontend/package-lock.json
@@ -19293,7 +19293,7 @@
     "node_modules/ui-frontend-common": {
       "version": "2.1.58",
       "resolved": "file:../ui-frontend-common/ui-frontend-common-2.1.58.tgz",
-      "integrity": "sha512-VmaNxVve5WU+pmnRnTSfyPWRTnorR7qITCNUvTHir+MTi1o8EyUaRNfPp/c/a+QWN4vtmfk3ugR0LXZfNg2+sw==",
+      "integrity": "sha512-Yxk4VrnL6RCFGDRFX2jJXWYDiUsSY6+s9habbp1xZO7xLPqQTUfZ3W/IFptit8hyutYjI33T7ga+vBr6g3vKKw==",
       "dependencies": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "13.0.0",
@@ -35077,7 +35077,7 @@
     },
     "ui-frontend-common": {
       "version": "file:../ui-frontend-common/ui-frontend-common-2.1.58.tgz",
-      "integrity": "sha512-VmaNxVve5WU+pmnRnTSfyPWRTnorR7qITCNUvTHir+MTi1o8EyUaRNfPp/c/a+QWN4vtmfk3ugR0LXZfNg2+sw==",
+      "integrity": "sha512-Yxk4VrnL6RCFGDRFX2jJXWYDiUsSY6+s9habbp1xZO7xLPqQTUfZ3W/IFptit8hyutYjI33T7ga+vBr6g3vKKw==",
       "requires": {
         "@angular/material-moment-adapter": "^10.2.3",
         "@ngx-translate/core": "13.0.0",


### PR DESCRIPTION
changes:
* set by default datepicker into time part truncate mode

comments:
* side effect: solves unit descriptive dates which not supports datetime format

## Description

* Le composant datepicker gère maintenant par défaut seulement la partie date.
* Toutes les dates présentes dans l'éditeur de métadonnées des unités d'archive seront tronquées.  

## Type de changement:

*Indiquer le ou les types de changements*

* Build

* PKI

* Ansiblerie

* Nouveau Code

* Correction

* Refactorisation de code

* Autre

## Documentation:

*Indiquer la documentation mise à jour*

[ ] Quels sont les nouvelles documentations ?

[ ] Quels sont les modifications existantes ?

[ ] Quels sont les documentations ou sections de documentations supprimés ?

## Tests:

*Indiquer comment le code à été testé (manuel, environnement, TU, etc)*

manuel

environnement

TU

## Migration:

*Indiquer si les modifications apportées impliquent une migration sur l'existant et comment la faire*

## Checklist:

*Sélectionner les éléments de la checklist*

[ ] Mon code suit le style de code de ce projet.

[ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.

[ ] J'ai fait les changements correspondant dans la documentation RAML.

[ ] J'ai fait les changements correspondant dans la documentation Métier.

[ ] J'ai fait les changements correspondant dans la documentation Technique.

[ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.

[ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.

[ ] Les tests unitaires nouveaux et existants passent avec succès localement.

[ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

VAS (Vitam Accessible en Service)

CEA (Commissariat à l'énergie atomique et aux énergies alternatives)
