### PR TITLE
Bugs #12681: ensure that no accordion is grayed out

### DIFF
--- a/ui/ui-frontend-common/src/app/modules/object-editor/services/edit-object.service.spec.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-editor/services/edit-object.service.spec.ts
@@ -497,10 +497,10 @@ describe('EditObjectService', () => {
                 jasmine.objectContaining({
                   path: 'Addressee',
                   kind: 'object-array',
-                  children: [],
                 }),
               ]),
             );
+            expect(editObject.children.length).toEqual(16);
           });
         },
       ),

--- a/ui/ui-frontend-common/src/app/modules/object-editor/services/edit-object.service.ts
+++ b/ui/ui-frontend-common/src/app/modules/object-editor/services/edit-object.service.ts
@@ -75,6 +75,7 @@ export class EditObjectService {
 
     if (editObject.displayRule?.ui?.disabled) control.disable({ onlySelf: true, emitEvent: false });
     if (editObject.required) control.setValidators([Validators.required]);
+    if (editObject.kind === 'object-array' && editObject.children.length === 0) editObject.actions.add.handler();
 
     return editObject;
   }


### PR DESCRIPTION
Fait que tous les champs sont en noir lors de l'édition des MD.

Patch intégralement fait par Daniel, merci à lui.