### PR TITLE
bug #12401 : Non translated keys in security operations and bug #12550 : Harmonization of app's names, titles and descriptions 

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/securisation/securisation-list/securisation-list.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/securisation/securisation-list/securisation-list.component.html
@@ -41,7 +41,7 @@
           <i class="vitamui-icon vitamui-icon-operation" [ngClass]="secu | eventTypeBadgeClass"></i>
         </div>
         <div class="col-2 d-flex align-items-center text break" vitamuiCommonEllipsis>{{ secu.id }}</div>
-        <div class="col-3" vitamuiCommonEllipsis>{{ secu?.type }}</div>
+        <div class="col-3" vitamuiCommonEllipsis>{{ 'SECURE.HOME.ARRAY.TRACEABILITY_TYPES.' + secu?.type | translate }}</div>
         <div class="col-2" vitamuiCommonEllipsis>{{ secu.dateTime | dateTime: 'dd/MM/yyyy' }}</div>
         <div class="col-1" vitamuiCommonEllipsis [ngClass]="secu | eventTypeColorClass">
           {{ (secu | lastEvent)?.outcome }}

--- a/ui/ui-frontend/projects/referential/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/referential/src/assets/i18n/en.json
@@ -381,7 +381,7 @@
   },
   "ACCESS_CONTRACT": {
     "HOME": {
-      "TITLE": "Set up access contracts",
+      "TITLE": "Access contracts",
       "SEARCH_PLACEHOLDER": "Name, ID",
       "CREATE_ACCESS_CONTRACT": "Create access contract",
       "IMPORT": "Import",
@@ -733,7 +733,7 @@
   },
   "AGENCY": {
     "HOME": {
-      "TITLE": "Configure agent services",
+      "TITLE": "Agent services",
       "TITLE_PLACEHOLDER": "Name, Identifier",
       "ACTION_BUTTON": "Create agent service",
       "ACTION_IMPORT": "Import the referential",
@@ -803,7 +803,7 @@
   },
   "INGEST_CONTRACT": {
     "HOME": {
-      "TITLE": "Set up ingest contracts",
+      "TITLE": "Ingest contracts",
       "SEARCH_PLACEHOLDER": "Name, identifier",
       "CREATE_INGEST_CONTRACT": "Create an ingest contract",
       "IMPORT": "Import",

--- a/ui/ui-frontend/projects/referential/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/referential/src/assets/i18n/fr.json
@@ -381,7 +381,7 @@
   },
   "ACCESS_CONTRACT": {
     "HOME": {
-      "TITLE": "Paramétrer les contrats d'accès",
+      "TITLE": "Contrats d'accès",
       "SEARCH_PLACEHOLDER": "Nom, identifiant",
       "CREATE_ACCESS_CONTRACT": "Créer un contrat d'accès",
       "IMPORT": "Importer",
@@ -733,7 +733,7 @@
   },
   "AGENCY": {
     "HOME": {
-      "TITLE": "Paramétrer les services agents",
+      "TITLE": "Services agents",
       "TITLE_PLACEHOLDER": "Nom, Identifiant",
       "ACTION_BUTTON": "Créer un service agent",
       "ACTION_IMPORT": "Importer le référentiel",
@@ -803,7 +803,7 @@
   },
   "INGEST_CONTRACT": {
     "HOME": {
-      "TITLE": "Paramétrer les contrats d’entrée",
+      "TITLE": "Contrats d’entrée",
       "SEARCH_PLACEHOLDER": "Nom, identifiant",
       "CREATE_INGEST_CONTRACT": "Créer un contrat d'entrée",
       "IMPORT": "Importer",


### PR DESCRIPTION
## Description

Dans l'app Opérations de sécurisation, des clés ne sont pas traduites. Visiblement un doublon avec le ticket 12549 Avec ticket 12550 : harmonisation des noms, titres et descriptions des APPs

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

VAS (Vitam Accessible en Service)