### PR TITLE
bug #12097 : Signature tab after attachment tab

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-preview.component.html
@@ -54,6 +54,11 @@
       </app-ingest-contract-heritage-tab>
     </mat-tab>
 
+    <mat-tab [label]="'INGEST_CONTRACT.TAB.ATTACHEMENT.TITLE' | translate" class="no-padding">
+      <app-ingest-contract-attachment-tab [readOnly]="readOnly" [ingestContract]="ingestContract" [tenantIdentifier]="tenantIdentifier">
+      </app-ingest-contract-attachment-tab>
+    </mat-tab>
+
     <mat-tab [label]="'INGEST_CONTRACT.ELEMENT_TO_CHECK.SIGNATURE' | translate" class="no-padding">
       <app-ingest-contract-signature-tab
         [readOnly]="readOnly"
@@ -62,11 +67,6 @@
         #signatureTab
       >
       </app-ingest-contract-signature-tab>
-    </mat-tab>
-
-    <mat-tab [label]="'INGEST_CONTRACT.TAB.ATTACHEMENT.TITLE' | translate" class="no-padding">
-      <app-ingest-contract-attachment-tab [readOnly]="readOnly" [ingestContract]="ingestContract" [tenantIdentifier]="tenantIdentifier">
-      </app-ingest-contract-attachment-tab>
     </mat-tab>
 
     <mat-tab [label]="'INGEST_CONTRACT.TAB.HISTORY.TITLE' | translate">


### PR DESCRIPTION
## Description

Sur l'app Contrat d'entrée, lors de la consultation, l'onglet Signature est situé avant l'onglet Rattachement. Ce doit être l'inverse.

## Type de changement:

* Correction

## Contributeur

VAS (Vitam Accessible en Service)