### PR TITLE
Story #12517: Various fixes for Filebeat

### DIFF
--- a/deployment/roles/filebeat/templates/filebeat.yml.j2
+++ b/deployment/roles/filebeat/templates/filebeat.yml.j2
@@ -68,7 +68,7 @@ output.elasticsearch:
     - index: "logstash-access-%{+yyyy.MM.dd}"
       when:
         regexp:
-          fields.kind: "^(access,management)$"
+          kind: "^(access,management)$"
     - index: "logstash-system-%{+yyyy.MM.dd}"
       when.equals:
         event.module: system
@@ -79,7 +79,7 @@ output.elasticsearch:
             - equals:
                 event.module: system
             - regexp:
-                fields.kind: "^(access,management)$"
+                kind: "^(access,management)$"
 
 #
 # Processors

--- a/deployment/roles/filebeat/templates/inputs/cots.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/cots.yml.j2
@@ -17,8 +17,9 @@
     type: cots
   processors:
     - dissect:
-        tokenizer: '%{date_time} [%{log_level}]  %{logger}: %{log_message}'
+        tokenizer: '%{date_time} [%{log_level}]%{*}%{logger}: %{log_message}'
         target_prefix: ""
+        trim_values: all
     - drop_fields:
         fields: ["date_time"]
   parsers:

--- a/deployment/roles/filebeat/templates/inputs/cots.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/cots.yml.j2
@@ -9,6 +9,7 @@
   enabled: {{ filebeat.cots.consul.enable_log | bool | lower }}
   paths:
     - "{{ vitam_defaults.folder.root_path }}/log/consul/consul*.log"
+  fields_under_root: true
   fields:
     kind: log
     vitam_component: consul
@@ -16,11 +17,6 @@
     type: cots
   processors:
   - dissect:
-      tokenizer: '%{timestamp} [%{loglevel}]  %{logger}: %{message}'
-      field: "message"
-      target: ""
-  - copy_fields:
-      fields:
-        - from: dissect.loglevel
-          to: loglevel
+      tokenizer: '%{date_time} [%{log_level}]  %{logger}: %{log_message}'
+      target_prefix: ""
 {% endif %}

--- a/deployment/roles/filebeat/templates/inputs/cots.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/cots.yml.j2
@@ -16,7 +16,13 @@
     source: vitamui
     type: cots
   processors:
-  - dissect:
-      tokenizer: '%{date_time} [%{log_level}]  %{logger}: %{log_message}'
-      target_prefix: ""
+    - dissect:
+        tokenizer: '%{date_time} [%{log_level}]  %{logger}: %{log_message}'
+        target_prefix: ""
+  parsers:
+    - multiline:
+        type: pattern
+        pattern: '^[[:space:]]'
+        negate: false
+        match: after
 {% endif %}

--- a/deployment/roles/filebeat/templates/inputs/cots.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/cots.yml.j2
@@ -19,6 +19,8 @@
     - dissect:
         tokenizer: '%{date_time} [%{log_level}]  %{logger}: %{log_message}'
         target_prefix: ""
+    - drop_fields:
+        fields: ["date_time"]
   parsers:
     - multiline:
         type: pattern

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -22,6 +22,7 @@
     'vitamui_api_gateway': filebeat.services.vitamui_api_gateway.enable_access} [vitamui_service] | default(true) | bool | lower }}
   paths:
     - "{{ vitamui_defaults.folder.root_path }}/log/{{ vitamui_service }}/accesslog-{{ vitamui_service }}.*.log"
+  fields_under_root: true
   fields:
     kind: access
     vitam_component: {{ vitamui_service }}
@@ -29,9 +30,8 @@
     type: application
   processors:
     - dissect:
-        tokenizer: '%{client_ip} - - [%{[date_time]}] "%{[http_method]} %{[request_path]} HTTP/%{[http_version]}" %{[http_status_code]} %{[response_size]}'
-        field: "message"
-        target: ""
+        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer}'
+        target_prefix: ""
   {% endif %}
 
   {% if filebeat.services[vitamui_service].enable_management | default(true) | bool %}
@@ -53,6 +53,7 @@
     'vitamui_api_gateway': filebeat.services.vitamui_api_gateway.enable_management} [vitamui_service] | default(true) | bool | lower }}
   paths:
     - "{{ vitamui_defaults.folder.root_path }}/log/{{ vitamui_service }}/management_accesslog-{{ vitamui_service }}.*.log"
+  fields_under_root: true
   fields:
     kind: management
     vitam_component: {{ vitamui_service }}
@@ -60,9 +61,8 @@
     type: application
   processors:
     - dissect:
-        tokenizer: '%{client_ip} - - [%{[date_time]}] "%{[http_method]} %{[request_path]} HTTP/%{[http_version]}" %{[http_status_code]} %{[response_size]}'
-        field: "message"
-        target: ""
+        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer}'
+        target_prefix: ""
   {% endif %}
 
   {% if filebeat.services[vitamui_service].enable_log | default(true) | bool %}
@@ -84,6 +84,7 @@
     'vitamui_api_gateway': filebeat.services.vitamui_api_gateway.enable_log} [vitamui_service] | default(true) | bool | lower }}
   paths:
     - "{{ vitamui_defaults.folder.root_path }}/log/{{ vitamui_service }}/{{ vitamui_service }}.*.log"
+  fields_under_root: true
   fields:
     kind: log
     vitam_component: {{ vitamui_service }}
@@ -91,15 +92,8 @@
     type: application
   processors:
     - dissect:
-        tokenizer: '%{timestamp} [%{thread}] [] %{loglevel} %{logger} - %{message}'
-        field: "message"
-        target: ""
-    - drop_fields:
-        fields: ["timestamp","dissect.timestamp"]
-    - copy_fields:
-        fields:
-          - from: dissect.loglevel
-            to: loglevel
+        tokenizer: '%{date_time} [%{thread}] [] %{log_level} %{logger} - %{log_message}'
+        target_prefix: ""
   parsers:
     - multiline:
         type: pattern

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -96,8 +96,9 @@
     type: application
   processors:
     - dissect:
-        tokenizer: '%{date_time} [%{thread}] [] %{log_level} %{logger} - %{log_message}'
+        tokenizer: '%{date_time} [[%{thread}]] [%{request_id}] %{log_level} %{logger} - %{log_message}'
         target_prefix: ""
+        trim_values: all
     - drop_fields:
         fields: ["date_time"]
   parsers:

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -30,7 +30,11 @@
     type: application
   processors:
     - dissect:
+    {% if vitamui_service == 'cas-server' %}
+        tokenizer: '[%{date_time}] %{client_ip|ip} "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} (%{duration|integer} ms)'
+    {% else %}
         tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
+    {% endif %}
         target_prefix: ""
     - drop_fields:
         fields: ["date_time"]
@@ -63,7 +67,11 @@
     type: application
   processors:
     - dissect:
+    {% if vitamui_service == 'cas-server' %}
+        tokenizer: '[%{date_time}] %{client_ip|ip} "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} (%{duration|integer} ms)'
+    {% else %}
         tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
+    {% endif %}
         target_prefix: ""
     - drop_fields:
         fields: ["date_time"]

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -30,7 +30,7 @@
     type: application
   processors:
     - dissect:
-        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer}'
+        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
         target_prefix: ""
     - drop_fields:
         fields: ["date_time"]
@@ -63,7 +63,7 @@
     type: application
   processors:
     - dissect:
-        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer}'
+        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
         target_prefix: ""
     - drop_fields:
         fields: ["date_time"]

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -25,7 +25,7 @@
   fields_under_root: true
   fields:
     kind: access
-    vitam_component: {{ vitamui_service }}
+    vitam_component: vitamui-{{ vitamui_service }}
     source: vitamui
     type: application
   processors:
@@ -62,7 +62,7 @@
   fields_under_root: true
   fields:
     kind: management
-    vitam_component: {{ vitamui_service }}
+    vitam_component: vitamui-{{ vitamui_service }}
     source: vitamui
     type: application
   processors:
@@ -99,7 +99,7 @@
   fields_under_root: true
   fields:
     kind: log
-    vitam_component: {{ vitamui_service }}
+    vitam_component: vitamui-{{ vitamui_service }}
     source: vitamui
     type: application
   processors:

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -32,6 +32,8 @@
     - dissect:
         tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer}'
         target_prefix: ""
+    - drop_fields:
+        fields: ["date_time"]
   {% endif %}
 
   {% if filebeat.services[vitamui_service].enable_management | default(true) | bool %}
@@ -63,6 +65,8 @@
     - dissect:
         tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer}'
         target_prefix: ""
+    - drop_fields:
+        fields: ["date_time"]
   {% endif %}
 
   {% if filebeat.services[vitamui_service].enable_log | default(true) | bool %}
@@ -94,6 +98,8 @@
     - dissect:
         tokenizer: '%{date_time} [%{thread}] [] %{log_level} %{logger} - %{log_message}'
         target_prefix: ""
+    - drop_fields:
+        fields: ["date_time"]
   parsers:
     - multiline:
         type: pattern

--- a/deployment/roles/filebeat/templates/modules/apache.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/apache.yml.j2
@@ -10,15 +10,15 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
         kind: access
         vitam_component: apache
         source: vitamui
       processors:
       - dissect:
-          tokenizer: '%{client_ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code} %{response_size} "%{referer}" "%{user_agent}"'
-          field: "message"
-          target: ""
+          tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer} "%{referer}" "%{user_agent}"'
+          target_prefix: ""
 
   # Error logs
   error:
@@ -28,7 +28,8 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
-      kind: error
-      vitam_component: apache
-      source: vitamui
+        kind: error
+        vitam_component: apache
+        source: vitamui

--- a/deployment/roles/filebeat/templates/modules/apache.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/apache.yml.j2
@@ -15,10 +15,11 @@
         kind: access
         vitam_component: apache
         source: vitamui
+        type: cots
       processors:
-      - dissect:
-          tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer} "%{referer}" "%{user_agent}"'
-          target_prefix: ""
+        - dissect:
+            tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size} "%{referer}" "%{user_agent}"'
+            target_prefix: ""
         - drop_fields:
             fields: ["date_time"]
 

--- a/deployment/roles/filebeat/templates/modules/apache.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/apache.yml.j2
@@ -19,6 +19,8 @@
       - dissect:
           tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer} "%{referer}" "%{user_agent}"'
           target_prefix: ""
+        - drop_fields:
+            fields: ["date_time"]
 
   # Error logs
   error:

--- a/deployment/roles/filebeat/templates/modules/logstash.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/logstash.yml.j2
@@ -1,4 +1,3 @@
-#jinja2: lstrip_blocks: True
 # Module: logstash
 # Docs: https://www.elastic.co/guide/en/beats/filebeat/7.17/filebeat-module-logstash.html
 
@@ -14,5 +13,13 @@
         vitam_component: logstash
         source: vitamui
         type: cots
+      processors:
+        - dissect:
+            tokenizer: '[%{date_time}][%{log_level}]%{*}[%{logger}] %{log_message}'
+            target_prefix: ""
+            trim_values: all
+        - drop_fields:
+            fields: ["date_time"]
+
   slowlog:
     enabled: false

--- a/deployment/roles/filebeat/templates/modules/logstash.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/logstash.yml.j2
@@ -6,7 +6,7 @@
   log:
     enabled: {{ filebeat.cots.logstash.enable_log | bool | lower }}
     var.paths:
-      - "{{ vitam_defaults.folder.root_path }}/log/logstash/logstash-plain.log"
+      - "{{ vitamui_defaults.folder.root_path }}/log/logstash/logstash-plain.log"
     input:
       fields_under_root: true
       fields:

--- a/deployment/roles/filebeat/templates/modules/logstash.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/logstash.yml.j2
@@ -8,6 +8,7 @@
     var.paths:
       - "{{ vitam_defaults.folder.root_path }}/log/logstash/logstash-plain.log"
     input:
+      fields_under_root: true
       fields:
         kind: log
         vitam_component: logstash

--- a/deployment/roles/filebeat/templates/modules/mongodb.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/mongodb.yml.j2
@@ -24,6 +24,7 @@
             id: set_log_level
             source: >
               function process(event) {
+                event.Put("log_message", event.Get("message.msg"));
                 switch (event.Get("message.s")) {
                     case "I":
                         event.Put("log_level", "INFO");
@@ -42,6 +43,6 @@
                   }
                 }
         - drop_event:
-          when:
-            equals:
-              log_level: "INFO"
+            when:
+              equals:
+                log_level: "INFO"

--- a/deployment/roles/filebeat/templates/modules/mongodb.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/mongodb.yml.j2
@@ -8,6 +8,7 @@
     var.paths:
       - "{{ vitamui_defaults.folder.root_path }}/log/mongod/mongo*.log"
     input:
+      fields_under_root: true
       fields:
         kind: log
         vitam_component: mongod_vitamui
@@ -25,22 +26,22 @@
               function process(event) {
                 switch (event.Get("message.s")) {
                     case "I":
-                        event.Put("loglevel", "INFO");
+                        event.Put("log_level", "INFO");
                         break;
                     case "W":
-                        event.Put("loglevel", "WARN");
+                        event.Put("log_level", "WARN");
                         break;
                     case "E":
-                        event.Put("loglevel", "ERROR");
+                        event.Put("log_level", "ERROR");
                         break;
                     case "F":
-                        event.Put("loglevel", "FATAL");
+                        event.Put("log_level", "FATAL");
                         break;
                     default:
-                        event.Put("loglevel", "UNKNOWN");
+                        event.Put("log_level", "UNKNOWN");
                   }
                 }
         - drop_event:
           when:
             equals:
-              loglevel: "INFO"
+              log_level: "INFO"

--- a/deployment/roles/filebeat/templates/modules/nginx.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/nginx.yml.j2
@@ -17,9 +17,9 @@
         source: vitamui
         type: cots
       processors:
-      - dissect:
-          tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer} %{log_message}'
-          target_prefix: ""
+        - dissect:
+            tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size} %{log_message}'
+            target_prefix: ""
         - drop_fields:
             fields: ["date_time"]
 

--- a/deployment/roles/filebeat/templates/modules/nginx.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/nginx.yml.j2
@@ -20,6 +20,8 @@
       - dissect:
           tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer} %{log_message}'
           target_prefix: ""
+        - drop_fields:
+            fields: ["date_time"]
 
   # Error logs
   error:

--- a/deployment/roles/filebeat/templates/modules/nginx.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/nginx.yml.j2
@@ -10,6 +10,7 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
         kind: access
         vitam_component: nginx
@@ -17,9 +18,8 @@
         type: cots
       processors:
       - dissect:
-          tokenizer: '%{client_ip} - %{sender} [%{[date_time]}] "%{[http_method]} %{[request_path]} HTTP/%{[http_version]}" %{[http_status_code]} %{[response_size]} %{message}'
-          field: "message"
-          target: ""
+          tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size|integer} %{log_message}'
+          target_prefix: ""
 
   # Error logs
   error:
@@ -29,6 +29,7 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
         kind: error
         vitam_component: nginx
@@ -43,6 +44,7 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
         kind: ingress
         vitam_component: nginx

--- a/deployment/roles/filebeat/templates/modules/system.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/system.yml.j2
@@ -9,6 +9,7 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
         kind: syslog
         source: vitamui
@@ -20,6 +21,7 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
     input:
+      fields_under_root: true
       fields:
         kind: auth
         source: vitamui

--- a/deployment/roles/logstash/templates/filebeat-to-logstash.conf.j2
+++ b/deployment/roles/logstash/templates/filebeat-to-logstash.conf.j2
@@ -19,7 +19,7 @@ output
             hosts => [{% for host in groups['hosts_elasticsearch_log'] %}"{{ hostvars[host]['ip_admin'] }}:{{ elasticsearch.log.port_http }}"{% if not loop.last %},{% endif %}{% endfor %}]
         }
     }
-    else if [fields][kind] =~ "access" or [fields][kind] =~ "management"
+    else if [kind] =~ "access" or [kind] =~ "management"
     {
         elasticsearch
         {


### PR DESCRIPTION
## Description

* Set custom fields at root level.
  * Using target_prefix for dissect section: https://www.elastic.co/guide/en/beats/filebeat/current/dissect.html
  * Using fields_under_root for custom fields: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#fields-under-root-filestream
* Fix multi-line parser for consul logs: https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html
* Rename fields to fit the former naming convention.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)