### PR TITLE
Story #12113: activate spotless plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,9 @@
         <opencsv.version>5.4</opencsv.version>
         <spring.data.mongo.version>3.3.5</spring.data.mongo.version>
         <podam.version>7.2.5.RELEASE</podam.version>
+        <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.prettier.version>3.2.4</spotless-maven-plugin.prettier.version>
+        <spotless-maven-plugin.prettier-plugin-java.version>2.6.0</spotless-maven-plugin.prettier-plugin-java.version>
 
         <!-- Profile properties -->
         <angular.additional.test.informations></angular.additional.test.informations>
@@ -218,14 +221,12 @@
         <!-- Swagger doc generation -->
         <swagger.dir>.</swagger.dir>
         <swagger.skip>true</swagger.skip>
-        <!--we
-        can choose to build angular project and embedded it in our jar or not-->
+        <!--we can choose to build angular project and embedded it in our jar or not-->
         <skipAllFrontend>true</skipAllFrontend>
-        <!--we
-        can choose to execute Karma tests or not-->
+        <!--we can choose to execute Karma tests or not-->
         <skipAllFrontendTests>true</skipAllFrontendTests>
-
         <itCoverageAgent></itCoverageAgent>
+        <spotless.check.skip>true</spotless.check.skip> <!-- Remove after global reformat is done -->
     </properties>
 
     <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
@@ -1621,6 +1622,42 @@
                         <configuration>
                             <property>main.basedir</property>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
+                <configuration>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                        </includes>
+                        <prettier>
+                            <devDependencies>
+                                <prettier>${spotless-maven-plugin.prettier.version}</prettier>
+                                <prettier-plugin-java>${spotless-maven-plugin.prettier-plugin-java.version}</prettier-plugin-java>
+                            </devDependencies>
+                            <config>
+                                <printWidth>120</printWidth>
+                                <tabWidth>4</tabWidth>
+                                <parser>java</parser>
+                                <plugins>prettier-plugin-java</plugins>
+                            </config>
+                        </prettier>
+                        <importOrder>
+                            <order>,javax|java,\#</order>
+                        </importOrder>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Utilisation de Spotless (https://github.com/diffplug/spotless) pour le formatage du code, en respectant le code style Vitam le plus possible.

Pour l'instant le plugin n'est pas activé pour la phase "verify". Cela sera fait dans une deuxième story (#12584).

Intégration IntelliJ :
- L'installation du plugin IntelliJ "Spotless Applier" est recommandée.
- télécharger le code style IntelliJ depuis https://assistance.programmevitam.fr/plugins/docman/download/152/1 et l'activer pour le projet
