### PR TITLE
Story #12116 & #12302: Add GiHub Actions + SonarCloud

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,149 @@
+name: Build and test
+run-name: Building and testing branch ${{ github.ref }}
+on:
+  pull_request: # run on every pull request
+  push:
+    branches: # run only on protected branches (develop & master_*)
+      - develop
+      - master_*
+jobs:
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14.15.1'
+          cache: 'npm'
+          cache-dependency-path: |
+            ui/ui-frontend-common/package-lock.json
+            ui/ui-frontend/package-lock.json
+      - name: Install correct version of NPM (the one shipped with node is not the expected one)
+        run: npm install -g npm@7.17.0
+      - name: Install ui-frontend-common dependencies
+        working-directory: ui/ui-frontend-common
+        run: npm install
+      - name: Build ui-frontend-common
+        working-directory: ui/ui-frontend-common
+        run: npm run build:prod
+      - name: Package ui-frontend-common
+        working-directory: ui/ui-frontend-common
+        run: npm run packagr:tar
+      - name: Run tests on ui-frontend-common
+        working-directory: ui/ui-frontend-common
+        run: npm run test:conf-ci
+      - name: Install ui-frontend dependencies
+        working-directory: ui/ui-frontend
+        run: npm install ui-frontend-common --legacy-peer-deps --loglevel warn
+      - name: Build vitamui-library
+        working-directory: ui/ui-frontend
+        run: npm run build:vitamui-library
+      - name: Copy vitamui-library SCSS
+        working-directory: ui/ui-frontend
+        run: npm run copy-scss:vitamui-library
+      - name: Build ui-frontend apps
+        working-directory: ui/ui-frontend
+        run: npm run build:allModules
+      - name: Run tests on ui-frontend apps
+        working-directory: ui/ui-frontend
+        run: npm run ci:test
+      - name: Package ui-frontend apps
+        working-directory: ui/ui-frontend
+        run: npm run package:all
+      - name: Save JUnit report as artifact
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: |
+            **/target/junit/*.xml
+          check_name: Frontend Test Report
+      - name: Save test & coverage reports as artifact
+        if: success() || failure() # always run even if the previous step fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-reports
+          path: |
+            **/target/junit/*.xml
+            **/target/coverage/*
+  build-backend:
+    name: Build Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "Europe/Paris" # we set the timezone for Unit Tests to pass (we shouldn't need to, but it's currently required)
+      - name: Build and test
+        run: mvn --settings .ci/settings.xml
+              -Pvitam,no-cve-proxy
+              -Dspotless.check.skip=true
+              --batch-mode --errors -U
+              --projects '!cots/vitamui-mongo-express'
+              --projects '!ui'
+              --projects '!ui/ui-frontend'
+              --projects '!ui/ui-frontend-common'
+              verify
+        env:
+          SERVICE_NEXUS_URL: ${{ secrets.SERVICE_NEXUS_URL }}
+          CI_USR: ${{ secrets.CI_USR }}
+          CI_PSW: ${{ secrets.CI_PSW }}
+      - name: Save JUnit report as artifact
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: |
+            **/target/surefire-reports/*.xml
+          check_name: Backend Test Report
+      - name: Save test & coverage reports as artifact
+        if: success() || failure() # always run even if the previous step fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-reports
+          path: |
+            **/target/surefire-reports/*.xml
+            **/target/site/jacoco/jacoco.xml
+      - name: Save generated classes as (temporary) artifact for SonarCloud analysis
+        if: ${{ github.event_name == 'push' && github.ref_protected }} # only save generated classes when executing SonarCloud analysis
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-generated-classes
+          path: |
+            **/target/classes/**/*
+            **/target/test-classes/**/*
+  sonarcloud:
+    name: Run SonarCloud analysis
+    needs: [build-frontend, build-backend]
+    if: ${{ github.event_name == 'push' && github.ref_protected }} # only run SonarCloud analysis on protected branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download frontend test reports
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-test-reports
+      - name: Download backend test reports
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-test-reports
+      - name: Download backend target directories
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-generated-classes
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Delete temporary artifact
+        uses: geekyeggo/delete-artifact@v5
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          name: backend-generated-classes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+run-name: Linting branch ${{ github.ref }}
+on: [push]
+jobs:
+  lint-frontend:
+    name: Lint Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14.15.1'
+      - name: Check missing icon in icomoon
+        run: ./tools/check_icomoon.sh
+      # Only install prettier globally (with same version as in package.json)
+      - name: Install Prettier
+        working-directory: ui/ui-frontend
+        run: npm i -g prettier@$(jq -r '.devDependencies.prettier' package.json)
+      - name: Lint ui-frontend-common
+        working-directory: ui/ui-frontend-common
+        run: npm run prettier:ci
+      - name: Lint ui-frontend
+        working-directory: ui/ui-frontend
+        run: npm run prettier:ci
+  lint-backend:
+    name: Lint Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Lint Java
+        run: mvn -T1C spotless:check

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,9 @@
         <!--we can choose to execute Karma tests or not-->
         <skipAllFrontendTests>true</skipAllFrontendTests>
         <itCoverageAgent></itCoverageAgent>
+
+        <cveUrlBase>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.1-%d.json.gz</cveUrlBase>
+        <cveUrlModified>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.1-modified.json.gz</cveUrlModified>
     </properties>
 
     <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
@@ -1515,8 +1518,6 @@
                 <version>${maven.dependencycheck.version}</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <cveUrlModified>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                    <cveUrlBase>${env.SERVICE_REPOSITORY_URL}/nist/nvdcve-1.1-%d.json.gz</cveUrlBase>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                     <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                     <failOnError>false</failOnError>
@@ -1658,6 +1659,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -1986,6 +1991,13 @@
     </reporting>
 
     <profiles>
+        <profile>
+            <id>no-cve-proxy</id>
+            <properties>
+                <cveUrlBase>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</cveUrlBase>
+                <cveUrlModified>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</cveUrlModified>
+            </properties>
+        </profile>
 
         <!-- This profile is used to build frontend project for dev purposes. -->
         <profile>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.organization=programme-vitam2
+sonar.projectKey=programme-vitam2_vitam-ui
+
+# relative paths to source directories. More details and properties are described
+# in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
+sonar.sources=.
+sonar.java.binaries=.
+
+sonar.exclusions=**/node_modules/**, **/target/**
+sonar.javascript.lcov.reportPaths=**/target/coverage/lcov.info
+sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml


### PR DESCRIPTION
## Description

* workflow (rapide) de linting back et front sur chaque push
* workflow de build/test back et front sur chaque PR et sur chaque branche protégée (develop/master_*)
* analyse SonarCloud (uniquement sur les branches protégées)
* modification de la configuration de l'URL de téléchargement de la base de données NVD pour le plugin OWASP. L'activation du profil `no-cve-proxy` permet d'utiliser le site public officiel comme source de données au lieu de la version en cache qui est utilisée par défaut sur l'infra Vitam

RAF :

* désactiver la nécessité d'avoir un build Jenkins OK
* activer la nécessité d'avoir les 4 jobs (lint front, lint back, build front et build back) GitHub actions OK

## Type de changement:

* Build

## Contributeur

VAS (Vitam Accessible en Service)