### PR TITLE
Bug 12641 reopen no message when duration not valid

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-create/rule-create.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-create/rule-create.component.html
@@ -91,6 +91,9 @@
           <vitamui-common-input-error *ngIf="!!form.get('ruleDuration')?.errors?.required">
             {{ 'COMMON.REQUIRED' | translate }}
           </vitamui-common-input-error>
+          <vitamui-common-input-error *ngIf="!!form.get('ruleDuration')?.errors?.pattern">
+            {{ 'RULES_APP.TAB.ERROR.INTEGER_REQUIRED' | translate }}
+          </vitamui-common-input-error>
         </ng-container>
       </vitamui-common-input>
 


### PR DESCRIPTION
## Description

No error message when the duration is not valid in management rules

## Type de changement:

* Correction

## Contributeur

VAS (Vitam Accessible en Service)
