### PR TITLE
Story #12116: Improve GitHub Actions cache management

### DIFF
--- a/.ci/github-actions-settings.xml
+++ b/.ci/github-actions-settings.xml
@@ -1,0 +1,22 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>vitam</id>
+            <username>${env.CI_USR}</username>
+            <password>${env.CI_PSW}</password>
+        </server>
+        <server>
+            <id>vitam-snapshots</id>
+            <username>${env.CI_USR}</username>
+            <password>${env.CI_PSW}</password>
+        </server>
+        <server>
+            <id>vitam-releases</id>
+            <username>${env.CI_USR}</username>
+            <password>${env.CI_PSW}</password>
+        </server>
+    </servers>
+</settings>

--- a/.ci/settings.xml
+++ b/.ci/settings.xml
@@ -19,12 +19,12 @@
 			<password>${env.CI_PSW}</password>
 		</server>
 		<server>
-			<id>snapshots</id>
+			<id>vitam-snapshots</id>
 			<username>${env.CI_USR}</username>
 			<password>${env.CI_PSW}</password>
 		</server>
 		<server>
-			<id>releases</id>
+			<id>vitam-releases</id>
 			<username>${env.CI_USR}</username>
 			<password>${env.CI_PSW}</password>
 		</server>

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,18 +52,37 @@ jobs:
     name: Build Backend
     runs-on: ubuntu-latest
     steps:
+      - uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "Europe/Paris" # we set the timezone for Unit Tests to pass (we shouldn't need to, but it's currently required)
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "11"
-          cache: "maven"
-      - uses: szenius/set-timezone@v2.0
+      - name: Restore maven cache # We're not using cache feature from actions/setup-java as it's not allowing to fine-tune it (in particular, we can't use restore-keys to load a previous cache if cache name mismatches)
+        uses: actions/cache@v4
         with:
-          timezoneLinux: "Europe/Paris" # we set the timezone for Unit Tests to pass (we shouldn't need to, but it's currently required)
+          # See https://github.com/actions/toolkit/issues/713 for why we use */*/* to be able to exclude dependency-check-data from the cache
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/owasp/dependency-check-data
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-${{ github.ref_protected && hashFiles('**/pom.xml') || '' }} # If the key doesn't exist, tries to find a previous cache to speedup build, except for protected branches (to make sure we have a clean cache)
+      - name: Get today's date
+        id: get-date
+        run: |
+          echo "today=$(/bin/date -u "+%Y-%m-%d")" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Restore latest owasp-dependency-check cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: owasp-dependency-check-${{ steps.get-date.outputs.today }} # The key changes every day
+          restore-keys: owasp-dependency-check- # If the key doesn't exist, tries to find a previous cache
       - name: Build and test
         run: >
-          mvn --settings .ci/settings.xml
+          mvn --settings .ci/github-actions-settings.xml
           -Pvitam,no-cve-proxy
           -Dspotless.check.skip=true
           --batch-mode --errors -U

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-          cache: "maven"
+      - name: Restore maven cache # We're not using cache feature from actions/setup-java as it could conflict with other GitHub Actions maven caches (our cache doesn't include all Vitam dependencies: it is limited to spotless and its dependencies)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            **/target/spotless-prettier-node-modules-*
+          key: maven-spotless-${{ runner.os }}-${{ hashFiles('**/pom.xml') }} # We invalidate cache if pom.xml change to detect spotless version update or new maven modules
       - name: Lint Java
         run: mvn -T1C spotless:check

--- a/api/api-pastis/pastis-standalone/pom.xml
+++ b/api/api-pastis/pastis-standalone/pom.xml
@@ -380,11 +380,11 @@
 
             <distributionManagement>
                 <repository>
-                    <id>releases</id>
+                    <id>vitam-releases</id>
                     <url>${env.SERVICE_NEXUS_URL}/repository/maven-releases/</url>
                 </repository>
                 <snapshotRepository>
-                    <id>snapshots</id>
+                    <id>vitam-snapshots</id>
                     <url>${env.SERVICE_NEXUS_URL}/repository/maven-snapshots/</url>
                 </snapshotRepository>
                 <site>
@@ -395,25 +395,20 @@
 
             <repositories>
                 <repository>
-                    <id>vitam</id>
-                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-public/</url>
+                    <id>vitam-releases</id>
+                    <name>Vitam release repository</name>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-releases/</url>
+                </repository>
+                <repository>
+                    <id>vitam-snapshots</id>
+                    <name>Vitam SNAPSHOT repository</name>
+                    <releases><enabled>false</enabled></releases>
+                    <snapshots><enabled>true</enabled></snapshots>
+                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-snapshots/</url>
                 </repository>
             </repositories>
-
-            <!-- Maven plugins repositories -->
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>vitam</id>
-                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-public/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-
         </profile>
     </profiles>
 </project>

--- a/api/api-referential/referential-commons/src/main/java/fr/gouv/vitamui/referential/common/service/IngestContractService.java
+++ b/api/api-referential/referential-commons/src/main/java/fr/gouv/vitamui/referential/common/service/IngestContractService.java
@@ -138,11 +138,11 @@ public class IngestContractService {
             ac.setComputeInheritedRulesAtIngest(acModel.isComputeInheritedRulesAtIngest());
 
             if (acModel.getActivationdate() != null) {
-                ac.setActivationdate(LocalDateUtil.getFormattedDateForMongo(acModel.getActivationdate()));
+                ac.setActivationdate(LocalDateUtil.getFormattedDateTimeForMongo(acModel.getActivationdate()));
             }
 
             if (acModel.getDeactivationdate() != null) {
-                ac.setDeactivationdate(LocalDateUtil.getFormattedDateForMongo(acModel.getDeactivationdate()));
+                ac.setDeactivationdate(LocalDateUtil.getFormattedDateTimeForMongo(acModel.getDeactivationdate()));
             }
 
             LOGGER.debug("outputIC: {}", ac);

--- a/api/api-referential/referential-external/src/main/java/fr/gouv/vitamui/referential/external/server/rest/OperationExternalController.java
+++ b/api/api-referential/referential-external/src/main/java/fr/gouv/vitamui/referential/external/server/rest/OperationExternalController.java
@@ -77,6 +77,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -166,8 +167,8 @@ public class OperationExternalController {
             X500Name signerCertIssuer = signerId.getIssuer();
             result.put(
                 "genTime",
-                LocalDateUtil.getString(
-                    LocalDateUtil.fromDate(tsResp.getTimeStampToken().getTimeStampInfo().getGenTime())
+                LocalDateUtil.fromDate(tsResp.getTimeStampToken().getTimeStampInfo().getGenTime()).format(
+                    DateTimeFormatter.ISO_DATE_TIME
                 )
             );
             result.put("signerCertIssuer", signerCertIssuer.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -2474,11 +2474,13 @@
             <!-- Dépôts Maven privés -->
             <distributionManagement>
                 <repository>
-                    <id>releases</id>
+                    <id>vitam-releases</id>
+                    <name>Vitam release repository</name>
                     <url>${env.SERVICE_NEXUS_URL}/repository/maven-releases/</url>
                 </repository>
                 <snapshotRepository>
-                    <id>snapshots</id>
+                    <id>vitam-snapshots</id>
+                    <name>Vitam SNAPSHOT repository</name>
                     <url>${env.SERVICE_NEXUS_URL}/repository/maven-snapshots/</url>
                 </snapshotRepository>
                 <site>
@@ -2487,33 +2489,27 @@
                 </site>
             </distributionManagement>
 
-
             <repositories>
                 <repository>
-                    <id>vitam</id>
-                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-public/</url>
+                    <id>vitam-releases</id>
+                    <name>Vitam release repository</name>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-releases/</url>
+                </repository>
+                <repository>
+                    <id>vitam-snapshots</id>
+                    <name>Vitam SNAPSHOT repository</name>
+                    <releases><enabled>false</enabled></releases>
+                    <snapshots><enabled>true</enabled></snapshots>
+                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-snapshots/</url>
                 </repository>
             </repositories>
-
-            <!-- Maven plugins repositories -->
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>vitam</id>
-                    <url>${env.SERVICE_NEXUS_URL}/repository/maven-public/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
 
             <properties>
                 <serverId>vitam</serverId>
                 <downloadRoot>${env.SERVICE_NEXUS_URL}/repository/node-distrib/</downloadRoot>
             </properties>
-
         </profile>
 
         <profile>
@@ -2522,19 +2518,13 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <!-- Dépôts Maven privés -->
-            <distributionManagement>
-                <repository>
-                    <id>releases</id>
-                    <url>http://download.programmevitam.fr/vitam_repository/${vitam.version}/mvn_repo/</url>
-                </repository>
-            </distributionManagement>
-
-
+            <!-- Dépôts publics de releases -->
             <repositories>
                 <repository>
-                    <id>vitam</id>
+                    <id>public-vitam-releases</id>
                     <url>http://download.programmevitam.fr/vitam_repository/${vitam.version}/mvn_repo/</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
                 </repository>
             </repositories>
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=programme-vitam2_vitam-ui
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=.
 sonar.java.binaries=.
+sonar.java.libraries=~/.m2/repository/**/*.jar
 
 sonar.exclusions=**/node_modules/**, **/target/**
 sonar.javascript.lcov.reportPaths=**/target/coverage/lcov.info


### PR DESCRIPTION
## Description

* Séparation des caches maven de l'action de Lint et de l'action de build/test (sinon, le cache du Lint ne comprenant que les dépendances Spotless était utilisé pour le build...)
* Utilisation de `actions/cache` au lieu de `actions/setup-java` pour la gestion du cache maven, ce qui permet :
  * de ne pas inclure les données owasp dependency-check dans le cache (on utilise un cache séparé)
  * d'utiliser un cache qui ne correspond pas exactement (hash différent parce que pom.xml modifié) pour accélérer le build (uniquement sur les branches non protégées)
* Cache séparé pour les données owasp dependency-check :
  * nouveau cache quotidien
  * repart du dernier cache si pas de cache du jour J
* Mise en cache des spotless-prettier-node-modules-* pour le Lint java
* Modification de la configuration des repository maven pour que le repository central soit utilisé par défaut (et celui de Vitam uniquement pour les dépendances Vitam)

## Type de changement

* Build

## Contributeur

* VAS (Vitam Accessible en Service)