### PR TITLE
bug #12792 : dashes on complementary fields

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/archive-unit-edit-object.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/archive-unit-edit-object.service.ts
@@ -147,11 +147,22 @@ export class ArchiveUnitEditObjectService {
   }
 
   public displayOtherMetadata(displayObject: DisplayObject, path = 'OtherMetadata') {
-    if (displayObject.path === path) {
-      displayObject.displayRule = { ...displayObject.displayRule, ui: { ...displayObject.displayRule.ui, display: true } };
+    if (!displayObject.path.includes(path)) return;
+
+    if (!displayObject.displayRule) {
+      return this.logger.warn(this, `Element '${displayObject.path}' has no displayRule`);
     }
 
-    displayObject.children.forEach((child) => this.displayOtherMetadata(child));
+    const isConsistent = this.typeService.isConsistent(displayObject.value);
+
+    displayObject.displayRule = {
+      ...displayObject.displayRule,
+      ui: { ...displayObject.displayRule.ui, display: isConsistent },
+    };
+
+    if (isConsistent) {
+      displayObject.children.forEach((child) => this.displayOtherMetadata(child));
+    }
   }
 
   public hideInconsistentDisplayObjects(displayObject: DisplayObject): void {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-viewer/services/type.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-viewer/services/type.service.ts
@@ -82,15 +82,9 @@ export class TypeService {
   }
 
   public isConsistent(value: any): boolean {
-    if (this.isPrimitive(value)) {
-      return Boolean(value) && value !== '';
-    }
-    if (this.isList(value)) {
-      return value.some((item: any) => this.isConsistent(item));
-    }
-    if (!value) {
-      return false;
-    }
+    if (value === null || value === undefined) return false;
+    if (this.isPrimitive(value)) return value !== '';
+    if (this.isList(value)) return value.some((item: any) => this.isConsistent(item));
 
     return Object.values(value).some((v: any) => this.isConsistent(v));
   }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/empty.pipe.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/empty.pipe.ts
@@ -5,6 +5,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class EmptyPipe implements PipeTransform {
   transform(value: any): any {
-    return value ? value : '— —';
+    return value ?? '— —';
   }
 }


### PR DESCRIPTION
## Description

Dans l'onglet "Autres métadonnées", des traits s'affichent dans les champs complémentaires

## Type de changement

* Correction

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

* VAS (Vitam Accessible en Service)
