### PR TITLE
Story #11854 Clean code: Fix Sonar build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,6 +126,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Restore maven cache # We need maven cache for Sonar to have access to java libraries code
+        uses: actions/cache/restore@v4
+        with:
+          fail-on-cache-miss: true
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/owasp/dependency-check-data
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
       - name: Download frontend test reports
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Description

Sonar a besoin des jar des dépendances, or le repository m2 était vide car l'action `sonarcloud` s'exécute dans une nouvelle machine. On récupère donc le cache maven généré par l'action `build-backend` en début d'action `sonarcloud`

## Type de changement

* Build

## Contributeur

* VAS (Vitam Accessible en Service)
