### PR TITLE
Story #11854 Clean code: Fix Sonar build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -134,6 +134,8 @@ jobs:
             ~/.m2/repository/*/*/*
             !~/.m2/repository/org/owasp/dependency-check-data
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+      - name: Copy m2 repository in workspace "lib" directory to make it available from SonarCloud docker container # If not copied in the source code folder, it's not visible by the docker container
+        run: cp -r ~/.m2/repository ${{ github.workspace }}/lib
       - name: Download frontend test reports
         uses: actions/download-artifact@v4
         with:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,9 @@ sonar.projectKey=programme-vitam2_vitam-ui
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=.
 sonar.java.binaries=.
-sonar.java.libraries=~/.m2/repository/**/*.jar
+# "**.jar" because of https://sonarsource.atlassian.net/browse/SONARJAVA-1965
+# "lib" directory is created and populated with m2 repository content by the GitHub Action
+sonar.java.libraries=lib/**.jar
 
 sonar.exclusions=**/node_modules/**, **/target/**
 sonar.javascript.lcov.reportPaths=**/target/coverage/lcov.info


### PR DESCRIPTION
## Description

Finalement, le m2 repository ne semble pas être visible depuis l'action Sonar qui utilise un conteneur docker. J'ai donc copié le m2 repository dans un dossier "lib" du workspace pour qu'il soit visible depuis le conteneur docker.

## Type de changement

* Build

## Contributeur

* VAS (Vitam Accessible en Service)
