### PR TITLE
story #12867 : ontology form fixes

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" class="side-form" (ngSubmit)="onSubmit()">
   <div class="d-flex mt-3">
-    <vitamui-common-input formControlName="identifier" [placeholder]="'ONTOLOGY.TAB.INFORMATION.IDENTIFIER' | translate" disabled>
+    <vitamui-common-input formControlName="identifier" [placeholder]="'ONTOLOGY.TAB.INFORMATION.IDENTIFIER' | translate">
     </vitamui-common-input>
   </div>
 
@@ -25,7 +25,7 @@
     </mat-form-field>
   </div>
 
-  <div *ngIf="sizeFieldVisible" class="d-flex mt-4">
+  <div [hidden]="!sizeFieldVisible" class="d-flex mt-4">
     <mat-form-field class="vitamui-mat-select w-100">
       <mat-select
         formControlName="stringSize"

--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.scss
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.scss
@@ -7,3 +7,7 @@
     margin-top: auto;
   }
 }
+
+[hidden] {
+  display: none !important;
+}

--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.ts
@@ -91,13 +91,13 @@ export class OntologyInformationTabComponent implements OnInit {
     private ontologyService: OntologyService,
   ) {
     this.form = this.formBuilder.group({
-      identifier: [null, Validators.required],
-      shortName: [{ value: null, disabled: true }, Validators.required],
-      type: [null, Validators.required],
-      typeDetail: [null],
-      stringSize: [null],
-      collections: [null, Validators.required],
-      description: [null],
+      identifier: [{ disabled: true }, Validators.required],
+      shortName: [{ disabled: true }, Validators.required],
+      type: [{ value: null, disabled: true }, Validators.required],
+      typeDetail: [{ value: null, disabled: true }],
+      stringSize: [{ value: null, disabled: true }],
+      collections: [{ value: null, disabled: true }, Validators.required],
+      description: [{ value: null, disabled: true }],
       creationDate: [{ value: null, disabled: true }],
     });
   }
@@ -106,6 +106,7 @@ export class OntologyInformationTabComponent implements OnInit {
     if (this._inputOntology.origin === 'EXTERNAL') {
       this.form.enable({ emitEvent: false });
     }
+    this.form.controls.identifier.disable({ emitEvent: true });
   }
 
   unchanged(): boolean {


### PR DESCRIPTION
## Description

Correction de formulaire de l'ontology : lors de la consultation, le champ stringSize ne doit s'afficher que lorsque le type Texte est sélectionné

## Type de changement

## Contributeur

*Indiquer qui a développé cette fonctionnalité*

* VAS (Vitam Accessible en Service)
