### PR TITLE
Bug#13084: remove vitam common-private library references and use com…

### DIFF
--- a/api/api-iam/iam-internal/pom.xml
+++ b/api/api-iam/iam-internal/pom.xml
@@ -196,11 +196,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>fr.gouv.vitam</groupId>
-            <artifactId>common-private</artifactId>
-        </dependency>
-
 
         <!-- Apereo CAS Server Core Api Ticket -->
         <dependency>

--- a/commons/commons-logbook/pom.xml
+++ b/commons/commons-logbook/pom.xml
@@ -72,10 +72,7 @@
             	</exclusion>
             </exclusions>
         </dependency>
-		<dependency>
-			<groupId>fr.gouv.vitam</groupId>
-			<artifactId>common-private</artifactId>
-		</dependency>
+
         <dependency>
             <groupId>fr.gouv.vitam</groupId>
             <artifactId>common-public</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -928,29 +928,7 @@
                 <artifactId>common-database-public</artifactId>
                 <version>${vitam.version}</version>
             </dependency>
-            <dependency>
-                <groupId>fr.gouv.vitam</groupId>
-                <artifactId>common-private</artifactId>
-                <version>${vitam.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient_common</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient_dropwizard</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient_hotspot</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
+
             <dependency>
                 <groupId>fr.gouv.vitam</groupId>
                 <artifactId>logbook-common</artifactId>


### PR DESCRIPTION
## Description


L'object de cette PR est de supprimer les références vers le composant common-private de Vitamui et utiliser le composant common-public.


## Contributeur


* VAS (Vitam Accessible en Service)
