### PR TITLE
CP V7.1 - Bug #13113: Force ip_service to be set to ip_admin as mongo-express is binded on ip_admin.

### DIFF
--- a/deployment/ansible-vitamui-exploitation/start_vitamui.yml
+++ b/deployment/ansible-vitamui-exploitation/start_vitamui.yml
@@ -61,6 +61,7 @@
     vitamui_struct:
       vitamui_component: "{{ mongo_express.vitamui_component }}"
       port_service: "{{ mongo_express.port }}"
+    ip_service: "{{ ip_admin }}"
     etat: started
   tags:
     - cots

--- a/deployment/ansible-vitamui-exploitation/stop_vitamui.yml
+++ b/deployment/ansible-vitamui-exploitation/stop_vitamui.yml
@@ -286,6 +286,7 @@
     vitamui_struct:
       vitamui_component: "{{ mongo_express.vitamui_component }}"
       port_service: "{{ mongo_express.port }}"
+    ip_service: "{{ ip_admin }}"
     etat: stopped
   tags:
     - cots


### PR DESCRIPTION
## Description

Lors d'un déploiement avec 2 interfaces réseaux (service & admin), les scripts de start/stop vitamui n'arrivent pas à récupérer le statut du port de mongo-express.

En effet, mongo-express est bindé sur l'ip_admin, hors on tente de récupérer le statut du port sur l'ip_service.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)