### PR TITLE
CP 7.0 - Bug#13084: remove vitam common-private library references and use common-public

### DIFF
--- a/api/api-iam/iam-internal/pom.xml
+++ b/api/api-iam/iam-internal/pom.xml
@@ -191,11 +191,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>fr.gouv.vitam</groupId>
-            <artifactId>common-private</artifactId>
-        </dependency>
-
 
         <!-- Apereo CAS Server Core Api Ticket -->
         <dependency>

--- a/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/user/service/UserInfoInternalService.java
+++ b/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/user/service/UserInfoInternalService.java
@@ -61,7 +61,6 @@ import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.shiro.util.Assert;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.transaction.Transactional;
@@ -193,13 +192,5 @@ public class UserInfoInternalService extends VitamUICrudService<UserInfoDto, Use
         super.checkIdentifier(dto.getIdentifier(), message);
 
         dto.setIdentifier(getNextSequenceId(SequencesConstants.USER_INFOS_IDENTIFIER));
-    }
-
-    private UserInfo find(final String id, final String message) {
-        Assert.isTrue(StringUtils.isNotEmpty(id), message + ": no id");
-
-        return getRepository()
-            .findById(id)
-            .orElseThrow(() -> new IllegalArgumentException(message + ": no user info found for id " + id));
     }
 }

--- a/commons/commons-logbook/pom.xml
+++ b/commons/commons-logbook/pom.xml
@@ -72,10 +72,7 @@
             	</exclusion>
             </exclusions>
         </dependency>
-		<dependency>
-			<groupId>fr.gouv.vitam</groupId>
-			<artifactId>common-private</artifactId>
-		</dependency>
+
         <dependency>
             <groupId>fr.gouv.vitam</groupId>
             <artifactId>common-public</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -868,29 +868,7 @@
                 <artifactId>common-database-public</artifactId>
                 <version>${vitam.version}</version>
             </dependency>
-            <dependency>
-                <groupId>fr.gouv.vitam</groupId>
-                <artifactId>common-private</artifactId>
-                <version>${vitam.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient_common</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient_dropwizard</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient_hotspot</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.prometheus</groupId>
-                        <artifactId>simpleclient</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
+
             <dependency>
                 <groupId>fr.gouv.vitam</groupId>
                 <artifactId>logbook-common</artifactId>


### PR DESCRIPTION
## Description


L'object de cette PR est de supprimer les références vers le composant common-private de Vitamui et utiliser le composant common-public.


## Contributeur


* VAS (Vitam Accessible en Service)
