### PR TITLE
Story #12963 (collect): filter access to projects by originating agency

### DIFF
--- a/api/api-collect/collect-external/src/main/java/fr/gouv/vitamui/collect/external/server/rest/ProjectExternalController.java
+++ b/api/api-collect/collect-external/src/main/java/fr/gouv/vitamui/collect/external/server/rest/ProjectExternalController.java
@@ -96,17 +96,14 @@ public class ProjectExternalController {
         @RequestParam(required = false) final Optional<String> orderBy,
         @RequestParam(required = false) final Optional<DirectionDto> direction
     ) throws PreconditionFailedException {
-        direction.ifPresent(directionDto -> {
-            SanityChecker.sanitizeCriteria(directionDto);
-        });
-        if (orderBy.isPresent()) {
-            SanityChecker.checkSecureParameter(orderBy.get());
-        }
+        direction.ifPresent(SanityChecker::sanitizeCriteria);
+        orderBy.ifPresent(SanityChecker::checkSecureParameter);
         SanityChecker.sanitizeCriteria(criteria);
         LOGGER.debug(
             "getPaginateEntities page={}, size={}, criteria={}, orderBy={}, ascendant={}",
             page,
             size,
+            criteria,
             orderBy,
             direction
         );
@@ -127,14 +124,13 @@ public class ProjectExternalController {
         SanityChecker.checkSecureParameter(projectId);
         SanityChecker.sanitizeCriteria(direction);
         SanityChecker.sanitizeCriteria(criteria);
-        if (orderBy.isPresent()) {
-            SanityChecker.checkSecureParameter(orderBy.get());
-        }
+        orderBy.ifPresent(SanityChecker::checkSecureParameter);
 
         LOGGER.debug(
             "getPaginateEntities page={}, size={}, criteria={}, orderBy={}, ascendant={}",
             page,
             size,
+            criteria,
             orderBy,
             direction
         );

--- a/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/config/ApiCollectInternalServerConfig.java
+++ b/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/config/ApiCollectInternalServerConfig.java
@@ -30,6 +30,7 @@ package fr.gouv.vitamui.collect.internal.server.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.gouv.vitamui.collect.internal.server.dao.SearchCriteriaHistoryRepository;
 import fr.gouv.vitamui.collect.internal.server.security.WebSecurityConfig;
+import fr.gouv.vitamui.collect.internal.server.service.ExternalParametersService;
 import fr.gouv.vitamui.collect.internal.server.service.ProjectInternalService;
 import fr.gouv.vitamui.collect.internal.server.service.ProjectObjectGroupInternalService;
 import fr.gouv.vitamui.collect.internal.server.service.SearchCriteriaHistoryInternalService;
@@ -114,9 +115,10 @@ public class ApiCollectInternalServerConfig extends AbstractContextConfiguration
     @Bean
     public ProjectInternalService collectInternalService(
         final CollectService collectService,
-        ObjectMapper objectMapper
+        ObjectMapper objectMapper,
+        ExternalParametersService externalParametersService
     ) {
-        return new ProjectInternalService(collectService, objectMapper);
+        return new ProjectInternalService(collectService, objectMapper, externalParametersService);
     }
 
     @Bean

--- a/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/rest/ProjectInternalController.java
+++ b/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/rest/ProjectInternalController.java
@@ -84,6 +84,7 @@ public class ProjectInternalController {
         this.externalParametersService = externalParametersService;
     }
 
+    // FIXME: page, size, orderBy and direction are not used!
     @GetMapping(params = { "page", "size" })
     public PaginatedValuesDto<CollectProjectDto> getAllProjectsPaginated(
         @RequestParam final Integer page,
@@ -212,6 +213,7 @@ public class ProjectInternalController {
         );
     }
 
+    // FIXME: page, size, orderBy and direction are not used!
     @ApiOperation(value = "Get transactions by project paginated")
     @GetMapping(params = { "page", "size" }, value = PATH_ID + TRANSACTIONS)
     public PaginatedValuesDto<CollectTransactionDto> getTransactionsByProjectPaginated(

--- a/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/rest/ProjectObjectGroupInternalController.java
+++ b/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/rest/ProjectObjectGroupInternalController.java
@@ -40,7 +40,6 @@ import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.ParameterChecker;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.vitam.api.dto.ResultsDto;
-import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import io.swagger.annotations.Api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,17 +70,14 @@ public class ProjectObjectGroupInternalController {
     private final ProjectObjectGroupInternalService projectObjectGroupInternalService;
     private final ExternalParametersService externalParametersService;
 
-    private final InternalSecurityService securityService;
     private static final String IDENTIFIER_MANDATORY = "The identifier is mandatory parameter: ";
 
     public ProjectObjectGroupInternalController(
         ProjectObjectGroupInternalService projectObjectGroupInternalService,
-        final ExternalParametersService externalParametersService,
-        InternalSecurityService securityService
+        final ExternalParametersService externalParametersService
     ) {
         this.projectObjectGroupInternalService = projectObjectGroupInternalService;
         this.externalParametersService = externalParametersService;
-        this.securityService = securityService;
     }
 
     @GetMapping(
@@ -97,9 +93,7 @@ public class ProjectObjectGroupInternalController {
         SanityChecker.checkSecureParameter(id, usage);
         LOGGER.debug("Download Archive Unit Object with id {}", id);
 
-        VitamContext vitamContext = new VitamContext(securityService.getTenantIdentifier())
-            .setAccessContract(externalParametersService.retrieveAccessContractFromExternalParam())
-            .setApplicationSessionId(securityService.getApplicationId());
+        VitamContext vitamContext = externalParametersService.buildVitamContextFromExternalParam();
 
         return Mono.<Resource>fromCallable(() -> {
             Response response = projectObjectGroupInternalService.downloadObjectFromUnit(

--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestExternalParametersService.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestExternalParametersService.java
@@ -29,8 +29,8 @@ package fr.gouv.vitamui.ingest.internal.server.service;
 
 import fr.gouv.vitamui.commons.api.domain.ExternalParametersDto;
 import fr.gouv.vitamui.commons.api.domain.ParameterDto;
-import fr.gouv.vitamui.commons.rest.client.InternalHttpContext;
 import fr.gouv.vitamui.iam.internal.client.ExternalParametersInternalRestClient;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -45,13 +45,16 @@ public class IngestExternalParametersService {
 
     public static final String PARAM_ACCESS_CONTRACT_NAME = "PARAM_ACCESS_CONTRACT";
 
-    @Autowired
     private final ExternalParametersInternalRestClient externalParametersInternalRestClient;
+    private final InternalSecurityService securityService;
 
+    @Autowired
     public IngestExternalParametersService(
-        final ExternalParametersInternalRestClient externalParametersInternalRestClient
+        final ExternalParametersInternalRestClient externalParametersInternalRestClient,
+        InternalSecurityService securityService
     ) {
         this.externalParametersInternalRestClient = externalParametersInternalRestClient;
+        this.securityService = securityService;
     }
 
     /**
@@ -59,13 +62,13 @@ public class IngestExternalParametersService {
      *
      * @return Optional of access contract otherwise Optional.empty
      */
-    public Optional<String> retrieveProfilAccessContract(InternalHttpContext internalHttpContext) {
+    public Optional<String> retrieveProfilAccessContract() {
         Optional<String> accessContractOpt = Optional.empty();
-        ExternalParametersDto myExternalParameter = externalParametersInternalRestClient.getMyExternalParameters(
-            internalHttpContext
+        final ExternalParametersDto myExternalParameter = externalParametersInternalRestClient.getMyExternalParameters(
+            securityService.getHttpContext()
         );
         if (myExternalParameter != null && CollectionUtils.isNotEmpty(myExternalParameter.getParameters())) {
-            ParameterDto parameterAccessContract = myExternalParameter
+            final ParameterDto parameterAccessContract = myExternalParameter
                 .getParameters()
                 .stream()
                 .filter(parameter -> PARAM_ACCESS_CONTRACT_NAME.equals(parameter.getKey()))

--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestInternalService.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/service/IngestInternalService.java
@@ -163,15 +163,13 @@ public class IngestInternalService {
         VitamContext vitamContext,
         Optional<String> criteria
     ) {
-        Optional<String> accessContractdOpt = ingestExternalParametersService.retrieveProfilAccessContract(
-            internalSecurityService.getHttpContext()
-        );
+        Optional<String> accessContractOpt = ingestExternalParametersService.retrieveProfilAccessContract();
         Set<String> originatingAgencies = new HashSet<>();
         Boolean everyOriginatingAgency = false;
-        if (accessContractdOpt.isPresent()) {
+        if (accessContractOpt.isPresent()) {
             Optional<AccessContractDto> accessContractDtoOpt = accessContractInternalService.getOne(
                 vitamContext,
-                accessContractdOpt.get()
+                accessContractOpt.get()
             );
             if (accessContractDtoOpt.isPresent()) {
                 originatingAgencies = accessContractDtoOpt.get().getOriginatingAgencies();
@@ -184,7 +182,7 @@ public class IngestInternalService {
         try {
             LOGGER.info(" All ingests EvIdAppSession : {} ", vitamContext.getApplicationSessionId());
             if (criteria.isPresent()) {
-                TypeReference<HashMap<String, Object>> typRef = new TypeReference<HashMap<String, Object>>() {};
+                TypeReference<HashMap<String, Object>> typRef = new TypeReference<>() {};
                 vitamCriteria = objectMapper.readValue(criteria.get(), typRef);
                 if (!everyOriginatingAgency) {
                     vitamCriteria.put(

--- a/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/service/ExternalParametersService.java
+++ b/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/service/ExternalParametersService.java
@@ -70,14 +70,14 @@ public class ExternalParametersService {
      * @return access contract throws IllegalArgumentException
      */
     public String retrieveAccessContractFromExternalParam() {
-        ExternalParametersDto myExternalParameter = externalParametersInternalRestClient.getMyExternalParameters(
+        final ExternalParametersDto myExternalParameter = externalParametersInternalRestClient.getMyExternalParameters(
             securityService.getHttpContext()
         );
         if (myExternalParameter == null || CollectionUtils.isEmpty(myExternalParameter.getParameters())) {
             throw new IllegalArgumentException("No external profile defined for access contract defined");
         }
 
-        ParameterDto parameterAccessContract = myExternalParameter
+        final ParameterDto parameterAccessContract = myExternalParameter
             .getParameters()
             .stream()
             .filter(parameter -> PARAM_ACCESS_CONTRACT_NAME.equals(parameter.getKey()))


### PR DESCRIPTION
## Description

Lors de la recherche des projets, on ajoute les services producteurs (originating agency) aux critères.
Les services producteurs sont récupérés via l'access contract.
Si `EveryOriginatingAgency` est à `true`, on n'ajoute pas de critère (ce qui correspond à ne pas filtrer les résultats et donc les avoir tous en réponse).
Si `EveryOriginatingAgency` est à `false`, on fourni les `OriginatingAgencies` en critère de recherche, ce qui permet de ne remonter que les projets dont le service producteur est dans la liste. N.B. : si la liste est vide, aucun résultat ne remonte (ce qui est le comportement attendu).

## Type de changement

* Nouveau Code
* Refactorisation de code

## Tests

* manuel
* TU

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)
