### PR TITLE
Bug#13197: drop old index named idx_user_email

### DIFF
--- a/deployment/scripts/mongod/v7.1/60_update_cas_create_user_email_customerid_index.js.j2
+++ b/deployment/scripts/mongod/v7.1/60_update_cas_create_user_email_customerid_index.js.j2
@@ -2,6 +2,10 @@ print("START 60_update_cas_create_user_email_customerid_index");
 
 db = db.getSiblingDB('iam');
 
+//Drop old index base on user email Only
+db.users.dropIndex("idx_user_email");
+
+//Create a new index base on user email with userId for multi domain feature
 db.users.createIndex(
     {
         "email": 1,


### PR DESCRIPTION
## Description

L'objectif de cette PR est de supprimer un ancien index empechant la création d'utilisateur en multi-domain

 
## Contributeur

 

* VAS (Vitam Accessible en Service)
 
