### PR TITLE
CP V7.1 - Fix #13175 (pastis): fix null pointer error when reloading PUA with regex

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.html
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.html
@@ -442,7 +442,7 @@
                 <div>
                   <mat-form-field class="ml-3 vitamui-mat-select">
                     <mat-select
-                      *ngIf="availableRegex.length > 1; else valueUnique"
+                      *ngIf="availableRegex?.length > 1; else valueUnique"
                       disableRipple="true"
                       panelClass="vitamui-mat-select"
                       [(value)]="regex"


### PR DESCRIPTION
Impossible de recharger une REGEX créée dans une PUA

Cherry pick du fix présent dans https://github.com/ProgrammeVitam/vitam-ui/pull/1967