### PR TITLE
Story #13140: datepicker minor fix

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/multiple-options-datepicker/multiple-options-datepicker.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/multiple-options-datepicker/multiple-options-datepicker.component.ts
@@ -99,7 +99,7 @@ export class MultipleOptionsDatepickerComponent implements ControlValueAccessor,
   }
 
   writeValue(value: string) {
-    this.datePickerValue = new Date(value);
+    this.datePickerValue = value ? new Date(value) : new Date();
   }
 
   registerOnChange(fn: any): void {


### PR DESCRIPTION
## Description

Le datepicker ouvrait sur le 01/01/1970 lorsqu'aucune valeur n'était pré-renseignée.
Dorénavant, il ouvrira sur la date du jour.

## Type de changement

* Correction

## Tests

* manuel

## Contributeur

* VAS (Vitam Accessible en Service)