### PR TITLE
Bugs #13218: correctly handle the disabled attribute

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
@@ -302,6 +302,6 @@ export class IngestContractCreateComponent implements OnInit, OnDestroy {
   }
 
   signedDocumentPolicyIsDisabled(): boolean {
-    return this.signaturePolicy?.value?.signedDocument === SignedDocumentPolicyEnum.FORBIDDEN;
+    return this.signaturePolicy?.value?.signedDocument === SignedDocumentPolicyEnum.FORBIDDEN ? true : null;
   }
 }


### PR DESCRIPTION
Utilisé comme ceci :

```
                  <input
                    type="checkbox"
                    id="TIMESTAMP"
                    formControlName="declaredTimestamp"
                    [attr.disabled]="signedDocumentPolicyIsDisabled()"
                  />
```

Si on renvoie la valeur `false`, l'attribut reste disabled, il faut donc renvoyer `null` au lieu de `false`.