### PR TITLE
Bugs #13269: do not order audits by _id anymore, use evDateTime DESC instead

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-list/audit-list.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-list/audit-list.component.html
@@ -7,12 +7,6 @@
 
       <div class="col-3 d-flex align-items-center justify-content-between">
         <div>{{ 'AUDIT.HOME.ARRAY.IDENTIFIER' | translate }}</div>
-        <vitamui-common-order-by-button
-          orderByKey="#id"
-          [(orderBy)]="orderBy"
-          [(direction)]="direction"
-          (orderChange)="emitOrderChange()"
-        ></vitamui-common-order-by-button>
       </div>
 
       <div class="col-2 d-flex align-items-center justify-content-between">

--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-list/audit-list.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-list/audit-list.component.ts
@@ -73,8 +73,8 @@ export class AuditListComponent extends InfiniteScrollTable<any> implements OnDe
   @Output() auditClick = new EventEmitter<any>();
 
   public loaded = false;
-  public orderBy = '#id';
-  public direction = Direction.ASCENDANT;
+  public orderBy = 'evDateTime';
+  public direction = Direction.DESCENDANT;
   public filterMap: { [key: string]: any[] } = { type: null };
 
   private readonly searchChange = new Subject<string>();
@@ -87,7 +87,7 @@ export class AuditListComponent extends InfiniteScrollTable<any> implements OnDe
 
   ngOnInit() {
     this.auditService
-      .search(new PageRequest(0, DEFAULT_PAGE_SIZE, this.orderBy, Direction.ASCENDANT, JSON.stringify(this.buildCriteriaFromSearch())))
+      .search(new PageRequest(0, DEFAULT_PAGE_SIZE, this.orderBy, this.direction, JSON.stringify(this.buildCriteriaFromSearch())))
       .subscribe((data: any[]) => (this.dataSource = data));
 
     const searchCriteriaChange = merge(this.searchChange, this.filterChange, this.orderChange).pipe(debounceTime(FILTER_DEBOUNCE_TIME_MS));


### PR DESCRIPTION
Bug lié à la mise à jour d'ES en version 8. Sur les versions précédentes, on pouvait trier sur le champ _id. Sur la version 8 ce n'est plus activé par défault : Fielddata access on the _id field is disallowed, you can re-enable it by updating the dynamic cluster setting: indices.id_field_data.enabled

À la place, on trie sur la date de l'audit, ce qui fonctionnellement a plus de sens.