### PR TITLE
Bugs #13345: do not order by _id anymore

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/audit/audit.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit.service.ts
@@ -150,7 +150,7 @@ export class AuditService extends SearchService<Event> {
     criteria.evType = ['EVIDENCE_AUDIT'];
     criteria['#id'] = evidenceAuditId;
 
-    const pageRequest = new PageRequest(0, DEFAULT_PAGE_SIZE, '#id', Direction.ASCENDANT, JSON.stringify(criteria));
+    const pageRequest = new PageRequest(0, DEFAULT_PAGE_SIZE, 'evDateTime', Direction.DESCENDANT, JSON.stringify(criteria));
 
     return this.search(pageRequest).pipe(map((res) => res.length === 0));
   }


### PR DESCRIPTION
## Description

Même type de correction que pour le bug 13269 : on ne peut pas ordonner sur le champ _id depuis la mise à jour à ElasticSearch 8.

