### PR TITLE
Bug #13377: Remove system module for filebeat if all filesets are disabled.

### DIFF
--- a/deployment/roles/filebeat/tasks/add_modules.yml
+++ b/deployment/roles/filebeat/tasks/add_modules.yml
@@ -31,4 +31,16 @@
     src: modules/system.yml.j2
     dest: /etc/filebeat/modules.d/system.yml
     mode: 0644
+  when:
+    - filebeat.system.enable_log | bool or
+      filebeat.system.enable_auth | bool
+  notify: "filebeat - restart service"
+
+- name: Disable system filebeat module
+  file:
+    path: /etc/filebeat/modules.d/system.yml
+    state: absent
+  when:
+    - filebeat.system.enable_log | bool == false
+    - filebeat.system.enable_auth | bool == false
   notify: "filebeat - restart service"

--- a/deployment/roles/filebeat/templates/modules/system.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/system.yml.j2
@@ -1,5 +1,5 @@
 # Module: system
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/7.17/filebeat-module-system.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/8.14/filebeat-module-system.html
 
 - module: system
   # Syslog


### PR DESCRIPTION
## Description

Cause the following error in filebeat logs:

```json
{"log.level":"error","@timestamp":"2024-09-18T17:33:08.911+0200","log.logger":"reload","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*RunnerList).Reload","file.name":"cfgfile/list.go","file.line":138},"message":"Error creating runner from config: could not create module registry for filesets: module system is configured but has no enabled filesets","service.name":"filebeat","ecs.version":"1.6.0"}
```

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)