### PR TITLE
Bug #13414: Fix nginx tokenizer for filebeat.

### DIFF
--- a/deployment/roles/filebeat/templates/modules/nginx.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/nginx.yml.j2
@@ -18,7 +18,7 @@
         type: cots
       processors:
         - dissect:
-            tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size} %{log_message}'
+            tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size} "%{referer}" "%{user_agent}" "%{x_forwarded_for}"'
             target_prefix: ""
         - drop_fields:
             fields: ["date_time"]


### PR DESCRIPTION
## Description

Correction du parsing des accesslogs de nginx.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)