### PR TITLE
Bug #13163: Remove improper post action when upgrading -rsc packages

### DIFF
--- a/tools/packaging/templates/after-remove-rsc.sh
+++ b/tools/packaging/templates/after-remove-rsc.sh
@@ -1,1 +1,0 @@
-rm -R /vitamui/data/__NAME__/


### PR DESCRIPTION
Bug #13163 :  Deleting /vitamui/data/ causes error when upgrading RSC packages.