### PR TITLE
Story #11854: clean code - fix doc (python/ansible)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ tools/docker/mongo/mongo-entrypoint
 #####################
 
 .virtualenvs
+vitamUI-ansible

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Current version of VitamUI depends on Ansible version 2.7.0 in order to run inst
 In order not to interfere with more recent Ansible version, deploy a Python VirtualEnv
 in which you install Ansible 2.7.0:
 * Check that VirtualEnv executable is installed: `apt-get install python-virtualenv`
-* In a directory of your choice, create the virtual environment: `virtualenv vitamUI-ansible`
-* Activate the environment: `vitamUI-ansible/bin/activate`
+* In a directory of your choice, create the virtual environment: `virtualenv --python=python2.7 vitamUI-ansible`
+* Activate the environment: `source vitamUI-ansible/bin/activate`
 
 #### Without VirtualEnv
 * First remove older versions of Ansible before re-installing it:


### PR DESCRIPTION
## Description

* Ajout de `--python=python2.7` sur la commande `virtualenv` pour s'assurer que python 2 soit utilisé (sinon risque d'incompatibilité avec python 3)
* L'activation de l'environnement se fait via la commande `source` et pas en exécutant un script. C'est d'ailleurs ce qui est indiqué dès la première ligne du fichier :
```
# This file must be used with "source bin/activate" *from bash*
# you cannot run it directly
```

## Type de changement

* Refactorisation de code

## Contributeur

* VAS (Vitam Accessible en Service)