### PR TITLE
bug #13206 : signed document non downloadable

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-information-tab/archive-unit-information-tab.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-information-tab/archive-unit-information-tab.component.html
@@ -108,7 +108,7 @@
   <div class="col-12">
     <button
       class="btn primary download-btn"
-      [disabled]="!hasDownloadDocumentRole || archiveUnit['#object'] === null"
+      [disabled]="!hasDownloadDocumentRole || !archiveUnit['#object']"
       (click)="onDownloadObjectFromUnit(archiveUnit)"
     >
       <span>{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.DOWNLOAD_DOC' | translate }}</span>


### PR DESCRIPTION
## Description

The main issue of this bug is that the button for downloading a document from an archive unit is enabled when no object is associated with this AU

## Type de changement

*Indiquer le ou les types de changements*

* Correction
* 
## Contributeur

* VAS (Vitam Accessible en Service)
