### PR TITLE
CP 6 - Bugs #13460: allow $match operator in DSL

### DIFF
--- a/commons/commons-security/src/main/java/fr/gouv/vitamui/common/security/SanityChecker.java
+++ b/commons/commons-security/src/main/java/fr/gouv/vitamui/common/security/SanityChecker.java
@@ -109,6 +109,7 @@ public class SanityChecker {
         "$limit",
         "$orderby",
         "$eq",
+        "$match",
         "$offset",
         "events.agIdExt.TransferringAgency",
         "events.agIdExt.originatingAgency",


### PR DESCRIPTION
Allow the use of the $match operator in query DSL.