### PR TITLE
CP V7.1 - Bugs #13481: correctly escape the json schema in the notice

### DIFF
--- a/api/api-pastis/pastis-commons/src/main/java/fr/gouv/vitamui/pastis/common/service/PuaFromJSON.java
+++ b/api/api-pastis/pastis-commons/src/main/java/fr/gouv/vitamui/pastis/common/service/PuaFromJSON.java
@@ -90,8 +90,8 @@ public class PuaFromJSON {
         JSONArray allElements = puaPastisValidator.getJSONObjectFromAllTree(elementsForTree);
         JSONObject sortedElements = getJSONObjectsFromJSonArray(allElements);
         controlSchema.put("properties", sortedElements);
-        // 7. Remove excessive backslashes from mapping strings to objects and vice-versa
-        return controlSchema.toString().replaceAll("[\\\\]+", "");
+        // 7. Return string representation
+        return controlSchema.toString();
     }
 
     public String getDefinitions() {


### PR DESCRIPTION
Saving a PUA profile failed when the comment contained a quote (").