### PR TITLE
Story #13474: Retrieving timestamp from log's date_time field instead of writing's date.

### DIFF
--- a/deployment/roles/filebeat/templates/inputs/cots.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/cots.yml.j2
@@ -19,6 +19,12 @@
         tokenizer: '%{date_time} [%{log_level}]%{*}%{logger}: %{log_message}'
         target_prefix: ""
         trim_values: all
+    - timestamp:
+        field: date_time
+        layouts:
+          - '2006-01-02T15:04:05.000-0700'
+        test:
+          - '2024-09-30T13:46:37.298+0200'
     - drop_fields:
         fields: ["date_time"]
   parsers:

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -17,12 +17,19 @@
     source: vitamui
     type: application
   processors:
+    {% if vitamui_service == 'api_gateway' %}
     - dissect:
-        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
+        tokenizer: '[%{date_time}] %{client_ip|ip} - - [%{misformated_date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
         target_prefix: ""
+    - timestamp:
+        field: date_time
+        layouts:
+          - '2006-01-02 15:04:05,000'
+        test:
+          - '2024-09-30 13:46:37,298'
     - drop_fields:
-        fields: ["date_time"]
-    {% if vitamui_service == 'api_gateway' and filebeat.drop_health_checks_logs | default(true) | bool %}
+        fields: ["date_time", "misformated_date_time"]
+      {% if filebeat.drop_health_checks_logs | default(true) | bool %}
     # Drop health checks
     - drop_event:
         when:
@@ -31,6 +38,19 @@
                 http_status_code: 200
             - equals:
                 request_path: "/actuator/health"
+      {% endif %}
+    {% else %}
+    - dissect:
+        tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
+        target_prefix: ""
+    - timestamp:
+        field: date_time
+        layouts:
+          - '02/Jan/2006:15:04:05 -0700'
+        test:
+          - '30/Sep/2024:13:46:37 +0200'
+    - drop_fields:
+        fields: ["date_time"]
     {% endif %}
 
   {% endif %}
@@ -50,6 +70,12 @@
     - dissect:
         tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size}'
         target_prefix: ""
+    - timestamp:
+        field: date_time
+        layouts:
+          - '02/Jan/2006:15:04:05 -0700'
+        test:
+          - '30/Sep/2024:13:46:37 +0200'
     - drop_fields:
         fields: ["date_time"]
     {% if filebeat.drop_health_checks_logs | default(true) | bool %}
@@ -81,6 +107,12 @@
         tokenizer: '%{date_time} [[%{thread}]] [%{request_id}] %{log_level} %{logger} - %{log_message}'
         target_prefix: ""
         trim_values: all
+    - timestamp:
+        field: date_time
+        layouts:
+          - '2006-01-02 15:04:05,000'
+        test:
+          - '2024-09-30 13:46:37,298'
     - drop_fields:
         fields: ["date_time"]
   parsers:

--- a/deployment/roles/filebeat/templates/modules/apache.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/apache.yml.j2
@@ -21,6 +21,12 @@
         - dissect:
             tokenizer: '%{client_ip|ip} - - [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size} "%{referer}" "%{user_agent}"'
             target_prefix: ""
+        - timestamp:
+            field: date_time
+            layouts:
+              - '02/Jan/2006:15:04:05 -0700'
+            test:
+              - '30/Sep/2024:13:46:37 +0200'
         - drop_fields:
             fields: ["date_time"]
 {% if filebeat.drop_health_checks_logs | default(true) | bool %}
@@ -47,3 +53,16 @@
         kind: error
         vitam_component: apache
         source: vitamui
+        log_level: WARN
+      processors:
+        - dissect:
+            tokenizer: '[%{date_time}] [%{logger}] [%{*}] %{log_message}'
+            target_prefix: ""
+        - timestamp:
+            field: date_time
+            layouts:
+              - 'Mon Jan 02 15:04:05.000000 2006'
+            test:
+              - 'Tue Sep 30 13:46:37.594890 2024'
+        - drop_fields:
+            fields: ["date_time"]

--- a/deployment/roles/filebeat/templates/modules/logstash.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/logstash.yml.j2
@@ -18,6 +18,12 @@
             tokenizer: '[%{date_time}][%{log_level}]%{*}[%{logger}] %{log_message}'
             target_prefix: ""
             trim_values: all
+        - timestamp:
+            field: date_time
+            layouts:
+              - '2006-01-02T15:04:05,000'
+            test:
+              - '2024-09-30T14:51:17,100'
         - drop_fields:
             fields: ["date_time"]
 

--- a/deployment/roles/filebeat/templates/modules/mongodb.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/mongodb.yml.j2
@@ -42,6 +42,12 @@
                         event.Put("log_level", "UNKNOWN");
                   }
                 }
+        - timestamp:
+            field: message.t.$date
+            layouts:
+              - '2006-01-02T15:04:05.000Z07:00'
+            test:
+              - '2024-09-30T13:46:37.298+02:00'
         - drop_event:
             when:
               equals:

--- a/deployment/roles/filebeat/templates/modules/nginx.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/nginx.yml.j2
@@ -21,6 +21,12 @@
         - dissect:
             tokenizer: '%{client_ip|ip} - %{sender} [%{date_time}] "%{http_method} %{request_path} HTTP/%{http_version}" %{http_status_code|integer} %{response_size} "%{referer}" "%{user_agent}" "%{x_forwarded_for}"'
             target_prefix: ""
+        - timestamp:
+            field: date_time
+            layouts:
+              - '02/Jan/2006:15:04:05 -0700'
+            test:
+              - '30/Sep/2024:13:46:37 +0200'
         - drop_fields:
             fields: ["date_time"]
 {% if filebeat.drop_health_checks_logs | default(true) | bool %}

--- a/deployment/roles/vitamui/templates/logback.xml.j2
+++ b/deployment/roles/vitamui/templates/logback.xml.j2
@@ -9,7 +9,7 @@
       <maxHistory>{{ vitamui_struct.access_retention_days | default(access_retention_days) }}</maxHistory>
     </rollingPolicy>
     <encoder>
-      <pattern>%msg%n</pattern>
+      <pattern>[%d{ISO8601}] %msg%n</pattern>
     </encoder>
   </appender>
   <appender name="async-accessLog" class="ch.qos.logback.classic.AsyncAppender">


### PR DESCRIPTION
## Description

* Use as timestamp the date and time in the log instead of the writing's date from filebeat.
* Fix wrong date format in api-gateway's accesslogs.

## Type de changement

* Ansiblerie
* Nouveau Code
* Correction
* Refactorisation de code

## Contributeur

* VAS (Vitam Accessible en Service)