### PR TITLE
CP V7.0 - Bugs #13480 #13486: fix JSON Schema generation for array properties with enum or pattern

### DIFF
--- a/api/api-pastis/pastis-commons/src/main/java/fr/gouv/vitamui/pastis/common/dto/pua/PuaMetadataDetails.java
+++ b/api/api-pastis/pastis-commons/src/main/java/fr/gouv/vitamui/pastis/common/dto/pua/PuaMetadataDetails.java
@@ -69,6 +69,24 @@ public class PuaMetadataDetails {
     public String serialiseString() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new AfterburnerModule());
-        return mapper.writeValueAsString(this);
+        String result = mapper.writeValueAsString(this);
+        // This whole method of generating the JSON Schema should really be completely rewritten. This is unreadable
+        // and not maintainable. Here we manage the correct generation of the "array" type having enum or pattern...
+        if ("array".equals(type) && (pattern != null || (enums != null && !enums.isEmpty()))) {
+            JSONObject jsonObject = new JSONObject(result);
+            JSONObject items = new JSONObject();
+            jsonObject.put("items", items);
+            items.put("type", "string");
+            if (enums != null && !enums.isEmpty()) {
+                items.put("enum", jsonObject.getJSONArray("enum"));
+                jsonObject.remove("enum");
+            }
+            if (pattern != null) {
+                items.put("pattern", jsonObject.getString("pattern"));
+                jsonObject.remove("pattern");
+            }
+            result = jsonObject.toString();
+        }
+        return result;
     }
 }


### PR DESCRIPTION
When the property is a string array, with a field control of type enum or pattern, the generated JSON schema is invalid.