### PR TITLE
bugs #13494 fix(pastis): create PA

### DIFF
--- a/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/rest/ProfileInternalController.java
+++ b/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/rest/ProfileInternalController.java
@@ -200,7 +200,6 @@ public class ProfileInternalController {
         SanityChecker.sanitizeCriteria(archivalProfile);
         LOGGER.debug("create profile={}", archivalProfile);
         final VitamContext vitamContext = securityService.buildVitamContext(securityService.getTenantIdentifier());
-        archivalProfile.setTenant(vitamContext.getTenantId());
         return profileInternalService.create(vitamContext, archivalProfile);
     }
 


### PR DESCRIPTION
## Description

* Corrige le problème de création des PA

Problème lié à la modification du DTO de création d'une notice de PA. Il n'est plus permis d'ajouter les informations calculées par Vitam (tenant, ...<xxx>Date).

Par contre ça ne règle pas:

* le problème de remontée d'erreur entre référential internal et external de Vitam UI.
* le problème de gestion du spinner si jamais la sauvegarde du PA échoue.

```js
savePA() {
  if (!this.editProfile) {
    this.profileService.createProfilePa(this.profile).subscribe((createdProfile) => {
      if (createdProfile) {
        // STEP 2 : ASSIGNER LE PROFIL A LA NOTICE
        this.profileService
          .uploadFile(this.data, this.profileDescription, ProfileType.PA, createdProfile.sedaVersion)
          .subscribe((retrievedData) => {
            const myFile = this.blobToFile(retrievedData, 'file');
            this.profileService.updateProfileFilePa(createdProfile, myFile).subscribe(() => {
              this.toggleService.hidePending();
              this.success('La création du profil a bien été effectué');
            });
          });
      }
    });
  }
```
