### PR TITLE
CP V7.1: Bug #13179: Force using index with name idx_token_date on token collection

### DIFF
--- a/deployment/scripts/mongod/v7.1/002_TRV-389_add_index_on_updatedDate_field_of_tokens_collection_ref.js
+++ b/deployment/scripts/mongod/v7.1/002_TRV-389_add_index_on_updatedDate_field_of_tokens_collection_ref.js
@@ -5,8 +5,8 @@ db = db.getSiblingDB("iam");
 db.tokens.dropIndex("updatedDate_1");
 
 db.tokens.createIndex(
-  { updatedDate: 1 },
-  { expireAfterSeconds: 0, background: true }
+  {updatedDate: 1},
+  {name: "idx_token_date", expireAfterSeconds: 0, background: true}
 );
 
 print("END 002_TRV-389_add_index_on_updatedDate_field_of_tokens_collection_ref.js");


### PR DESCRIPTION
## Description

Force index name on creation to avoid conflict.

## Contributeur

* VAS (Vitam Accessible en Service)

