### PR TITLE
Story #13302: Fix consul startup in production cluster mode

### DIFF
--- a/deployment/roles/consul/templates/vitam-container-consul.service.j2
+++ b/deployment/roles/consul/templates/vitam-container-consul.service.j2
@@ -16,7 +16,7 @@ ExecStart=/usr/bin/docker run --rm --net=host -e 'CONSUL_ALLOW_PRIVILEGED_PORTS=
         -v "/vitam/script/consul:/vitam/script/consul" \
         -v "/vitam/data/consul:/consul/data" \
         -v "/vitam/tmp/consul:/vitam/tmp/consul" \
-        {{ container_repository.registry_url }}/vitam-external/hashicorp/consul:{{ consul_version }} {{ 'agent ' if inventory_hostname not in groups['hosts_vitamui_consul_server'] }}
+        {{ container_repository.registry_url }}/vitam-external/hashicorp/consul:{{ consul_version }} agent
 
 ExecStop=/usr/bin/docker stop -t 85 vitam-consul
 ExecRestart=/usr/bin/docker restart -t 85 vitam-consul


### PR DESCRIPTION
## Description

See https://github.com/hashicorp/consul/blob/main/Dockerfile

> By default you'll get an insecure single-node development server that stores
> everything in RAM, exposes a web UI and HTTP endpoints, and bootstraps itself.
> Don't use this configuration for production.

`CMD ["agent", "-dev", "-client", "0.0.0.0"]`

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)