### PR TITLE
Story #11851 Clean Code: fix agency routing

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/agency/agency-routing.module.ts
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency-routing.module.ts
@@ -44,6 +44,7 @@ const routes: Route[] = [
   {
     path: '',
     redirectTo: 'tenant',
+    pathMatch: 'full',
   },
   {
     path: 'tenant',


### PR DESCRIPTION
## Description

* Correction de l'erreur suivante lors de l'accès au Service Agents en développement :
```
ERROR Error: NG04014: Invalid configuration of route '{path: "agency/", redirectTo: "tenant"}': please provide 'pathMatch'. The default value of 'pathMatch' is 'prefix', but often the intent is to use 'full'.
```

## Contributeur

* VAS (Vitam Accessible en Service)