### PR TITLE
Fix #13571: Password reset token should be revoked after 1st use

### DIFF
--- a/cas/cas-server/src/main/config/cas-server-application-dev.yml
+++ b/cas/cas-server/src/main/config/cas-server-application-dev.yml
@@ -109,7 +109,7 @@ cas.authn.pm.reset.mail.text: "Changez de mot de passe via le lien: %s"
 cas.authn.pm.reset.mail.from: serveur-cas@noreply.com
 # 1 Day : 24 * 60 Minutes to reset password
 cas.authn.pm.reset.expiration: PT1440M
-cas.authn.pm.reset.number-of-uses: 2
+cas.authn.pm.reset.number-of-uses: 1
 cas.authn.pm.reset.mail.attribute-name: email
 cas.authn.pm.reset.security-questions-enabled: false
 cas.authn.pm.reset.include-server-ip-address: false

--- a/cas/cas-server/src/main/config/cas-server-application-recette.yml
+++ b/cas/cas-server/src/main/config/cas-server-application-recette.yml
@@ -81,7 +81,7 @@ cas.authn.pm.reset.mail.text: "Changez de mot de passe via le lien: %s"
 cas.authn.pm.reset.mail.from: serveur-cas@noreply.com
 # 1 Day : 24 * 60 Minutes to reset password
 cas.authn.pm.reset.expiration: PT1440M
-cas.authn.pm.reset.number-of-uses: 2
+cas.authn.pm.reset.number-of-uses: 1
 cas.authn.pm.reset.mail.attribute-name: email
 cas.authn.pm.reset.security-questions-enabled: false
 cas.authn.pm.reset.include-server-ip-address: false

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -115,7 +115,7 @@ cas.authn.pm.reset.mail.subject: Requete de reinitialisation de mot de passe
 cas.authn.pm.reset.mail.text: "Changez de mot de passe via le lien: %s"
 cas.authn.pm.reset.mail.from: {{ smtp.cas.sender }}
 cas.authn.pm.reset.expiration: PT{{ smtp.cas.expiration }}M
-cas.authn.pm.reset.number-of-uses: 2
+cas.authn.pm.reset.number-of-uses: 1
 cas.authn.pm.reset.mail.attribute-name: email
 cas.authn.pm.reset.security-questions-enabled: false
 cas.authn.pm.reset.include-server-ip-address: false


### PR DESCRIPTION
## Description

Le fait que le lien de reset de mot de passe puisse être utilisé 2 fois expose à un risque de sécurité. Une fuite du lien (présent dans le mail, dans les access logs, ...) permet de changer le mot de passe d'un utilisateur à son insu.

## Type de changement

* Correction

## Tests

Non testé (impact du paramètre expliqué dans la documentation CAS)

## Contributeur

* VAS (Vitam Accessible en Service)