### PR TITLE
bug #13541 : agency and rule previews, non-disabled fields

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.html
@@ -9,7 +9,12 @@
 <div class="vitamui-sidepanel-body">
   <mat-tab-group #tabs class="preview-tab-group" (selectedIndexChange)="selectedIndex = $event">
     <mat-tab [label]="'AGENCY.TAB.INFORMATION' | translate">
-      <app-agency-information-tab #infoTab [agency]="agency" (updated)="updatedChange($event, 0)"></app-agency-information-tab>
+      <app-agency-information-tab
+        #infoTab
+        [agency]="agency"
+        [readOnly]="readOnly"
+        (updated)="updatedChange($event, 0)"
+      ></app-agency-information-tab>
     </mat-tab>
 
     <mat-tab [label]="'AGENCY.TAB.HISTORY' | translate">

--- a/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.ts
@@ -56,6 +56,7 @@ import { AgencyInformationTabComponent } from './agency-information-tab/agency-i
 export class AgencyPreviewComponent implements AfterViewInit {
   @Input() agency: Agency;
   @Input() tenantIdentifier: number;
+  @Input() readOnly: boolean;
 
   @Output() previewClose = new EventEmitter<void>();
 

--- a/ui/ui-frontend/projects/referential/src/app/agency/agency.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency.component.html
@@ -5,6 +5,7 @@
       (previewClose)="closePanel()"
       [agency]="openedItem"
       [tenantIdentifier]="tenantIdentifier"
+      [readOnly]="hasUpdateRole === false"
     ></app-agency-preview>
   </mat-sidenav>
 

--- a/ui/ui-frontend/projects/referential/src/app/agency/agency.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency.component.ts
@@ -61,6 +61,7 @@ export class AgencyComponent extends SidenavPage<Agency> implements OnInit {
   hasCreateRole = false;
   hasImportRole = false;
   hasExportRole = false;
+  hasUpdateRole = false;
 
   constructor(
     public dialog: MatDialog,
@@ -82,10 +83,12 @@ export class AgencyComponent extends SidenavPage<Agency> implements OnInit {
       this.securityService.hasRole(ApplicationId.AGENCIES_APP, this.tenantIdentifier, Role.ROLE_CREATE_AGENCIES),
       this.securityService.hasRole(ApplicationId.AGENCIES_APP, this.tenantIdentifier, Role.ROLE_IMPORT_AGENCIES),
       this.securityService.hasRole(ApplicationId.AGENCIES_APP, this.tenantIdentifier, Role.ROLE_EXPORT_AGENCIES),
-    ).subscribe((values: [boolean, boolean, boolean]) => {
+      this.securityService.hasRole(ApplicationId.AGENCIES_APP, this.tenantIdentifier, Role.ROLE_UPDATE_AGENCIES),
+    ).subscribe((values: [boolean, boolean, boolean, boolean]) => {
       this.hasCreateRole = values[0];
       this.hasImportRole = values[1];
       this.hasExportRole = values[2];
+      this.hasUpdateRole = values[3];
     });
   }
 

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-information-tab/rule-information-tab.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-information-tab/rule-information-tab.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" class="side-form" (ngSubmit)="onSubmit()">
   <div class="d-flex">
     <mat-form-field class="vitamui-mat-select w-100">
-      <mat-select formControlName="ruleType" [placeholder]="'RULES_APP.TAB.INFORMATION.TYPE' | translate" required [disabled]="true">
+      <mat-select formControlName="ruleType" [placeholder]="'RULES_APP.TAB.INFORMATION.TYPE' | translate" required>
         <mat-option *ngFor="let ruleType of ruleTypes" [value]="ruleType.key">{{ ruleType.label }}</mat-option>
       </mat-select>
       <div class="select-arrow"><i class="material-icons">keyboard_arrow_down</i></div>
@@ -15,7 +15,6 @@
       minlength="2"
       required
       [placeholder]="'RULES_APP.TAB.INFORMATION.NAME' | translate"
-      [disabled]="(hasUpdateRuleRole$ | async) !== true"
     >
       <ng-container *ngIf="form.get('ruleValue')?.touched">
         <vitamui-common-input-error *ngIf="!!form.get('ruleValue')?.errors?.required">
@@ -32,7 +31,6 @@
       pattern="[0-9]*"
       required
       [placeholder]="'RULES_APP.TAB.INFORMATION.PERIOD' | translate"
-      [disabled]="(hasUpdateRuleRole$ | async) !== true"
     >
       <ng-container *ngIf="form.get('ruleDuration')?.touched">
         <vitamui-common-input-error *ngIf="!!form.get('ruleDuration')?.errors?.required">
@@ -47,12 +45,7 @@
 
   <div class="d-flex">
     <mat-form-field class="vitamui-mat-select w-100">
-      <mat-select
-        formControlName="ruleMeasurement"
-        [placeholder]="'RULES_APP.TAB.INFORMATION.UNIT_MEASURE' | translate"
-        required
-        [disabled]="(hasUpdateRuleRole$ | async) !== true"
-      >
+      <mat-select formControlName="ruleMeasurement" [placeholder]="'RULES_APP.TAB.INFORMATION.UNIT_MEASURE' | translate" required>
         <mat-option *ngFor="let ruleMeasurement of ruleMeasurements" [value]="ruleMeasurement.key">
           {{ ruleMeasurement.label }}
         </mat-option>
@@ -66,7 +59,6 @@
       class="w-100"
       required
       formControlName="ruleDescription"
-      [disabled]="(hasUpdateRuleRole$ | async) !== true"
       [placeholder]="'RULES_APP.TAB.INFORMATION.DESCRIPTION' | translate"
       [rows]="2"
     >

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.html
@@ -4,7 +4,8 @@
 <div class="vitamui-sidepanel-body">
   <mat-tab-group class="preview-tab-group" #tabs>
     <mat-tab [label]="'RULES_APP.TAB.INFORMATION.TITLE' | translate">
-      <app-rule-information-tab [rule]="rule" (updated)="updatedChange($event, 0)" #infoTab> </app-rule-information-tab>
+      <app-rule-information-tab [rule]="rule" [readOnly]="readOnly" (updated)="updatedChange($event, 0)" #infoTab>
+      </app-rule-information-tab>
     </mat-tab>
 
     <mat-tab [label]="'RULES_APP.TAB.HISTORY.TITLE' | translate">

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.ts
@@ -53,6 +53,7 @@ import { switchMap } from 'rxjs/operators';
 export class RulePreviewComponent implements AfterViewInit {
   @Output() previewClose: EventEmitter<any> = new EventEmitter();
   @Input() rule: Rule;
+  @Input() readOnly: boolean;
 
   tabUpdated: boolean[] = [false, false];
   @ViewChild('tabs', { static: false }) tabs: MatTabGroup;

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule.component.html
@@ -1,6 +1,11 @@
 <mat-sidenav-container [autosize]="true" [hasBackdrop]="false">
   <mat-sidenav #panel mode="side" position="end" [fixedInViewport]="true">
-    <app-rule-preview *ngIf="openedItem" (previewClose)="closePanel()" [rule]="openedItem"></app-rule-preview>
+    <app-rule-preview
+      *ngIf="openedItem"
+      (previewClose)="closePanel()"
+      [rule]="openedItem"
+      [readOnly]="(checkUpdateRole | async) !== true"
+    ></app-rule-preview>
   </mat-sidenav>
 
   <mat-sidenav-content>

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule.component.ts
@@ -59,6 +59,7 @@ export class RuleComponent extends SidenavPage<Rule> implements OnInit {
   tenantId: number;
 
   checkCreateRole = new Observable<boolean>();
+  checkUpdateRole = new Observable<boolean>();
   checkImportRole = new Observable<boolean>();
   checkExportRole = new Observable<boolean>();
 
@@ -117,6 +118,7 @@ export class RuleComponent extends SidenavPage<Rule> implements OnInit {
     this.checkCreateRole = this.securityService.hasRole(ApplicationId.RULES_APP, this.tenantId, Role.ROLE_CREATE_RULES);
     this.checkImportRole = this.securityService.hasRole(ApplicationId.RULES_APP, this.tenantId, Role.ROLE_IMPORT_RULES);
     this.checkExportRole = this.securityService.hasRole(ApplicationId.RULES_APP, this.tenantId, Role.ROLE_EXPORT_RULES);
+    this.checkUpdateRole = this.securityService.hasRole(ApplicationId.RULES_APP, this.tenantId, Role.ROLE_UPDATE_RULES);
   }
 
   showRule(item: Rule) {


### PR DESCRIPTION
## Description

In previews of agent services and management rules, fields weren't disabled when update rules weren't allowed for users

## Type de changement

* Correction
