### PR TITLE
Fix #13214 & #13133: subrogation duration & date in number (timestamp) format

### DIFF
--- a/api/api-iam/iam-commons/src/main/java/fr/gouv/vitamui/iam/common/dto/SubrogationDto.java
+++ b/api/api-iam/iam-commons/src/main/java/fr/gouv/vitamui/iam/common/dto/SubrogationDto.java
@@ -46,7 +46,7 @@ import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 /**
  * The DTO v1 for a subrogation.
@@ -65,7 +65,7 @@ public class SubrogationDto extends IdDto {
     @NotNull
     private SubrogationStatusEnum status;
 
-    private OffsetDateTime date;
+    private Instant date;
 
     @NotNull
     @Length(min = 4, max = 100)

--- a/api/api-iam/iam-commons/src/test/java/fr/gouv/vitamui/iam/common/utils/IamDtoBuilder.java
+++ b/api/api-iam/iam-commons/src/test/java/fr/gouv/vitamui/iam/common/utils/IamDtoBuilder.java
@@ -20,6 +20,7 @@ import fr.gouv.vitamui.iam.common.dto.SubrogationDto;
 import fr.gouv.vitamui.iam.common.enums.OtpEnum;
 import fr.gouv.vitamui.iam.common.enums.SubrogationStatusEnum;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -201,7 +202,7 @@ public class IamDtoBuilder {
     ) {
         final SubrogationDto subrogation = new SubrogationDto();
         subrogation.setId(id);
-        subrogation.setDate(OffsetDateTime.now());
+        subrogation.setDate(Instant.now());
         subrogation.setStatus(SubrogationStatusEnum.CREATED);
         subrogation.setSurrogate(surrogate);
         subrogation.setSurrogateCustomerId(surrogateCustomerId);

--- a/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/subrogation/converter/SubrogationConverter.java
+++ b/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/subrogation/converter/SubrogationConverter.java
@@ -44,11 +44,10 @@ import fr.gouv.vitamui.iam.internal.server.subrogation.domain.Subrogation;
 import fr.gouv.vitamui.iam.internal.server.user.dao.UserRepository;
 import fr.gouv.vitamui.iam.internal.server.user.domain.User;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class SubrogationConverter implements Converter<SubrogationDto, Subrogation> {
 
@@ -79,9 +78,7 @@ public class SubrogationConverter implements Converter<SubrogationDto, Subrogati
     public Subrogation convertDtoToEntity(final SubrogationDto dto) {
         final Subrogation entity = new Subrogation();
         VitamUIUtils.copyProperties(dto, entity);
-        if (dto != null && dto.getDate() != null) {
-            entity.setDate(Date.from(dto.getDate().toInstant()));
-        }
+        Optional.ofNullable(dto).map(SubrogationDto::getDate).map(Date::from).ifPresent(entity::setDate);
         return entity;
     }
 
@@ -89,9 +86,7 @@ public class SubrogationConverter implements Converter<SubrogationDto, Subrogati
     public SubrogationDto convertEntityToDto(final Subrogation entity) {
         final SubrogationDto dto = new SubrogationDto();
         VitamUIUtils.copyProperties(entity, dto);
-        if (entity != null && entity.getDate() != null) {
-            dto.setDate(OffsetDateTime.ofInstant(entity.getDate().toInstant(), ZoneOffset.UTC));
-        }
+        Optional.ofNullable(entity).map(Subrogation::getDate).map(Date::toInstant).ifPresent(dto::setDate);
         return dto;
     }
 }

--- a/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/subrogation/service/SubrogationInternalService.java
+++ b/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/subrogation/service/SubrogationInternalService.java
@@ -76,7 +76,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import javax.validation.constraints.NotNull;
-import java.time.OffsetDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Optional;
 
@@ -193,7 +194,7 @@ public class SubrogationInternalService extends VitamUICrudService<SubrogationDt
         } else {
             ttlInMinutes = subrogationTtl;
         }
-        final OffsetDateTime nowPlusXMinutes = OffsetDateTime.now().plusMinutes(ttlInMinutes);
+        final Instant nowPlusXMinutes = Instant.now().plus(ttlInMinutes, ChronoUnit.MINUTES);
         dto.setDate(nowPlusXMinutes);
 
         checkSubrogationAlreadyExist(dto.getSurrogate(), dto.getSurrogateCustomerId());

--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/rest/CasControllerTest.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/rest/CasControllerTest.java
@@ -310,7 +310,7 @@ public final class CasControllerTest {
         assertEquals(1, subrogations.size());
         final SubrogationDto dto = subrogations.get(0);
         assertEquals(subrogation.getId(), dto.getId());
-        assertEquals(subrogation.getDate(), Date.from(dto.getDate().toInstant()));
+        assertEquals(subrogation.getDate(), Date.from(dto.getDate()));
         assertEquals(subrogation.getSuperUser(), dto.getSuperUser());
         assertEquals(subrogation.getSurrogate(), dto.getSurrogate());
         assertEquals(subrogation.getStatus(), dto.getStatus());
@@ -330,7 +330,7 @@ public final class CasControllerTest {
         assertEquals(1, subrogations.size());
         final SubrogationDto dto = subrogations.get(0);
         assertEquals(subrogation.getId(), dto.getId());
-        assertEquals(subrogation.getDate(), Date.from(dto.getDate().toInstant()));
+        assertEquals(subrogation.getDate(), Date.from(dto.getDate()));
         assertEquals(subrogation.getSuperUser(), dto.getSuperUser());
         assertEquals(subrogation.getSurrogate(), dto.getSurrogate());
         assertEquals(subrogation.getStatus(), dto.getStatus());

--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/rest/SubrogationCrudControllerTest.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/rest/SubrogationCrudControllerTest.java
@@ -32,7 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 import static org.mockito.Mockito.when;
 
@@ -47,7 +47,7 @@ public final class SubrogationCrudControllerTest extends AbstractCrudControllerT
     private static final String SUPER_USER_CUSTOMER_ID = "systemCustomerId";
     private static final String SURROGATE_CREATE_EMAIL = "surrogate@test.fr";
     private static final String SURROGATE_CUSTOMER_ID = "customerId";
-    private static final OffsetDateTime NOW = OffsetDateTime.now();
+    private static final Instant NOW = Instant.now();
     private static final User SURROGATE;
     private static final User SURROGATE_CREATE;
     private static final User SUPERUSER;

--- a/ui/ui-frontend/projects/pastis/src/app/profile/list-profile/list-profile.component.html
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/list-profile/list-profile.component.html
@@ -138,7 +138,7 @@
                 </div>
                 <div (click)="showProfile(element)" class="col-3 clickable" style="word-wrap: break-word">{{ element.identifier }}</div>
                 <div (click)="showProfile(element)" class="col-3 clickable" style="word-wrap: break-word">{{ element.name }}</div>
-                <div (click)="showProfile(element)" class="col-2 mr-3 clickable">{{ element.lastUpdate | date: 'medium' : 'UTC+4' }}</div>
+                <div (click)="showProfile(element)" class="col-2 mr-3 clickable">{{ element.lastUpdate | dateTime: 'medium' }}</div>
                 <div class="col-2 actions">
                   <div>
                     <button

--- a/ui/ui-frontend/projects/pastis/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/pastis/src/assets/i18n/fr.json
@@ -344,7 +344,7 @@
       }
     },
     "BANNER": {
-      "MESSAGE": "Subrogation de l'utilisateur {{ email }} jusqu'à {{ endDate }}",
+      "MESSAGE": "Subrogation de l'utilisateur {{ email }} de l'organisation {{surrogateCustomerName}} ({{surrogateCustomerCode}}) jusqu'à {{ endDate }}",
       "STOP_LABEL": "Arrêter la subrogation"
     }
   },

--- a/ui/ui-frontend/projects/referential/src/app/logbook-management-operation/logbook-management-operation-preview/logbook-management-operation-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/logbook-management-operation/logbook-management-operation-preview/logbook-management-operation-preview.component.html
@@ -84,7 +84,7 @@
       <div class="col-3">
         <div>{{ operation?.processDate | dateTime: 'dd/MM/yyyy' }}</div>
         <span class="date">
-          {{ operation?.processDate | dateTime: 'hh:mm:ss' }}
+          {{ operation?.processDate | dateTime: 'HH:mm:ss' }}
         </span>
       </div>
       <div class="col-6">

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-interval-date-picker/vitamui-interval-date-picker.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-interval-date-picker/vitamui-interval-date-picker.component.html
@@ -12,7 +12,7 @@
           </span>
           <ng-template #showMin>
             <span (click)="pickerStart.open()">
-              {{ dateRangeFilterForm.get('dateMin').value | dateTime: 'dd/MM/yyyy' }}
+              {{ searchCriteria.dateMin }}
             </span>
             <i class="material-icons clear-date-icon clickable" (click)="clearDate('dateMin')">clear</i>
           </ng-template>
@@ -44,7 +44,7 @@
           </span>
           <ng-template #showMax>
             <span (click)="pickerEnd.open()">
-              {{ dateRangeFilterForm.get('dateMax').value | dateTime: 'dd/MM/yyyy' }}
+              {{ searchCriteria.dateMax }}
             </span>
             <i class="material-icons clear-date-icon clickable" (click)="clearDate('dateMax')">clear</i>
           </ng-template>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-viewer/services/date-display.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-viewer/services/date-display.service.ts
@@ -42,7 +42,7 @@ import { ComponentType } from '../types';
 })
 export class DateDisplayService {
   private dateFormat = {
-    wanted: { datepicker: 'dd/MM/yyyy', datetime: 'dd/MM/yyyy hh:mm:ss' },
+    wanted: { datepicker: 'dd/MM/yyyy', datetime: 'dd/MM/yyyy HH:mm:ss' },
     default: { datepicker: 'medium', datetime: 'medium' },
   };
 

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.spec.ts
@@ -53,6 +53,8 @@ describe('DateTimePipe', () => {
       expect(pipe.transform('2024-10-24T00:00:00.000Z', 'HH:mm:ss')).toBe('00:00:00');
       expect(pipe.transform('2024-10-24T23:59:59.999Z', 'HH:mm:ss')).toBe('23:59:59');
       expect(pipe.transform('2024-10-24T14:02:36.000', 'HH:mm:ss')).toBe('14:02:36'); // No timezone (defaults to 'Z')
+
+      expect(pipe.transform(1729728000.0, 'dd/MM/yyyy')).toBe('24/10/2024');
     });
   });
 
@@ -80,6 +82,8 @@ describe('DateTimePipe', () => {
       expect(pipe.transform('2024-10-24T00:00:00.000Z', 'HH:mm:ss')).toBe('02:00:00');
       expect(pipe.transform('2024-10-24T23:59:59.999Z', 'HH:mm:ss')).toBe('01:59:59');
       expect(pipe.transform('2024-10-24T14:02:36.000', 'HH:mm:ss')).toBe('16:02:36'); // No timezone (defaults to 'Z')
+
+      expect(pipe.transform(1729728000.0, 'dd/MM/yyyy')).toBe('24/10/2024');
     });
   });
 
@@ -107,6 +111,8 @@ describe('DateTimePipe', () => {
       expect(pipe.transform('2024-10-24T00:00:00.000Z', 'HH:mm:ss')).toBe('22:00:00');
       expect(pipe.transform('2024-10-24T23:59:59.999Z', 'HH:mm:ss')).toBe('21:59:59');
       expect(pipe.transform('2024-10-24T14:02:36.000', 'HH:mm:ss')).toBe('12:02:36'); // No timezone (defaults to 'Z')
+
+      expect(pipe.transform(1729728000.0, 'dd/MM/yyyy')).toBe('23/10/2024');
     });
   });
 });

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.spec.ts
@@ -24,194 +24,89 @@
  * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
  * accept its terms.
  */
-import { DatePipe } from '@angular/common';
+import { DATE_PIPE_DEFAULT_OPTIONS, DatePipe } from '@angular/common';
 import { DateTimePipe } from './datetime.pipe';
+import { TestBed } from '@angular/core/testing';
 
-describe('DatePipe', () => {
-  const fake = {
-    transform: (_value: any, _format?: string, timezone?: string) => {
-      return timezone;
-    },
-  };
+describe('DateTimePipe', () => {
+  describe('in UTC', () => {
+    let pipe: DateTimePipe;
+    beforeAll(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          DatePipe,
+          { provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: { timezone: '+0000' } }, // Simulate browser in UTC timezone
+        ],
+      });
+      const datePipe = TestBed.inject(DatePipe);
+      pipe = new DateTimePipe(datePipe);
+    });
+    it('formats date correctly', () => {
+      expect(pipe.transform(null)).toBe(null);
+      expect(pipe.transform(undefined)).toBe(null);
 
-  beforeEach(() => {
-    jasmine.clock().uninstall();
-    jasmine.clock().install();
+      expect(pipe.transform('2024-10-24T00:00:00.000Z', 'dd/MM/yyyy')).toBe('24/10/2024');
+      expect(pipe.transform('2024-10-24T23:59:59.999Z', 'dd/MM/yyyy')).toBe('24/10/2024');
+      expect(pipe.transform('2024-10-24T00:00:00.000', 'dd/MM/yyyy')).toBe('24/10/2024'); // No timezone (defaults to 'Z')
+      expect(pipe.transform('2024-10-24T23:59:59.999', 'dd/MM/yyyy')).toBe('24/10/2024'); // No timezone (defaults to 'Z')
+
+      expect(pipe.transform('2024-10-24T00:00:00.000Z', 'HH:mm:ss')).toBe('00:00:00');
+      expect(pipe.transform('2024-10-24T23:59:59.999Z', 'HH:mm:ss')).toBe('23:59:59');
+      expect(pipe.transform('2024-10-24T14:02:36.000', 'HH:mm:ss')).toBe('14:02:36'); // No timezone (defaults to 'Z')
+    });
   });
 
-  it('convert date to a correct Date', () => {
-    // Given
-    const fixedDate = new Date(Date.UTC(2020, 6, 1));
-    jasmine.clock().mockDate(fixedDate);
-    const pipe = new DateTimePipe(fake as DatePipe);
+  describe('in UTC+2', () => {
+    let pipe: DateTimePipe;
+    beforeAll(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          DatePipe,
+          { provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: { timezone: '+0200' } }, // Simulate browser in UTC+2 timezone
+        ],
+      });
+      const datePipe = TestBed.inject(DatePipe);
+      pipe = new DateTimePipe(datePipe);
+    });
+    it('formats date correctly', () => {
+      expect(pipe.transform(null)).toBe(null);
+      expect(pipe.transform(undefined)).toBe(null);
 
-    const utcDate = '2018-02-20T11:15:14.00';
+      expect(pipe.transform('2024-10-24T00:00:00.000Z', 'dd/MM/yyyy')).toBe('24/10/2024');
+      expect(pipe.transform('2024-10-24T23:59:59.999Z', 'dd/MM/yyyy')).toBe('25/10/2024');
+      expect(pipe.transform('2024-10-24T01:00:00.000', 'dd/MM/yyyy')).toBe('24/10/2024'); // No timezone (defaults to 'Z')
+      expect(pipe.transform('2024-10-24T23:00:00.000', 'dd/MM/yyyy')).toBe('25/10/2024'); // No timezone (defaults to 'Z')
 
-    // When
-    const timezone = pipe.transform(utcDate);
-
-    // Then
-    expect(pipe).toBeTruthy();
-    expect(timezone).toContain('UTC');
+      expect(pipe.transform('2024-10-24T00:00:00.000Z', 'HH:mm:ss')).toBe('02:00:00');
+      expect(pipe.transform('2024-10-24T23:59:59.999Z', 'HH:mm:ss')).toBe('01:59:59');
+      expect(pipe.transform('2024-10-24T14:02:36.000', 'HH:mm:ss')).toBe('16:02:36'); // No timezone (defaults to 'Z')
+    });
   });
 
-  it('formatDateTime should return the correct DateFormat', () => {
-    // Given
-    const expectedResult = '2022-10-18T00:00:00.000Z';
-    const dateValue = 'Tue Oct 18 2022 00:00:00 GMT+0200 (heure d’été d’Europe centrale)';
-    const pipe = new DateTimePipe(fake as DatePipe);
+  describe('in UTC-2', () => {
+    let pipe: DateTimePipe;
+    beforeAll(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          DatePipe,
+          { provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: { timezone: '-0200' } }, // Simulate browser in UTC-2 timezone
+        ],
+      });
+      const datePipe = TestBed.inject(DatePipe);
+      pipe = new DateTimePipe(datePipe);
+    });
+    it('formats date correctly', () => {
+      expect(pipe.transform(null)).toBe(null);
+      expect(pipe.transform(undefined)).toBe(null);
 
-    // When
-    const result = pipe.formatDateTime(dateValue);
+      expect(pipe.transform('2024-10-24T00:00:00.000Z', 'dd/MM/yyyy')).toBe('23/10/2024');
+      expect(pipe.transform('2024-10-24T23:59:59.999Z', 'dd/MM/yyyy')).toBe('24/10/2024');
+      expect(pipe.transform('2024-10-24T01:00:00.000', 'dd/MM/yyyy')).toBe('23/10/2024'); // No timezone (defaults to 'Z')
+      expect(pipe.transform('2024-10-24T23:00:00.000', 'dd/MM/yyyy')).toBe('24/10/2024'); // No timezone (defaults to 'Z')
 
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('formatDateTime should return the correct DateFormat with hours, minutes and seconds', () => {
-    // Given
-    const expectedResult = '2022-10-18T15:03:14.000Z';
-    const dateValue = 'Tue Oct 18 2022 15:03:14 GMT+0200 (heure d’été d’Europe centrale)';
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.formatDateTime(dateValue);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct month', () => {
-    // Given
-    const expectedResult = '12';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getMonth(12);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct number of seconds', () => {
-    // Given
-    const expectedResult = '56';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getMinutes(56);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct number of minutes', () => {
-    // Given
-    const expectedResult = '56';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getMinutes(56);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct day', () => {
-    // Given
-    const expectedResult = '26';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getDay(26);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct hour', () => {
-    // Given
-    const expectedResult = '23';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getHour(23);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct month when month is less than 9', () => {
-    // Given
-    const expectedResult = '05';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getMonth(5);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct day when day is less than 9', () => {
-    // Given
-    const expectedResult = '09';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getDay(9);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct hour when hour is less than 9', () => {
-    // Given
-    const expectedResult = '07';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getHour(7);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct number of minutes when minutes is less than 9', () => {
-    // Given
-    const expectedResult = '02';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getMinutes(2);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  it('getMonth should return the correct number of seconds when seconds is less than 9', () => {
-    // Given
-    const expectedResult = '04';
-
-    const pipe = new DateTimePipe(fake as DatePipe);
-
-    // When
-    const result = pipe.getSeconds(4);
-
-    // Then
-    expect(result).toEqual(expectedResult);
-  });
-
-  afterEach(() => {
-    jasmine.clock().uninstall();
+      expect(pipe.transform('2024-10-24T00:00:00.000Z', 'HH:mm:ss')).toBe('22:00:00');
+      expect(pipe.transform('2024-10-24T23:59:59.999Z', 'HH:mm:ss')).toBe('21:59:59');
+      expect(pipe.transform('2024-10-24T14:02:36.000', 'HH:mm:ss')).toBe('12:02:36'); // No timezone (defaults to 'Z')
+    });
   });
 });

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.ts
@@ -33,8 +33,26 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class DateTimePipe implements PipeTransform {
   constructor(private datePipe: DatePipe) {}
 
-  transform(value?: string | Date | undefined, format?: string): string | null {
-    return this.datePipe.transform(this.appendZIfNoTimezone(value), format);
+  /**
+   * Handles different kind of values:
+   * - number: when the API sends a date of the form "1730279849.983" representing a timestamp with ms in decimal part (this should never happen because we explicitly configured Jackson to format a date as an ISO string, but in practice, it happens)
+   * - string: a date in ISO format (with or without timezone)
+   * - Date: a JavaScript date instance
+   */
+  transform(value?: number | string | Date | undefined, format?: string): string | null {
+    return this.datePipe.transform(this.appendZIfNoTimezone(this.transformTimestampToDate(value)), format);
+  }
+
+  /**
+   * If the value is a number, it is interpreted as a timestamp in seconds and converted to a Date. Otherwise, it returns the original value.
+   */
+  private transformTimestampToDate(value?: number | string | Date | undefined): string | Date | null {
+    if (typeof value === 'number') {
+      const timestampMs = value * 1000; // We're expecting timestamp in seconds (with ms in decimal), so we convert in ms
+      return new Date(timestampMs);
+    } else {
+      return value;
+    }
   }
 
   /**

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.ts
@@ -33,72 +33,19 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class DateTimePipe implements PipeTransform {
   constructor(private datePipe: DatePipe) {}
 
-  transform(value: any, format?: string, local?: string): any {
-    if (value) {
-      value = this.formatDateTime(value);
-      return this.datePipe.transform(value, format, this.getTimezone(), local);
-    }
+  transform(value?: string | Date | undefined, format?: string): string | null {
+    return this.datePipe.transform(this.appendZIfNoTimezone(value), format);
   }
 
-  private getTimezone(): string {
-    const hours = (new Date().getTimezoneOffset() / 60) * -1;
-    let timezone = 'UTC';
-
-    if (hours < 0) {
-      timezone = 'UTC' + hours;
-    } else if (hours > 0) {
-      timezone = 'UTC+' + hours;
-    }
-    return timezone;
-  }
-
-  formatDateTime(value: any): string {
-    const day = this.getDay(new Date(value).getDate());
-    const year = new Date(value).getFullYear();
-    const month = this.getMonth(new Date(value).getMonth() + 1);
-    const hour = this.getHour(new Date(value).getHours());
-    const minutes = this.getMinutes(new Date(value).getMinutes());
-    const seconds = this.getSeconds(new Date(value).getSeconds());
-    return year.toString() + '-' + month + '-' + day + 'T' + hour + ':' + minutes + ':' + seconds + '.000Z';
-  }
-
-  getMonth(num: number): string {
-    if (num > 9) {
-      return num.toString();
-    } else {
-      return '0' + num.toString();
-    }
-  }
-
-  getDay(day: number): string {
-    if (day > 9) {
-      return day.toString();
-    } else {
-      return '0' + day.toString();
-    }
-  }
-
-  getHour(hour: number): string {
-    if (hour > 9) {
-      return hour.toString();
-    } else {
-      return '0' + hour.toString();
-    }
-  }
-
-  getSeconds(seconds: number): string {
-    if (seconds > 9) {
-      return seconds.toString();
-    } else {
-      return '0' + seconds.toString();
-    }
-  }
-
-  getMinutes(minutes: number): string {
-    if (minutes > 9) {
-      return minutes.toString();
-    } else {
-      return '0' + minutes.toString();
-    }
+  /**
+   * If the value is a Date instance, returns a String expressed in timezone Z.
+   * If the value is a String, appends a Z (UTC) timezone if it has no timezone already.
+   * This pipe is useful for "dates" that are instances of String and with no defined timezone. When Vitam API sends that kind of date, it should be interpreted in the UTC timezone.
+   */
+  private appendZIfNoTimezone(value?: string | Date | undefined): string | null | undefined {
+    if (!value) return value as string;
+    if (value instanceof Date) return value.toISOString();
+    const hasTimezone = /Z$|[+-]\d{2}:\d{2}$|GMT[+-]\d{4}$/.test(value);
+    return hasTimezone ? value : value + 'Z';
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/subrogation/subrogation-banner/subrogation-banner.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/subrogation/subrogation-banner/subrogation-banner.component.html
@@ -8,7 +8,7 @@
               email: authService?.user?.email,
               surrogateCustomerName: surrogateCustomerName,
               surrogateCustomerCode: surrogateCustomerCode,
-              endDate: endDate | dateTime: 'HH:mm:ss',
+              endDate: endDate | date: 'HH:mm:ss',
             }
     }}</span>
     <button class="btn link ml-5" (click)="onStopSubrogation()">{{ 'SUBROGATION.BANNER.STOP_LABEL' | translate }}</button>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/subrogation/subrogation-banner/subrogation-banner.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/subrogation/subrogation-banner/subrogation-banner.component.ts
@@ -35,7 +35,6 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, OnInit } from '@angular/core';
-import moment from 'moment';
 import { filter } from 'rxjs/operators';
 
 import { AuthService } from '../../auth.service';
@@ -69,7 +68,7 @@ export class SubrogationBannerComponent implements OnInit {
           if (!this.subrogation) {
             this.subrogation = data;
             this.show = true;
-            this.endDate = moment(this.subrogation.date).toDate();
+            this.endDate = new Date(this.subrogation.date);
             this.subrogationTTL = this.endDate.getTime() - new Date().getTime();
             this.surrogateCustomerCode = this.subrogation.surrogateCustomerCode;
             this.surrogateCustomerName = this.subrogation.surrogateCustomerName;


### PR DESCRIPTION
## Description

### 13214
* Utilisation d'`Instant` au lieu d'`OffsetDateTime` pour la subrogation
* Réécriture du pipe `dateTime` : on comprends pas ce qu'il faisait, y compris en lisant les tests. Maintenant, il ajoute la timezone `Z` (UTC) si l'input est une string sans TZ puis utilise le DatePipe. Certaines dates contiennent une TZ, donc on la garde. Mais quand aucune TZ n'est précisée, c'est que la date a été stockée en UTC dans la base et on ajoute donc la TZ `Z` dans ce cas. En toute logique, la TZ aurait dû être stockée en base de données, mais ce n'est pas vraiment modifiable puisque ça concerne par exemple les journaux de logs
* Quelques corrections en plus :
  * Suppression d'un 'UTC+4' (???)
  * Utilisation de `HH` pour des heures au format 24h au lieu de `hh` (au format 12h AM/PM)

### 13133
Prise en compte des dates au format numérique (timestamp) dans le pipe `dateTime`.
Idéalement, les APIs devraient renvoyer des dates au format ISO (string). C'est d'ailleurs ce qui est configuré dans toutes les applications (`spring.jackson.serialization.write-dates-as-timestamps=false`). Mais en pratique, la configuration ne semble pas être correctement prise en compte tout le temps (pour des problèmes de compatibilités de versions Spring/Jackson ?). Pour gérer ce cas, le pipe prends donc en compte également les dates au format timestamp numérique (les millisecondes sont représentées par la partie décimale).


## Type de changement

* Nouveau Code
* Correction
* Refactorisation de code

## Documentation

*Indiquer la documentation mise à jour*

* [ ] Quels sont les nouvelles documentations ?
* [ ] Quels sont les modifications existantes ?
* [ ] Quels sont les documentations ou sections de documentations supprimés ?

## Tests

* manuel
* environnement
* TU

## Migration

*Indiquer si les modifications apportées impliquent une migration sur l'existant et comment la faire*

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)
