### PR TITLE
buf #13133 : wrong date on Search criteria list

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/pipes/datetime.pipe.ts
@@ -35,8 +35,12 @@ export class DateTimePipe implements PipeTransform {
 
   transform(value: any, format?: string, local?: string): any {
     if (value) {
-      value = this.formatDateTime(value);
-      return this.datePipe.transform(value, format, this.getTimezone(), local);
+      if (typeof value === 'string') {
+        value = this.formatDateTime(value);
+        return this.datePipe.transform(value, format, this.getTimezone(), local);
+      } else if (typeof value === 'number') {
+        return this.datePipe.transform(value * 1000, format, this.getTimezone(), local);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

When loading Search Criteria list filters on Archive-search and Collect, the recorded date is wrong because it is interpreted as a Number and not a string

## Type de changement

* Correction