### PR TITLE
bug #13111 : persistant hover on autocomplete option

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/autocomplete/vitamui-autocomplete/vitamui-autocomplete.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/autocomplete/vitamui-autocomplete/vitamui-autocomplete.component.html
@@ -30,7 +30,6 @@
 <mat-autocomplete
   #auto="matAutocomplete"
   [displayWith]="displayFn(options)"
-  autoActiveFirstOption
   (optionSelected)="selectionChange($event)"
   class="vitamui-autocomplete-panel"
 >


### PR DESCRIPTION
## Description

In vitamui-autocomplete component, remove option autoActiveFirstOption

## Type de changement

* Correction
