### PR TITLE
CP V7.1 - Bug #13792: persistent id search empty modal

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/persistent-identifier-search/found-object-modal/found-object-modal.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/persistent-identifier-search/found-object-modal/found-object-modal.component.ts
@@ -39,7 +39,7 @@ export class FoundObjectModalComponent {
     this.ark = data.ark;
     this.unitId = data.object['#unitups'][0];
     this.versionWithQualifier = qualifiersToVersionsWithQualifier(data.object['#qualifiers']).find((version) =>
-      version.PersistentIdentifier.some((persistentId) => persistentId.PersistentIdentifierContent === data.ark),
+      version.PersistentIdentifier?.some((persistentId) => persistentId.PersistentIdentifierContent === data.ark),
     );
 
     if (this.versionWithQualifier) {


### PR DESCRIPTION
## Description

La modal est vide à cause d'une erreur sur le filtre