### PR TITLE
Bugs #13615: allow selection of SigningRole and DetachedSigningRole values

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.ts
@@ -82,6 +82,8 @@ const PA_MANDATORY_ENUM_FIELDS = [
   'PreventInheritance',
   'FinalAction',
   'NeedReassessingAuthorization',
+  'SigningRole',
+  'DetachedSigningRole',
 ];
 
 function constantToTranslate() {


### PR DESCRIPTION
In Pastis, by default, enumeration fields are not displayed as select unless they appear in a magical constant.

Apply magic to both fields.