### PR TITLE
Story #13624: fix Vitam UI deployment

### DIFF
--- a/deployment/roles/vitamui/tasks/pastis-external.yml
+++ b/deployment/roles/vitamui/tasks/pastis-external.yml
@@ -1,0 +1,17 @@
+- name: "Copy vitam certificates"
+  copy:
+    src: "{{ item }}"
+    dest: "{{ vitamui_folder_conf }}/{{ item | basename }}"
+    owner: "{{ vitamui_defaults.users.vitamui | default('vitamui') }}"
+    group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
+    mode: "{{ vitamui_defaults.folder.folder_permission | default('0750') }}"
+  with_fileglob:
+    - "{{ inventory_dir }}/keystores/client-vitam/*.*"
+  when:
+    - vitam_cert is defined
+  tags:
+    - update_vitam_configuration
+  notify:
+    - restart service
+
+- include: copy_ontologies.yml

--- a/deployment/roles/vitamui/templates/pastis-external/collect-external-client.conf.j2
+++ b/deployment/roles/vitamui/templates/pastis-external/collect-external-client.conf.j2
@@ -1,0 +1,11 @@
+serverHost: {{ vitam_vars.collect_external.host }}
+serverPort: {{ vitam_vars.collect_external.port_service }}
+secure: true
+sslConfiguration :
+ keystore :
+  - keyPath: {{ vitamui_folder_conf }}/{{ vitam_cert.filename }}
+    keyPassword: {{ vitam_cert.password }}
+ truststore :
+  - keyPath: {{ vitamui_folder_conf }}/{{ vitam_cert.truststore_filename }}
+    keyPassword: {{ vitam_cert.password_truststore }}
+hostnameVerification: true

--- a/deployment/roles/vitamui/templates/pastis-external/ingest-external-client.conf.j2
+++ b/deployment/roles/vitamui/templates/pastis-external/ingest-external-client.conf.j2
@@ -1,0 +1,11 @@
+serverHost: {{ vitam_vars.ingest_external.host }}
+serverPort: {{ vitam_vars.ingest_external.port_service }}
+secure: true
+sslConfiguration :
+ keystore :
+  - keyPath: {{ vitamui_folder_conf }}/{{ vitam_cert.filename }}
+    keyPassword: {{ vitam_cert.password }}
+ truststore :
+  - keyPath: {{ vitamui_folder_conf }}/{{ vitam_cert.truststore_filename }}
+    keyPassword: {{ vitam_cert.password_truststore }}
+hostnameVerification: true


### PR DESCRIPTION
Correction du déploiement de Pastis External, vu que maintenant l'application accède à Vitam Core alors qu'avant ce n'était pas le cas.