### PR TITLE
Bug #13592: add validators on owner forms

### DIFF
--- a/ui/ui-frontend/projects/identity/src/app/customer/owner-form/owner-form.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/owner-form/owner-form.component.ts
@@ -41,11 +41,13 @@ import { distinctUntilChanged, map } from 'rxjs/operators';
 import { CountryOption, CountryService, Customer, Owner, StartupService } from 'vitamui-library';
 import {
   ALPHA_NUMERIC_REGEX,
+  OWNER_CITY_MAX_LENGTH,
   OWNER_CODE_MAX_LENGTH,
   OWNER_CODE_MIN_LENGTH,
   OWNER_COMPANY_NAME_MAX_LENGTH,
   OWNER_INTERNAL_CODE_MAX_LENGTH,
   OWNER_NAME_MAX_LENGTH,
+  OWNER_ZIP_CODE_MAX_LENGTH,
   OwnerFormValidators,
 } from './owner-form.validators';
 
@@ -132,8 +134,8 @@ export class OwnerFormComponent implements ControlValueAccessor, OnDestroy, OnIn
       internalCode: [null, [Validators.maxLength(OWNER_INTERNAL_CODE_MAX_LENGTH)]],
       address: this.formBuilder.group({
         street: [null, Validators.maxLength(this.maxStreetLength)],
-        zipCode: null,
-        city: null,
+        zipCode: [null, Validators.maxLength(OWNER_ZIP_CODE_MAX_LENGTH)],
+        city: [null, Validators.maxLength(OWNER_CITY_MAX_LENGTH)],
         country: 'FR',
       }),
       readonly: false,


### PR DESCRIPTION
## Description

Ajout de validateurs sur le code, company name et name dans le formulaire de gestion des owners pour prévenir une gestion d'erreur technique en back.


## Contributeur


* VAS (Vitam Accessible en Service)

