### PR TITLE
Story #13803: use units size GB instead of KB in CSV generation

### DIFF
--- a/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/accessionregister/AccessionRegisterInternalService.java
+++ b/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/accessionregister/AccessionRegisterInternalService.java
@@ -298,7 +298,7 @@ public class AccessionRegisterInternalService {
                             String.valueOf(accessionRegisterCsv.getTotalUnits().getIngested()),
                             String.valueOf(accessionRegisterCsv.getTotalObjectsGroups().getIngested()),
                             String.valueOf(accessionRegisterCsv.getTotalObjects().getIngested()),
-                            VitamUIUtils.convertSizeToKiloByte(accessionRegisterCsv.getObjectSize().getIngested()),
+                            VitamUIUtils.convertSizeToGigaByte(accessionRegisterCsv.getObjectSize().getIngested()),
                             accessionRegisterCsv.getStatus().value(),
                         }
                     );

--- a/commons/commons-utils/src/main/java/fr/gouv/vitamui/commons/utils/VitamUIUtils.java
+++ b/commons/commons-utils/src/main/java/fr/gouv/vitamui/commons/utils/VitamUIUtils.java
@@ -89,8 +89,8 @@ public final class VitamUIUtils {
 
     public static final String PRINT_ALGORITHM = "SHA-512";
 
-    public static final DecimalFormat UI_DECIMAL_FORMAT_2_DIGITS = decimalFormat2digits();
-    public static final String KILO = " ko";
+    public static final DecimalFormat UI_DECIMAL_FORMAT_6_DIGITS = decimalFormat6digits();
+    public static final String GIGA = " go";
 
     private VitamUIUtils() {
         // empty
@@ -346,19 +346,19 @@ public final class VitamUIUtils {
             .collect(Collectors.joining(", ", "[", "]"));
     }
 
-    private static DecimalFormat decimalFormat2digits() {
+    private static DecimalFormat decimalFormat6digits() {
         DecimalFormat df = new DecimalFormat();
         DecimalFormatSymbols symbols = df.getDecimalFormatSymbols();
         symbols.setGroupingSeparator(' ');
         symbols.setDecimalSeparator('.');
         df.setDecimalFormatSymbols(symbols);
-        df.setMaximumFractionDigits(2);
+        df.setMaximumFractionDigits(6);
         df.setRoundingMode(RoundingMode.HALF_UP);
         return df;
     }
 
-    public static String convertSizeToKiloByte(long sizeInBytes) {
-        double sizeInKilobytes = sizeInBytes / 1024.0;
-        return UI_DECIMAL_FORMAT_2_DIGITS.format(sizeInKilobytes) + KILO;
+    public static String convertSizeToGigaByte(long sizeInBytes) {
+        double sizeInGigaBytes = sizeInBytes / (1024.0 * 1024.0 * 1024.0);
+        return UI_DECIMAL_FORMAT_6_DIGITS.format(sizeInGigaBytes) + GIGA;
     }
 }

--- a/commons/commons-utils/src/test/java/fr/gouv/vitamui/commons/utils/VitamUIUtilsTest.java
+++ b/commons/commons-utils/src/test/java/fr/gouv/vitamui/commons/utils/VitamUIUtilsTest.java
@@ -137,13 +137,12 @@ public class VitamUIUtilsTest {
 
     @Test
     public void convertSizeToKiloByteByteCountSI() throws IOException {
-        assertEquals("638 988.83 ko", VitamUIUtils.convertSizeToKiloByte(654_324_564L));
-        assertEquals("0 ko", VitamUIUtils.convertSizeToKiloByte(0L));
-        assertEquals("0.98 ko", VitamUIUtils.convertSizeToKiloByte(1_000L));
-        assertEquals("1.17 ko", VitamUIUtils.convertSizeToKiloByte(1_200L));
-        assertEquals("76.95 ko", VitamUIUtils.convertSizeToKiloByte(78_800));
-        assertEquals("1 ko", VitamUIUtils.convertSizeToKiloByte(1_024L));
-        assertEquals("1.17 ko", VitamUIUtils.convertSizeToKiloByte(1_200L));
-        assertEquals("225.83 ko", VitamUIUtils.convertSizeToKiloByte(231_246L));
+        assertEquals("624 go", VitamUIUtils.convertSizeToGigaByte(670_014_898_176L));
+        assertEquals("0 go", VitamUIUtils.convertSizeToGigaByte(0L));
+        assertEquals("0.000001 go", VitamUIUtils.convertSizeToGigaByte(1_000L));
+        assertEquals("0.001118 go", VitamUIUtils.convertSizeToGigaByte(1_200_000L));
+        assertEquals("0.073388 go", VitamUIUtils.convertSizeToGigaByte(78_800_000));
+        assertEquals("1 go", VitamUIUtils.convertSizeToGigaByte(1_073_741_824L));
+        assertEquals("0.000215 go", VitamUIUtils.convertSizeToGigaByte(231_246L));
     }
 }


### PR DESCRIPTION
## Description

To replace size unit by GIGA byte instead of KB.


## Contributeur


* VAS (Vitam Accessible en Service)
