### PR TITLE
Story #13906: do not uninstall node anymore in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,6 @@ pipeline {
 
         stage('Upgrade build context') {
             steps {
-                sh 'sudo apt remove -y nodejs npm node-npmrc'
                 sh 'sudo apt install -y build-essential make ruby ruby-dev rubygems jq'
                 sh 'sudo timedatectl set-timezone Europe/Paris'
                 sh 'sudo gem install fpm'


### PR DESCRIPTION
## Description

node has been uninstalled on every Jenkins runner (we now use nvm-wrapper).
It is no more useful to uninstall it at every build.