### PR TITLE
CP 7.0 - Story #13791 cc: ensure mongo scripts are played in order

### DIFF
--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -69,7 +69,7 @@
     delegate_to: localhost
     set_fact:
       mongod_eligible_files : "{{ (mongod_eligible_files| default([])) + [ {'name': item, 'version': item | regex_replace('^(.+)/(.+)$', '\\1') ,'finalname': 'vitamui_' + item | regex_replace('/', '_') | basename | regex_replace('\\.j2$')} ] }}"
-    loop: "{{ mongod_files | difference(mongod_excluded_files| default([])) }}"
+    loop: "{{ mongod_files | difference(mongod_excluded_files| default([])) | sort }}" # Difference filter documentation states 'Items in the resulting list are returned in arbitrary order'. This is a workaround
 
   # We generate scripts and upload on remote host
   - name: Compute and copy script files


### PR DESCRIPTION
* Backport commit: https://github.com/ProgrammeVitam/vitam-ui/pull/1664/commits/1a1cd9263acdbe2f706fa4218a7a69bc27640fb5

Ensure that scripts are sorted by version, as the difference filter does not guarantee the order (https://docs.ansible.com/ansible/latest/collections/ansible/builtin/difference_filter.html#ansible-collections-ansible-builtin-difference-filter - "Items in the resulting list are returned in arbitrary order")