### PR TITLE
DS #14097: Fix start/stop vitamui playbooks for mongo-express component

### DIFF
--- a/deployment/ansible-vitamui-exploitation/start_vitamui.yml
+++ b/deployment/ansible-vitamui-exploitation/start_vitamui.yml
@@ -69,7 +69,7 @@
   gather_facts: no
   roles:
     - { role: service_state, when: "mongo_express_enabled | default(false) | bool == true" }
-    - check_port
+    - { role: check_port, when: "mongo_express_enabled | default(false) | bool == true" }
   vars:
     vitamui_struct:
       vitamui_component: "{{ mongo_express.vitamui_component }}"

--- a/deployment/ansible-vitamui-exploitation/stop_vitamui.yml
+++ b/deployment/ansible-vitamui-exploitation/stop_vitamui.yml
@@ -285,7 +285,7 @@
   gather_facts: no
   roles:
     - { role: service_state, when: "mongo_express_enabled | default(false) | bool == true" }
-    - check_port
+    - { role: check_port, when: "mongo_express_enabled | default(false) | bool == true" }
   vars:
     vitamui_struct:
       vitamui_component: "{{ mongo_express.vitamui_component }}"


### PR DESCRIPTION
## Description

Correction des playbooks de start/stop_vitamui pour le composant mongo-express. Autrement l'exécution reste bloquée si le composant n'est pas déployé.

## Type de changement

* Ansiblerie
* Correction