### PR TITLE
CP 8.0 - Bugs #11662: collect app needs ROLE_GET_UNITS to access trees and plans

### DIFF
--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -288,6 +288,7 @@ customer-init:
         - ROLE_COLLECT_GET_ARCHIVE_SEARCH
         - ROLE_COLLECT_GET_ARCHIVE_BINARY
         - ROLE_GET_FILLING_PLAN_ACCESS
+        - ROLE_GET_UNITS
 
 
     - name: Archiviste - gestion et collecte
@@ -313,6 +314,7 @@ customer-init:
         - ROLE_COLLECT_GET_ARCHIVE_SEARCH
         - ROLE_COLLECT_GET_ARCHIVE_BINARY
         - ROLE_GET_FILLING_PLAN_ACCESS
+        - ROLE_GET_UNITS
 
     - name: Service producteur
       description: Profil de préparation des versements des archives sans possibilité de transmettre les archives au SAE
@@ -333,6 +335,7 @@ customer-init:
         - ROLE_COLLECT_GET_ARCHIVE_SEARCH
         - ROLE_COLLECT_GET_ARCHIVE_BINARY
         - ROLE_GET_FILLING_PLAN_ACCESS
+        - ROLE_GET_UNITS
 
     - name: Profil pour les contrats de gestion
       description: Contrats de gestion

--- a/deployment/scripts/mongod/v7.1/63_collect_missing_role.js.j2
+++ b/deployment/scripts/mongod/v7.1/63_collect_missing_role.js.j2
@@ -1,0 +1,18 @@
+db = db.getSiblingDB('iam');
+dbSecurity = db.getSiblingDB('security');
+
+print('START 63_collect_missing_role.js');
+
+// ---- ROLE_GET_UNITS will be added to profiles including COLLECT_APP --- //
+
+db.profiles.updateMany(
+    { 'applicationName': 'COLLECT_APP' },
+    { '$addToSet': { 'roles': { $each: [{ 'name': 'ROLE_GET_UNITS' }] } } }
+);
+
+dbSecurity.contexts.updateOne(
+    { '_id': 'ui_collect_context' },
+    { $addToSet: { 'roleNames': 'ROLE_GET_UNITS' } }
+);
+
+print('END 63_collect_missing_role.js');


### PR DESCRIPTION
L'application collect doit pouvoir accéder aux units d'arbres et plans situées dans le menu de gauche. Pour cela, elle appelle le point d'accès `/units/{id}` sur referential, qui nécessite le rôle `ROLE_GET_UNITS`.