### PR TITLE
CP 7.1 - Bugs #11662: collect app needs ROLE_GET_UNITS to access trees and plans

### DIFF
--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -293,6 +293,7 @@ customer-init:
         - ROLE_UPDATE_UNITS_METADATA
         - ROLE_GET_SCHEMAS
         - ROLE_UPDATE_UNIT_DESC_METADATA
+        - ROLE_GET_UNITS
 
     - name: Profil pour les contrats de gestion
       description: Contrats de gestion

--- a/deployment/scripts/mongod/v7.1/63_collect_missing_role.js.j2
+++ b/deployment/scripts/mongod/v7.1/63_collect_missing_role.js.j2
@@ -1,0 +1,18 @@
+db = db.getSiblingDB('iam');
+dbSecurity = db.getSiblingDB('security');
+
+print('START 63_collect_missing_role.js');
+
+// ---- ROLE_GET_UNITS will be added to profiles including COLLECT_APP --- //
+
+db.profiles.updateMany(
+    { 'applicationName': 'COLLECT_APP' },
+    { '$addToSet': { 'roles': { $each: [{ 'name': 'ROLE_GET_UNITS' }] } } }
+);
+
+dbSecurity.contexts.updateOne(
+    { '_id': 'ui_collect_context' },
+    { $addToSet: { 'roleNames': 'ROLE_GET_UNITS' } }
+);
+
+print('END 63_collect_missing_role.js');


### PR DESCRIPTION
L'application collect doit pouvoir accéder aux units d'arbres et plans situées dans le menu de gauche. Pour cela, elle appelle le point d'accès `/units/{id}` sur referential, qui nécessite le rôle `ROLE_GET_UNITS`.