### PR TITLE
CP 6 - Bugs #14101: return 400 on error from backend instead of 200

### DIFF
--- a/api/api-referential/referential-internal-client/src/main/java/fr/gouv/vitamui/referential/internal/client/ProfileInternalRestClient.java
+++ b/api/api-referential/referential-internal-client/src/main/java/fr/gouv/vitamui/referential/internal/client/ProfileInternalRestClient.java
@@ -137,7 +137,14 @@ public class ProfileInternalRestClient extends BasePaginatingAndSortingRestClien
         bodyMap.add("file", new FileSystemResource(profileFile.getBytes(), profileFile.getOriginalFilename()));
 
         final HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(bodyMap, buildHeaders(context));
-        return restTemplate.exchange(uriBuilder.build(id), HttpMethod.PUT, request, JsonNode.class);
+        ResponseEntity<JsonNode> response = restTemplate.exchange(
+            uriBuilder.build(id),
+            HttpMethod.PUT,
+            request,
+            JsonNode.class
+        );
+        checkResponse(response);
+        return response;
     }
 
     public static class FileSystemResource extends ByteArrayResource {


### PR DESCRIPTION
Appelle checkResponse sur la réponse de ProfileInternal/updateProfileFile pour permettre d'envoyer une erreur 400 s'il y a eu une erreur du back. Sinon l'erreur est avalée silencieusement et l'appel renvoie un code 200.

A été corrigé en 8.0 lors des travaux de mise à jour de Pastis, mais n'avait pas été backporté, apparemment.