### PR TITLE
Story #13791 clean code: add GitHub Action to generate design system and publish it on GitHub Pages

### DIFF
--- a/.github/actions/update-gh-pages-index/action.yml
+++ b/.github/actions/update-gh-pages-index/action.yml
@@ -1,0 +1,43 @@
+name: Update index.html
+description: "Update the index.html file to reflect available branch directories"
+inputs:
+  branch_to_delete:
+    description: "Name of the branch to delete (optional)"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Clone the gh-pages branch
+      run: |
+        git config --global user.name "${{ github.actor }}"
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git clone --depth 1 --branch gh-pages https://github.com/${{ github.repository }} gh-pages
+      shell: bash
+    - name: Remove directory for deleted branch (if applicable)
+      if: inputs.branch_to_delete != ''
+      run: |
+        cd gh-pages
+        rm -rf "${{ inputs.branch_to_delete }}/"
+    - name: Update the index.html file
+      run: |
+        cd gh-pages
+        # Generate the index.html
+        echo '<!DOCTYPE html>' > index.html
+        echo "<html lang='en'>" >> index.html
+        echo "<head><meta charset='UTF-8'><title>Available Design System versions</title></head>" >> index.html
+        echo "<body><h1>Available Design System versions</h1><ul>" >> index.html
+        for dir in */; do
+          echo "<li><a href='${dir}'>${dir}</a></li>" >> index.html
+        done
+        echo "</ul></body></html>" >> index.html
+      shell: bash
+    - name: Commit and push changes
+      run: |
+        cd gh-pages
+        git add index.html
+        if [ -n "${{ inputs.branch_to_delete }}" ]; then
+          git add "${{ inputs.branch_to_delete }}" || echo "Directory already deleted"
+        fi
+        git commit -m "Update index.html" || echo "No changes to commit"
+        git push origin gh-pages
+      shell: bash

--- a/.github/workflows/publish-design-system.yml
+++ b/.github/workflows/publish-design-system.yml
@@ -1,0 +1,34 @@
+name: Publish design system
+run-name: Publishing design system for branch ${{ github.ref }}
+on: workflow_dispatch
+jobs:
+  build-and-publish-design-system:
+    name: Build design system
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.20.3"
+          cache: "npm"
+          cache-dependency-path: |
+            ui/ui-frontend/package-lock.json
+      - name: Install ui-frontend dependencies
+        working-directory: ui/ui-frontend
+        run: npm ci
+      - name: Build vitamui-library
+        working-directory: ui/ui-frontend
+        run: npm run build:vitamui-library
+      - name: Build design-system app
+        working-directory: ui/ui-frontend
+        run: npm run build:design-system -- --base-href=/vitam-ui/${{ github.ref_name }}/ --deploy-url=/vitam-ui/${{ github.ref_name }}/
+      - name: Publish design system to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ui/ui-frontend/dist/design-system/browser
+          destination_dir: ${{ github.ref_name }}
+          keep_files: true
+          allow_empty_commit: false
+      - name: Update index.html
+        uses: ./.github/actions/update-gh-pages-index

--- a/.github/workflows/unpublish-design-system.yml
+++ b/.github/workflows/unpublish-design-system.yml
@@ -1,0 +1,16 @@
+name: Unpublish design system
+run-name: Unpublishing design system for branch ${{ github.ref }}
+on: delete
+jobs:
+  unpublish-design-system:
+    name: Unpublish design system
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract branch name
+        run: echo "branch_name=${GITHUB_REF##refs/heads/}" >> $GITHUB_ENV
+      - name: Update index.html and remove branch directory
+        uses: ./.github/actions/update-gh-pages-index
+        with:
+          branch_to_delete: ${{ env.branch_name }}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/select-language/select-language.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/select-language/select-language.component.html
@@ -2,12 +2,12 @@
 
 <ng-template #button>
   <button mat-mini-fab class="flag-button" [matMenuTriggerFor]="menu" aria-label="flag">
-    <img [src]="'../../../assets/country/' + currentLang + '.svg'" />
+    <img [src]="'assets/country/' + currentLang + '.svg'" />
   </button>
 
   <mat-menu #menu="matMenu" [overlapTrigger]="false" xPosition="before">
-    <span mat-menu-item (click)="use(minLangString.FR)"> FR<img src="../../../assets/country/fr.svg" /> </span>
-    <span mat-menu-item (click)="use(minLangString.EN)"> EN<img src="../../../assets/country/en.svg" /> </span>
+    <span mat-menu-item (click)="use(minLangString.FR)"> FR<img src="assets/country/fr.svg" /> </span>
+    <span mat-menu-item (click)="use(minLangString.EN)"> EN<img src="assets/country/en.svg" /> </span>
   </mat-menu>
 </ng-template>
 


### PR DESCRIPTION
Le but de cette MR est d'ajouter 2 GitHub Actions :
- une de publication du design system, déclenchée manuellement depuis l'onglet "Actions" de GitHub (avec choix de la branche sur laquelle on souhaite exécuter l'action). Elle build le design-system, publie les fichiers générés dans la branche gh-pages (GitHub Pages) sous un dossier portant le nom de la branche et met à jour l'`index.html` à la racine de gh-pages afin de lister tous les design-system disponibles (1 pour chaque branche sur laquelle on a exécuté cette action)
- une de suppression du design system, déclenchée automatiquement à la suppression d'une branche. Elle supprime le dossier correspondant à la branche dans gh-pages et met à jour l'`index.html`

L'action de publication de design system n'est pas testable tant qu'elle n'est pas mergée sur la branche principale (develop) car elle n'y apparaîtra dans les "Actions" qu'une fois mergée. 

Le résultat (le site web correspondant aux sources sur la branche gh-pages) sera disponible sur https://programmevitam.github.io/vitam-ui (redirigé vers https://www.programmevitam.fr/vitam-ui/).