### PR TITLE
Bug #13909: Refreshing issue with the title when creating a PA or PUA.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/profile.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/profile.service.ts
@@ -225,6 +225,7 @@ export class ProfileService implements OnDestroy {
 
   createProfile(path: string, type: ProfileType, version: ProfileVersion): Observable<ProfileResponse> {
     const params = new HttpParams().set('type', type).set('version', version);
+    this.profileType = type;
     return this.apiService.get<ProfileResponse>(path, { params });
   }
 


### PR DESCRIPTION
Corrige un problème avec un titre incorrect dans le chemin de fer (breadcrumbs) qui ne prend pas en compte le type de profil pour afficher le message (PA ou PUA).