### PR TITLE
Story #13791 clean code: use hash location strategy on design system

### DIFF
--- a/ui/ui-frontend/projects/design-system/src/app/app-routing.module.ts
+++ b/ui/ui-frontend/projects/design-system/src/app/app-routing.module.ts
@@ -58,6 +58,7 @@ import { DesignSystemOldInputsComponent } from './components/molecules/inputs/ol
 import { DesignSystemRepeatableInputComponent } from './components/molecules/inputs/repeatable-input/design-system-repeatable-input.component';
 import { DesignSystemSearchWithTypeSelectorComponent } from './components/molecules/inputs/search-with-type-selector/design-system-search-with-type-selector.component';
 import { DesignSystemMultipleOptionsDatepickerComponent } from './components/molecules/inputs/multiple-options-datepicker/design-system-multiple-options-datepicker.component';
+import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 
 const routes: Routes = [
   { path: '', component: DesignSystemComponent },
@@ -122,5 +123,6 @@ const routes: Routes = [
     }),
   ],
   exports: [RouterModule],
+  providers: [{ provide: LocationStrategy, useClass: HashLocationStrategy }],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
It'll allow reloading the same page on GitHub Pages (as GH Pages doesn't have a feature to return the root index.html page when reloading a deep page)