### PR TITLE
Bug #14090: put back access contract id in filling plan service

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-create/access-contract-create.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-create/access-contract-create.component.html
@@ -170,12 +170,8 @@
           </vitamui-common-slide-toggle>
         </div>
 
-        <div *ngIf="!!allNodes.value && !allNodes.value">
-          <vitamui-library-filing-plan
-            [formControl]="selectNodesControl"
-            [tenantIdentifier]="tenantIdentifier"
-            [mode]="FILLING_PLAN_MODE.BOTH"
-          ></vitamui-library-filing-plan>
+        <div *ngIf="!allNodes.value">
+          <vitamui-library-filing-plan [formControl]="selectNodesControl" [mode]="FILLING_PLAN_MODE.BOTH"></vitamui-library-filing-plan>
         </div>
 
         <div class="actions">

--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-create/access-contract-create.component.spec.ts
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-create/access-contract-create.component.spec.ts
@@ -138,6 +138,7 @@ describe('AccessContractCreateComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AccessContractCreateComponent);
     component = fixture.componentInstance;
+    component.allNodes.setValue(true);
     fixture.detectChanges();
     page = new Page();
   });
@@ -208,6 +209,7 @@ describe('AccessContractCreateComponent', () => {
 
     it('should not call create()', () => {
       const accessContractService = TestBed.inject(AccessContractService);
+      component.allNodes.setValue(false);
       component.onSubmit();
       expect(accessContractService.create).toHaveBeenCalledTimes(0);
     });

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/filing-plan/filing-plan.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/filing-plan/filing-plan.service.ts
@@ -37,14 +37,15 @@
 
 import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
-import { Observable, of } from 'rxjs';
+import { Observable, of, switchMap } from 'rxjs';
 import { catchError, map, shareReplay, tap } from 'rxjs/operators';
-import { FileType, Unit, UnitType } from '../../../app/modules';
+import { AccessContractService, FileType, Unit, UnitType, VitamuiHttpHeaders } from '../../../app/modules';
 import { SearchUnitApiService } from '../../api/search-unit-api.service';
 import { DescriptionLevel } from '../../models/description-level.enum';
 import { Node } from '../../models/node.interface';
 
 import { getKeywordValue } from '../../utils/keyword.util';
+import { HttpHeaders } from '@angular/common/http';
 
 export enum ExpandLevel {
   NONE,
@@ -66,6 +67,7 @@ export class FilingPlanService {
 
   constructor(
     private searchUnitApi: SearchUnitApiService,
+    private accessContractService: AccessContractService,
     @Inject(LOCALE_ID) private locale: string,
   ) {}
 
@@ -79,7 +81,9 @@ export class FilingPlanService {
 
   public loadTree(idPrefix: string): Observable<Node[]> {
     this._pending++;
-    return this.searchUnitApi.getFilingPlan().pipe(
+    return this.accessContractService.currentAccessContractId$.pipe(
+      map((accessContractId) => new HttpHeaders().set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContractId)),
+      switchMap((headers) => this.searchUnitApi.getFilingPlan(headers)),
       catchError(() => of({ $hits: null, $results: [] })),
       map((response) => response.$results),
       tap(() => this._pending--),


### PR DESCRIPTION
## Description

L'access contract ID avait été retiré des requètes  pour récupérer l'arborescence.     
Et lors de la création de contract d'access l'arborescence ne s'affichait plus