### PR TITLE
CP V7.1 - DS #14157: Fix lookup syntax.

### DIFF
--- a/deployment/roles/uninstall/tasks/main.yml
+++ b/deployment/roles/uninstall/tasks/main.yml
@@ -2,4 +2,4 @@
 
 - name: "Execute uninstall for {{ uninstaller_type }}"
   include_tasks: "{{ uninstaller_type }}.yml"
-  when: "{{ lookup('pipe', 'test -f {{ role_path }}/tasks/{{ uninstaller_type }}.yml || echo nofile') == \"\" }}"
+  when: lookup('pipe', 'test -f {{ role_path }}/tasks/{{ uninstaller_type }}.yml || echo nofile') == ''

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -143,7 +143,9 @@
     owner: "{{ vitamui_defaults.users.vitamui | default('vitamui') }}"
     group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
     mode: "{{ vitamui_defaults.folder.folder_permission | default('0750') }}"
-  when: "( vitamui_struct.secure | default(secure) | lower == 'true' ) and ({{ lookup('pipe', 'test -f {{ inventory_dir }}/keystores/server/{{ inventory_hostname }}/keystore_{{ vitamui_struct.vitamui_component }}.jks || echo nofile') == \"\" }})"
+  when:
+    - vitamui_struct.secure | default(secure) | lower == 'true'
+    - lookup('pipe', 'test -f {{ inventory_dir }}/keystores/server/{{ inventory_hostname }}/keystore_{{ vitamui_struct.vitamui_component }}.jks || echo nofile') == ''
   tags:
     - update_vitamui_certificates
   notify:
@@ -159,9 +161,8 @@
     mode: "{{ vitamui_defaults.folder.folder_permission | default('0750') }}"
   when:
     - vitamui_struct.secure | default(secure) | lower == 'true'
-    - vitamui_certificate_type is defined
-    - "vitamui_certificate_type|lower == 'server'"
-    - "{{ lookup('pipe', 'test -f {{ inventory_dir }}/keystores/server/truststore_server.jks || echo nofile') == \"\" }}"
+    - vitamui_certificate_type | default('none') | lower == 'server'
+    - lookup('pipe', 'test -f {{ inventory_dir }}/keystores/server/truststore_server.jks || echo nofile') == ''
   tags:
     - update_vitamui_certificates
   notify:
@@ -177,9 +178,8 @@
     mode: "{{ vitamui_defaults.folder.folder_permission | default('0750') }}"
   when:
     - vitamui_struct.secure | default(secure) | lower == 'true'
-    - vitamui_certificate_type is defined
-    - "vitamui_certificate_type|lower == 'external'"
-    - "{{ lookup('pipe', 'test -f {{ inventory_dir }}/keystores/client-{{ vitamui_certificate_type }}/truststore_{{ vitamui_certificate_type }}.jks || echo nofile') == \"\" }}"
+    - vitamui_certificate_type | default('none') | lower == 'external'
+    - lookup('pipe', 'test -f {{ inventory_dir }}/keystores/client-{{ vitamui_certificate_type }}/truststore_{{ vitamui_certificate_type }}.jks || echo nofile') == ''
   tags:
     - update_vitamui_certificates
   notify:
@@ -187,7 +187,7 @@
 
 - name: "Execute sub-tasks for the component: {{ vitamui_struct.vitamui_component }}"
   include_tasks: "{{ vitamui_struct.vitamui_component }}.yml"
-  when: "{{ lookup('pipe', 'test -f {{ role_path }}/tasks/{{ vitamui_struct.vitamui_component }}.yml || echo nofile') == \"\" }}"
+  when: lookup('pipe', 'test -f {{ role_path }}/tasks/{{ vitamui_struct.vitamui_component }}.yml || echo nofile') == ''
 
 - meta: flush_handlers
   tags:


### PR DESCRIPTION
## Description

> Cherry-pick PR #2394

Erreur constatée:

```
TASK [vitamui : Copy vitamui-api-gateway jks keystore (server)] *********************************************************
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: ( vitamui_struct.secure | default(secure) | lower == 'true' ) and ({{ lookup('pipe', 'test -f {{ inventory_dir }}/keystores/server/{{ inventory_hostname }}/keystore_{{ vitamui_struct.vitamui_component }}.jks || echo nofile') == "" }})
fatal: [test-vm]: FAILED! => {"msg": "The conditional check '( vitamui_struct.secure | default(secure) | lower == 'true' ) and ({{ lookup('pipe', 'test -f {{ inventory_dir }}/keystores/server/{{ inventory_hostname }}/keystore_{{ vitamui_struct.vitamui_component }}.jks || echo nofile') == \"\" }})' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated.\n\nThe error appears to be in '/var/tmp/vitam-ui-8.0.0/deployment/roles/vitamui/tasks/main.yml': line 139, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Copy {{ vitamui_struct.service_name | default(service_name) }} jks keystore (server)\"\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes. Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
```

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)