### PR TITLE
CP V8.0 - Bug #13909: Refreshing issue with the title when creating a PA or PUA.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/profile.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/profile.service.ts
@@ -189,6 +189,7 @@ export class ProfileService implements OnDestroy {
 
   createProfile(path: string, type: ProfileType, version: ProfileVersion): Observable<ProfileResponse> {
     const params = new HttpParams().set('type', type).set('version', version);
+    this.profileType = type;
     return this.apiService.get<ProfileResponse>(path, { params });
   }
 


### PR DESCRIPTION
MAJ le titre de l'en-tête dynamiquement pour refléter correctement le type de profil sélectionné (PA ou PUA).