### PR TITLE
bug #14207 : Reclassification pull error

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/reclassification/reclassification.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/reclassification/reclassification.component.ts
@@ -210,6 +210,8 @@ export class ReclassificationComponent implements OnInit, OnDestroy {
       this.totalChilds +
       this.space +
       this.translateService.instant('RECLASSIFICATION.FIRST_STEP.CHILDS');
+
+    this.actions.find((action) => action.key === PULL).disabled = !this.archiveUnitAllunitup.length;
   }
 
   public getStepCount() {


### PR DESCRIPTION
## Description

L'opération "Retirer du dossier parent" du reclassement finit en erreur 500 car la ou les unités archivistiques sélectionnées n'ont aucun rattachement. Suite à un point avec Isabelle, il a été décidé de désactiver cette option si les UA sélectionnées n'ont aucun rattachement

## Type de changement

* Correction
