### PR TITLE
bug #14260 : Reclassification - Pull and Replace options

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/reclassification/reclassification.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/reclassification/reclassification.component.ts
@@ -211,7 +211,9 @@ export class ReclassificationComponent implements OnInit, OnDestroy {
       this.space +
       this.translateService.instant('RECLASSIFICATION.FIRST_STEP.CHILDS');
 
-    this.actions.find((action) => action.key === PULL).disabled = !this.archiveUnitAllunitup.length;
+    this.actions
+      .filter((action) => action.key === REPLACE || action.key === PULL)
+      .map((action) => (action.disabled = !this.archiveUnitAllunitup.length));
   }
 
   public getStepCount() {

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -493,6 +493,9 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
   }
 
   submit() {
+    this.listOfUAIdToInclude = [];
+    this.listOfUAIdToExclude = [];
+
     this.archiveSharedDataService.emitSelectedUnit(null);
     this.initializeSelectionParams();
     this.archiveHelperService.buildNodesListForQUery(this.searchCriterias, this.criteriaSearchList);


### PR DESCRIPTION
## Description

- Option "Déplacer vers un autre dossier" grisée si les UA sélectionnées n'ont pas de parents
- Lors d'un reclassement, des dossiers parents étaient listés pour des UA qui n'en avait pas


