### PR TITLE
Bugs #14132: disable spring security for pastis standalone

### DIFF
--- a/api/api-pastis/pastis-standalone/README.md
+++ b/api/api-pastis/pastis-standalone/README.md
@@ -28,4 +28,4 @@ Pour démarrer l'application en mode production
         ./build.sh
         ./run.sh (pour tester pastis standalone)
         
-        l'executable windows peut etre récupéré dans api/api-pastis/pastis-standalone/target/pastis-standalone-{verion}-package.zip
+        l'executable windows peut etre récupéré dans api/api-pastis/pastis-standalone/target/pastis-standalone-{version}-package.zip

--- a/api/api-pastis/pastis-standalone/src/main/java/fr/gouv/vitamui/pastis/standalone/ApiPastisStandaloneApplication.java
+++ b/api/api-pastis/pastis-standalone/src/main/java/fr/gouv/vitamui/pastis/standalone/ApiPastisStandaloneApplication.java
@@ -51,7 +51,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-@SpringBootApplication
+@SpringBootApplication(
+    exclude = {
+        org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class,
+        org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration.class,
+    }
+)
 public class ApiPastisStandaloneApplication extends SpringBootServletInitializer {
 
     private final PastisConfiguration pastisConfiguration;


### PR DESCRIPTION
Désactivation de l'autoconfiguration spring security pour Pastis standalone, pour ne pas avoir la fenêtre de login au démarrage.