### PR TITLE
CP V8.0 - Bug #13184: Set Filebeat ignore_older's limitation

### DIFF
--- a/deployment/roles/filebeat/defaults/main.yml
+++ b/deployment/roles/filebeat/defaults/main.yml
@@ -17,6 +17,8 @@ filebeat_log:
   keepfiles: 30
 
 filebeat:
+  config:
+    ignore_older: "24h"
   system:
     enable_log: false
     enable_auth: false

--- a/deployment/roles/filebeat/templates/inputs/cots.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/cots.yml.j2
@@ -8,6 +8,7 @@
   enabled: true
   paths:
     - "{{ vitam_defaults.folder.root_path }}/log/consul/consul*.log"
+  ignore_older: {{ filebeat.config.ignore_older }}
   fields_under_root: true
   fields:
     kind: log

--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -10,6 +10,7 @@
   enabled: true
   paths:
     - "{{ vitamui_defaults.folder.root_path }}/log/{{ vitamui_component }}/accesslog-{{ vitamui_component }}.*.log"
+  ignore_older: {{ filebeat.config.ignore_older }}
   fields_under_root: true
   fields:
     kind: access
@@ -60,6 +61,7 @@
   enabled: true
   paths:
     - "{{ vitamui_defaults.folder.root_path }}/log/{{ vitamui_component }}/management_accesslog-{{ vitamui_component }}.*.log"
+  ignore_older: {{ filebeat.config.ignore_older }}
   fields_under_root: true
   fields:
     kind: management
@@ -96,6 +98,7 @@
   enabled: true
   paths:
     - "{{ vitamui_defaults.folder.root_path }}/log/{{ vitamui_component }}/{{ vitamui_component }}.*.log"
+  ignore_older: {{ filebeat.config.ignore_older }}
   fields_under_root: true
   fields:
     kind: log


### PR DESCRIPTION
## Description

> Cherry-Pick from #2465

* This PR introduces a parameterized ignore_older setting in Filebeat, allowing greater flexibility in log retention policies. Now, it can be customized via the Ansible role's configuration to better fit different use cases.

## Type de changement

* Ansiblerie


## Contributeur

* Programme vitam

