### PR TITLE
CP V7.1 - Bug #14353: Add missing iam-external component from container build.

### DIFF
--- a/Jenkinsfile.containers
+++ b/Jenkinsfile.containers
@@ -53,6 +53,7 @@ pipeline {
                     def dockerImages = [
                         '$SERVICE_DOCKER_PUSH_URL/vitamui/security-internal',
                         '$SERVICE_DOCKER_PUSH_URL/vitamui/iam-internal',
+                        '$SERVICE_DOCKER_PUSH_URL/vitamui/iam-external',
                         '$SERVICE_DOCKER_PUSH_URL/vitamui/referential-external',
                         '$SERVICE_DOCKER_PUSH_URL/vitamui/referential-internal',
                         '$SERVICE_DOCKER_PUSH_URL/vitamui/ingest-internal',


### PR DESCRIPTION
## Description

Le composant iam-external semble manquant du build des containers.

## Type de changement

* Build
* Correction

## Contributeur

* Programme Vitam
