### PR TITLE
Bug #14221: Fix wrong drop message.

### DIFF
--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -29,7 +29,7 @@
         test:
           - '2024-09-30 13:46:37,298'
     - drop_fields:
-        fields: ["date_time", "message"]
+        fields: ["date_time"]
       {% if filebeat.drop_health_checks_logs | default(true) | bool %}
     # Drop health checks
     - drop_event:
@@ -51,7 +51,7 @@
         test:
           - '30/Sep/2024:13:46:37 +0200'
     - drop_fields:
-        fields: ["date_time", "message"]
+        fields: ["date_time"]
     {% endif %}
 
   {% endif %}
@@ -79,7 +79,7 @@
         test:
           - '30/Sep/2024:13:46:37 +0200'
     - drop_fields:
-        fields: ["date_time", "message"]
+        fields: ["date_time"]
     {% if filebeat.drop_health_checks_logs | default(true) | bool %}
     # Drop health checks
     - drop_event:


### PR DESCRIPTION
## Description

For accesslogs, the message is used in dashboards and must not be dropped.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam