### PR TITLE
CP V7.0 - Bug #14358: Do not build pastis-standalone in rpm or deb format.

### DIFF
--- a/api/api-pastis/pastis-standalone/pom.xml
+++ b/api/api-pastis/pastis-standalone/pom.xml
@@ -19,7 +19,7 @@
     <java.version>11</java.version>
     <angular.base.href>/</angular.base.href>
     <angular.build.project>pastis</angular.build.project>
-    <rpm.skip>false</rpm.skip>
+    <rpm.skip>true</rpm.skip>
     <sonar.sources>src/main/java</sonar.sources>
     <swagger.dir>ui</swagger.dir>
     <swagger.skip>false</swagger.skip>


### PR DESCRIPTION
## Description

> Cherry-Pick from #2475

pastis-standalone is a desktop application, there is no needs to install it on rpm/deb servers.

## Type de changement

* Build
* Correction

## Contributeur

* Programme Vitam