### PR TITLE
Story #14223: show other search types than strict without translation

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/simple-criteria-search/simple-criteria-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/simple-criteria-search/simple-criteria-search.component.ts
@@ -283,7 +283,10 @@ export class SimpleCriteriaSearchComponent implements OnInit {
     const customSearchTypes = schema.find((s) => s.item.ApiPath === path).item.CustomSearchTypes;
     return customSearchTypes?.length
       ? ['', ...customSearchTypes].map((type) => ({
-          label: this.translateService.instant(`ARCHIVE_SEARCH.SEARCH_CRITERIA_FILTER.SEARCH_TYPES.${type}`),
+          label:
+            type === 'Strict' || type === ''
+              ? this.translateService.instant(`ARCHIVE_SEARCH.SEARCH_CRITERIA_FILTER.SEARCH_TYPES.${type}`)
+              : type,
           value: type,
         }))
       : [];


### PR DESCRIPTION
## Description

Exclude other search types from translation


## Contributeur


* VAS (Vitam Accessible en Service)
