### PR TITLE
CP V8.0 - Bug #14379: Fix event when the step is empty.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/event-type-label/event-type-label.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/event-type-label/event-type-label.component.html
@@ -1,1 +1,1 @@
-<span class="history-event-type">{{ 'EVENT_TYPE_LABEL.' + key | translate }} </span>
+<span class="history-event-type">{{ key?.length ? ('EVENT_TYPE_LABEL.' + key | translate) : '' }}</span>


### PR DESCRIPTION
## Description

> Cherry-Pick from #2496

Lors de la consultation d'une opération terminée dans le panneau latéral de l'application **Gestion des opérations**, les champs **Dernière étape jouée** et **Prochaine étape** affichent une clé non traduite `EVENT_TYPE_LABEL.` lorsque l'API ne retourne aucune valeur pour ces étapes.

### Comportement constaté

Dans l'application **Gestion des opérations**, lorsque l'utilisateur consulte une opération terminée via le panneau latéral, deux champs sont affichés :

*   **Dernière étape jouée**
*   **Prochaine étape**

Si l'API **referential/referential-api/logbook-management-operation/operations** retourne : `{ "nextStep": "", "previousStep": "" }`

Alors, au lieu de ne rien afficher, une clé non traduite `EVENT_TYPE_LABEL.` apparaît dans l'interface.

### Comportement attendu

Lorsque les valeurs **nextStep** et **previousStep** sont vides (`""`), les champs **Dernière étape jouée** et **Prochaine étape** ne doivent pas être affichés ou doivent rester vides.

## Type de changement

* Correction

## Contributeur

* Programme Vitam