### PR TITLE
Story #14128: fix subrogation

### DIFF
--- a/api/api-iam/iam-commons/src/main/java/fr/gouv/vitamui/iam/common/dto/SubrogationDto.java
+++ b/api/api-iam/iam-commons/src/main/java/fr/gouv/vitamui/iam/common/dto/SubrogationDto.java
@@ -36,6 +36,7 @@
  */
 package fr.gouv.vitamui.iam.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import fr.gouv.vitamui.commons.api.domain.IdDto;
 import fr.gouv.vitamui.iam.common.enums.SubrogationStatusEnum;
 import lombok.EqualsAndHashCode;
@@ -65,6 +66,8 @@ public class SubrogationDto extends IdDto {
     @NotNull
     private SubrogationStatusEnum status;
 
+    // Somehow the date is serialized to number instead of iso date.
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
     private Instant date;
 
     @NotNull


### PR DESCRIPTION
La date de fin du subrogation renvoyée par le service était sous forme numérique au lieu d'une chaîne au format ISO.

Il faudrait regarder pourquoi, mais pour l'instant on va faire ça...