### PR TITLE
Fix #14424: fix missing access contract authorizations in creation

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-authorizations-tab/access-contract-authorizations-update/access-contract-authorizations-update.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-authorizations-tab/access-contract-authorizations-update/access-contract-authorizations-update.component.html
@@ -130,7 +130,7 @@
       <button type="button" class="btn cancel link" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
     } @else {
       <div>
-        <vitamui-next-step [disabled]="form.errors"></vitamui-next-step>
+        <vitamui-next-step [disabled]="form.errors" (click)="onValidate()"></vitamui-next-step>
         <button type="button" class="btn cancel link" (click)="onCancel()">{{ 'COMMON.UNDO' | translate }}</button>
       </div>
       <vitamui-previous-step></vitamui-previous-step>

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/next-step/next-step.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/next-step/next-step.component.html
@@ -1,3 +1,3 @@
-<button type="button" class="btn primary" [disabled]="disabled" (click)="stepper.next()">
+<button type="button" class="btn primary" [disabled]="disabled" (click)="stepper.next(); click.next($event)">
   {{ 'COMMON.NEXT' | translate }}
 </button>

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/next-step/next-step.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/next-step/next-step.component.ts
@@ -34,7 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Component, HostBinding, inject, Input } from '@angular/core';
+import { Component, EventEmitter, HostBinding, inject, Input, Output } from '@angular/core';
 import { CdkStepper } from '@angular/cdk/stepper';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -50,6 +50,9 @@ export class NextStepComponent {
    * A reference to the CdkStepper instance. It is automatically injected by Angular if the component is a child of vitamui-common-stepper. Otherwise, a reference must be provided.
    */
   @Input() stepper: CdkStepper = inject(CdkStepper, { optional: true });
+
+  // eslint-disable-next-line @angular-eslint/no-output-native
+  @Output() click = new EventEmitter();
 
   @HostBinding('style.display')
   get display(): string {


### PR DESCRIPTION
## Description

L'appel à `onValidate()` avait été perdu lors de la suppression d'Angular Material Legacy

## Type de changement

* Correction

## Tests

* manuel

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)
