### PR TITLE
Bug #13477 [Modify AU with PUA] Alert messages are neither identical nor compliant.

### DIFF
--- a/ui/ui-frontend/projects/design-system/src/app/components/molecules/inputs/repeatable-input/design-system-repeatable-input.component.html
+++ b/ui/ui-frontend/projects/design-system/src/app/components/molecules/inputs/repeatable-input/design-system-repeatable-input.component.html
@@ -26,6 +26,38 @@
       ></vitamui-common-repeatable-input>
     </div>
   </div>
+  <div class="row mb-4">
+    <div class="col-3">
+      <vitamui-common-repeatable-input
+        [required]="true"
+        [formControl]="repeatableEmptyAndRequired"
+        [placeholder]="'Input obligatoire sans valeur'"
+      ></vitamui-common-repeatable-input>
+    </div>
+    <div class="col-3">
+      <vitamui-common-repeatable-input
+        [required]="true"
+        [formControl]="repeatableRequired"
+        [placeholder]="'Input obligatoire avec valeur'"
+      ></vitamui-common-repeatable-input>
+    </div>
+    <div class="col-3">
+      <vitamui-common-repeatable-input
+        [textarea]="true"
+        [required]="true"
+        [formControl]="repeatableEmptyAndRequired"
+        [placeholder]="'Textarea obligatoire sans valeur'"
+      ></vitamui-common-repeatable-input>
+    </div>
+    <div class="col-3">
+      <vitamui-common-repeatable-input
+        [textarea]="true"
+        [required]="true"
+        [formControl]="repeatableTextareaOneValue"
+        [placeholder]="'Textarea obligatoire avec valeur'"
+      ></vitamui-common-repeatable-input>
+    </div>
+  </div>
   <div class="row">
     <div class="col-3">
       <vitamui-common-repeatable-input

--- a/ui/ui-frontend/projects/design-system/src/app/components/molecules/inputs/repeatable-input/design-system-repeatable-input.component.ts
+++ b/ui/ui-frontend/projects/design-system/src/app/components/molecules/inputs/repeatable-input/design-system-repeatable-input.component.ts
@@ -69,4 +69,14 @@ export class DesignSystemRepeatableInputComponent {
     fc.disable();
     return fc;
   })();
+  public repeatableEmptyAndRequired = (() => {
+    const fc = new FormControl([]);
+    fc.markAsTouched();
+    return fc;
+  })();
+  public repeatableRequired = (() => {
+    const fc = new FormControl(['Lorem Ipsum']);
+    fc.markAsTouched();
+    return fc;
+  })();
 }

--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-create/audit-create.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-create/audit-create.component.html
@@ -115,7 +115,7 @@
                     : ('AUDIT.CREATE_DIALOG.INGEST_OPERATION_DATE_PLACEHOLDER' | translate)
                 "
                 [hint]="'AUDIT.CREATE_DIALOG.DATE_GMT_TIME_CAPTION'"
-                [isRequired]="isStartDateRequired()"
+                [required]="isStartDateRequired()"
                 required
               ></vitamui-common-multiple-options-datepicker>
             </div>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/multiple-options-datepicker/multiple-options-datepicker.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/multiple-options-datepicker/multiple-options-datepicker.component.html
@@ -1,7 +1,7 @@
 <div class="vitamui-input" [class.disabled]="control.disabled">
   <label>
     {{ label | translate }}
-    <span *ngIf="isRequired" class="required-marker">*</span>
+    <span *ngIf="control.hasValidator(Validators.required)" class="required-marker">*</span>
   </label>
   <input
     class="hidden-input"
@@ -14,7 +14,7 @@
   <input
     #vitamUIInput
     [disabled]="control.disabled"
-    [required]="isRequired"
+    [required]="control.hasValidator(Validators.required)"
     (focus)="onFocus()"
     (blur)="onBlur()"
     [ngModel]="control.value"
@@ -36,16 +36,12 @@
   <div class="info" *ngIf="hint && (control.valid || control.disabled || control.pristine)">
     <i class="vitamui-icon vitamui-icon-info"></i>
     <mat-hint *ngIf="hint"> {{ hint | translate }} </mat-hint>
-    <!-- FIXME: we probably shouldn't ALWAYS show a hint -->
-    <!--    <mat-hint *ngIf="!hint">-->
-    <!--      {{ 'DATE.EXPECTED_FORMAT' | translate: { format: 'DATE.FORMAT.' + pickerType.toUpperCase() | translate } }}-->
-    <!--    </mat-hint>-->
   </div>
-  <div class="error" *ngIf="control.dirty && !!control.errors?.pattern">
+  <div class="error" *ngIf="control.touched && !!control.errors?.pattern">
     <i class="vitamui-icon vitamui-icon-anomalie"></i>
-    <mat-hint> {{ 'DATE.ERROR.INCORRECT_FORMAT' | translate }} </mat-hint>
+    <mat-hint> {{ 'DATE.EXPECTED_FORMAT' | translate: { format: 'DATE.FORMAT.' + pickerType.toUpperCase() | translate } }} </mat-hint>
   </div>
-  <div class="error" *ngIf="control.dirty && !!control.errors?.required">
+  <div class="error" *ngIf="control.touched && !!control.errors?.required">
     <i class="vitamui-icon vitamui-icon-anomalie"></i>
     <mat-hint> {{ 'DATE.ERROR.REQUIRED_FIELD' | translate }} </mat-hint>
   </div>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/multiple-options-datepicker/multiple-options-datepicker.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/multiple-options-datepicker/multiple-options-datepicker.component.ts
@@ -35,7 +35,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, ElementRef, forwardRef, HostBinding, HostListener, Injector, Input, ViewChild, OnInit } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
 import { PickerType } from './multiple-options-datepicker.interface';
 import { DatePipe } from '@angular/common';
 import { MatDatepicker } from '@angular/material/datepicker';
@@ -60,7 +60,6 @@ export class MultipleOptionsDatepickerComponent extends AbstractFormInputDirecti
   @Input() startView: MatDatepicker<Date>['startView'];
   @Input() label = 'DATE.DATE';
   @Input() hint: string;
-  @Input() isRequired = false;
   @Input() min?: Date;
   @Input() max?: Date;
 
@@ -156,4 +155,6 @@ export class MultipleOptionsDatepickerComponent extends AbstractFormInputDirecti
       this.datepicker.close();
     }
   }
+
+  protected readonly Validators = Validators;
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-repeatable-input/vitamui-repeatable-input.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-repeatable-input/vitamui-repeatable-input.component.html
@@ -5,7 +5,10 @@
   [class.vitamui-focused]="i === focused"
 >
   <div class="vitamui-input" [class.first]="first">
-    <label *ngIf="first">{{ placeholder }}</label>
+    <label *ngIf="first">
+      {{ placeholder }}
+      <span *ngIf="control.hasValidator(Validators.required)" class="required-marker">*</span>
+    </label>
 
     <input
       *ngIf="!textarea"

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-repeatable-input/vitamui-repeatable-input.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-repeatable-input/vitamui-repeatable-input.component.ts
@@ -34,8 +34,9 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Component, ElementRef, forwardRef, HostBinding, HostListener, Input } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Component, ElementRef, forwardRef, HostBinding, HostListener, Injector, Input } from '@angular/core';
+import { NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
+import { AbstractFormInputDirective } from '../../../../lib/components/abstract-form-input.directive';
 
 export const REPEATABLE_INPUT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -52,7 +53,7 @@ type InternalValue = { id: number; value: string | number | boolean };
   providers: [REPEATABLE_INPUT_VALUE_ACCESSOR],
   standalone: false,
 })
-export class VitamuiRepeatableInputComponent implements ControlValueAccessor {
+export class VitamuiRepeatableInputComponent extends AbstractFormInputDirective {
   @Input() placeholder: string;
   @Input() autofocus: boolean;
   @HostBinding('class.textarea')
@@ -85,7 +86,12 @@ export class VitamuiRepeatableInputComponent implements ControlValueAccessor {
     }
   }
 
-  constructor(private elRef: ElementRef) {}
+  constructor(
+    injector: Injector,
+    private elRef: ElementRef,
+  ) {
+    super(injector);
+  }
 
   writeValue(values: InternalValue['value'][]) {
     this.items = (values && values.length ? values : ['']).map((v, i) => ({ id: i, value: v.toString() }));
@@ -140,4 +146,6 @@ export class VitamuiRepeatableInputComponent implements ControlValueAccessor {
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
+
+  protected readonly Validators = Validators;
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/editor-input.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/editor-input.component.ts
@@ -35,7 +35,6 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, Input } from '@angular/core';
-import { AppendStarPipe } from '../required.pipe';
 import { HintComponent } from '../../components/hint/hint.component';
 import { FormErrorDisplayComponent } from '../../components/form-error-display/form-error-display.component';
 import { PipesModule } from '../../pipes/pipes.module';
@@ -46,20 +45,12 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 @Component({
   selector: 'vitamui-editor-input',
   template: `
-    <vitamui-common-input [formControl]="control" [placeholder]="label | translate | empty | appendStar: required" class="w-100">
+    <vitamui-common-input [formControl]="control" [placeholder]="label | translate | empty" [required]="required" class="w-100">
       <vitamui-hint [control]="control" [hint]="hint"></vitamui-hint>
       <vitamui-form-error-display [control]="control"></vitamui-form-error-display>
     </vitamui-common-input>
   `,
-  imports: [
-    AppendStarPipe,
-    HintComponent,
-    FormErrorDisplayComponent,
-    PipesModule,
-    TranslatePipe,
-    VitamUICommonInputModule,
-    ReactiveFormsModule,
-  ],
+  imports: [HintComponent, FormErrorDisplayComponent, PipesModule, TranslatePipe, VitamUICommonInputModule, ReactiveFormsModule],
 })
 export class EditorInputComponent {
   @Input({ required: true }) control!: FormControl;

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/editor-list-date.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/editor-list-date.component.ts
@@ -38,7 +38,6 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { EditObject } from '../models/edit-object.model';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { AppendStarPipe } from '../required.pipe';
 import { HintComponent } from '../../components/hint/hint.component';
 import { FormErrorDisplayComponent } from '../../components/form-error-display/form-error-display.component';
 import { MultipleOptionsDatepickerModule } from '../../components/multiple-options-datepicker/multiple-options-datepicker.module';
@@ -50,22 +49,15 @@ import { TranslatePipe } from '@ngx-translate/core';
   template: `
     <vitamui-common-multiple-options-datepicker
       [formControl]="control"
-      [label]="editObject.displayRule.ui.label | translate | empty | appendStar: editObject.required"
+      [label]="editObject.displayRule.ui.label | translate | empty"
+      [required]="editObject.required"
       pickerType="day"
     >
       <vitamui-hint [control]="editObject.control" [hint]="editObject.hint"></vitamui-hint>
       <vitamui-form-error-display [control]="editObject.control"></vitamui-form-error-display>
     </vitamui-common-multiple-options-datepicker>
   `,
-  imports: [
-    AppendStarPipe,
-    HintComponent,
-    FormErrorDisplayComponent,
-    MultipleOptionsDatepickerModule,
-    PipesModule,
-    TranslatePipe,
-    ReactiveFormsModule,
-  ],
+  imports: [HintComponent, FormErrorDisplayComponent, MultipleOptionsDatepickerModule, PipesModule, TranslatePipe, ReactiveFormsModule],
 })
 export class EditorListDateComponent implements OnInit, OnDestroy {
   @Input({ required: true }) editObject!: EditObject;

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/editor-textarea.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/editor-textarea.component.ts
@@ -35,7 +35,6 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, Input } from '@angular/core';
-import { AppendStarPipe } from '../required.pipe';
 import { HintComponent } from '../../components/hint/hint.component';
 import { FormErrorDisplayComponent } from '../../components/form-error-display/form-error-display.component';
 import { PipesModule } from '../../pipes/pipes.module';
@@ -46,20 +45,12 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 @Component({
   selector: 'vitamui-editor-textarea',
   template: `
-    <vitamui-common-textarea [formControl]="control" [placeholder]="label | translate | empty | appendStar: required" class="w-100">
+    <vitamui-common-textarea [formControl]="control" [placeholder]="label | translate | empty" [required]="required" class="w-100">
       <vitamui-hint [control]="control" [hint]="hint"></vitamui-hint>
       <vitamui-form-error-display [control]="control"></vitamui-form-error-display>
     </vitamui-common-textarea>
   `,
-  imports: [
-    AppendStarPipe,
-    HintComponent,
-    FormErrorDisplayComponent,
-    PipesModule,
-    TranslatePipe,
-    VitamUICommonInputModule,
-    ReactiveFormsModule,
-  ],
+  imports: [HintComponent, FormErrorDisplayComponent, PipesModule, TranslatePipe, VitamUICommonInputModule, ReactiveFormsModule],
 })
 export class EditorTextareaComponent {
   @Input({ required: true }) control!: FormControl;

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/list-editor/list-editor.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/list-editor/list-editor.component.html
@@ -43,7 +43,8 @@
     ['textfield', 'textarea'].includes(editObject?.displayRule?.ui?.component)
   ) {
     <vitamui-common-repeatable-input
-      [placeholder]="editObject.displayRule.ui.label | translate | empty | appendStar: editObject.required"
+      [placeholder]="editObject.displayRule.ui.label | translate | empty"
+      [required]="editObject.required"
       [textarea]="editObject.displayRule.ui.layout.size === 'large'"
       [formControl]="editObject.control"
     >

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/primitive-editor/primitive-editor.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/components/primitive-editor/primitive-editor.component.html
@@ -26,7 +26,8 @@
     <vitamui-common-multiple-options-datepicker
       *ngSwitchCase="'datepicker'"
       [formControl]="editObject.control"
-      [label]="editObject.displayRule.ui.label | translate | empty | appendStar: editObject.required"
+      [label]="editObject.displayRule.ui.label | translate | empty"
+      [required]="editObject.required"
       [pickerType]="getPickerType(editObject)"
     >
       <vitamui-hint [control]="editObject.control" [hint]="editObject.hint"></vitamui-hint>
@@ -35,7 +36,8 @@
     <vitamui-common-multiple-options-datepicker
       *ngSwitchCase="'datetime'"
       [formControl]="editObject.control"
-      [label]="editObject.displayRule.ui.label | translate | empty | appendStar: editObject.required"
+      [label]="editObject.displayRule.ui.label | translate | empty"
+      [required]="editObject.required"
       [pickerType]="getPickerType(editObject)"
     >
       <vitamui-hint [control]="editObject.control" [hint]="editObject.hint"></vitamui-hint>

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
@@ -5669,7 +5669,7 @@
     "WRONG_FILE_SIZE": "Les dimensions du fichier que vous essayez de déposer sont supérieures à {{width}} * {{height}}px"
   },
   "ERRORS": {
-    "required": "Ce champ est requis.",
+    "required": "Ce champ est obligatoire.",
     "minlength": "La longueur minimale est de {{ requiredLength }} caractères.",
     "maxlength": "La longueur maximale est de {{ requiredLength }} caractères.",
     "email": "Adresse e-mail invalide.",


### PR DESCRIPTION
Pour une métadonnée obléigatoire : 

- Le champ comprend une astérisque rouge Lorsque l'on surpprime la valeur du champ 
- le message "Ce champ est obligatoire." doit être présent et écrit en rouget et doit identique sur toutes les métadonnées - - les messages d'informations ne s'affiche que dans le cas d'une REGEX