### PR TITLE
Bugs #14166: adapt diff to support arrays in diff

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/archive-unit-editor/archive-unit-editor.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/archive-unit-editor/archive-unit-editor.service.ts
@@ -175,7 +175,7 @@ export class ArchiveUnitEditorService {
     const consistentUpdatedValue = this.filterByCriteria(updatedValue, criteria);
 
     const changes = diff(consistentUpdatedValue, consistentOriginalValue);
-    const replaceEntries = Object.entries(changes);
+    const replaceEntries = Object.entries(changes).filter(([key]) => Object.keys(consistentOriginalValue).includes(key));
     const addEntries = Object.entries(consistentUpdatedValue).filter(([key]) => !Object.keys(consistentOriginalValue).includes(key));
     const removeEntries = Object.entries(consistentOriginalValue).filter(([key]) => !Object.keys(consistentUpdatedValue).includes(key));
     const jsonPatch: JsonPatch = [];

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/utils/diff.util.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/utils/diff.util.spec.ts
@@ -45,8 +45,8 @@ describe('Diff', () => {
     expect(diff({ a: 'x', b: 'y', c: 'c' }, { a: 'a', b: 'b', c: 'c' })).toEqual({ a: 'x', b: 'y' });
   });
 
-  it('should return { a: "x" }', () => {
-    expect(diff({ a: 'x', b: 'b', c: 'c' }, { a: 'a', b: 'b' })).toEqual({ a: 'x' });
+  it('should return { a: "x", c: "c" }', () => {
+    expect(diff({ a: 'x', b: 'b', c: 'c' }, { a: 'a', b: 'b' })).toEqual({ a: 'x', c: 'c' });
   });
 
   it('should return { a: "x", b: { c: "y" } }', () => {
@@ -59,5 +59,21 @@ describe('Diff', () => {
 
   it('should return { b: { c: "x", d: "y" } }', () => {
     expect(diff({ a: 'a', b: { c: 'x', d: 'y' } }, { a: 'a', b: { c: 'c', d: 'd' } })).toEqual({ b: { c: 'x', d: 'y' } });
+  });
+
+  it('should return { a: "x", b: [] }', () => {
+    expect(diff({ a: 'x' }, { a: 'a', b: [1, 2, 3] })).toEqual({ a: 'x', b: [] });
+  });
+
+  it('should return { a: "x" }', () => {
+    expect(diff({ a: 'x', b: [1, 2, 3] }, { a: 'a', b: [1, 2, 3] })).toEqual({ a: 'x' });
+  });
+
+  it('should return { a: "x", b: [1, 2, 3] }', () => {
+    expect(diff({ a: 'x', b: [1, 2, 3] }, { a: 'a', b: [1, 2] })).toEqual({ a: 'x', b: [1, 2, 3] });
+  });
+
+  it('should return { a: "x", b: [1, 2, 3] }', () => {
+    expect(diff({ a: 'x', b: [1, 2, 3] }, { a: 'a' })).toEqual({ a: 'x', b: [1, 2, 3] });
   });
 });

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/utils/diff.util.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/utils/diff.util.ts
@@ -40,12 +40,17 @@ import { isArray, isEqual, isObject, mapObject, omit } from 'underscore';
 // The value of the properties are that of the first object
 export function diff(o1: { [key: string]: any }, o2: { [key: string]: any }): { [key: string]: any } {
   const diffObj = omit(o1, (value: any, key: string) => {
-    if (o2.hasOwnProperty(key)) {
+    if (o2 && o2.hasOwnProperty(key)) {
       return isObject(value) ? isEqual(o2[key], value) : o2[key] === value;
     }
-
-    return true;
+    return value === null;
   });
-
+  // Empty arrays not present in o1 but present in o2
+  for (const k in o2) {
+    const v = o2[k];
+    if (isArray(v) && !o1.hasOwnProperty(k)) {
+      diffObj[k] = [];
+    }
+  }
   return mapObject(diffObj, (value: any, key: string) => (isObject(value) && !isArray(value) ? diff(value, o2[key]) : value));
 }


### PR DESCRIPTION
Les diffs ne prenaient pas en compte les tableaux dans les différences d'objets. À CP en 8.0.