### PR TITLE
CP V8.0 - Bugs #14317: save seda version for PUA in pastis standalone

### DIFF
--- a/api/api-pastis/pastis-external/src/main/java/fr/gouv/vitamui/pastis/server/service/PastisService.java
+++ b/api/api-pastis/pastis-external/src/main/java/fr/gouv/vitamui/pastis/server/service/PastisService.java
@@ -207,8 +207,12 @@ public class PastisService {
 
     public String getArchiveUnitProfile(final ProfileNotice json, final boolean standalone) throws TechnicalException {
         Notice notice = new Notice();
-        if (!standalone && json.getNotice() != null) {
-            notice = json.getNotice();
+        if (json.getNotice() != null) {
+            if (standalone) {
+                notice.setSedaVersion(json.getNotice().getSedaVersion());
+            } else {
+                notice = json.getNotice();
+            }
         }
         String controlSchema;
         try {


### PR DESCRIPTION
Export du champ SedaVersion dans Pastis Standalone pour les PUA.

> Cherry-Pick from #2560 