### PR TITLE
Bugs #14394: fix collect profiles and groups

### DIFF
--- a/deployment/scripts/mongod/v8.0/005_create_new_collect_profiles_for_exist_customers.js.j2
+++ b/deployment/scripts/mongod/v8.0/005_create_new_collect_profiles_for_exist_customers.js.j2
@@ -6,8 +6,8 @@ print("START_005_create_new_collect_profiles_for_exist_customers.js");
 // Get sequence for profiles
 var maxIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;
 
-// For each tenants (except cas tenant)
-db.tenants.find({ "identifier": { $gte: 0 } }).forEach(function (tenant) {
+// For each tenants (except cas and system tenant)
+db.tenants.find({ "identifier": { $nin: [ {{ vitamui_platform_informations.cas_tenant | default(-1) }}, {{ vitamui_platform_informations.proof_tenant | default(1) }} ] } }).forEach(function (tenant) {
 
     //CREATE NEW PROFILES FOR COLLECT_APP except Archiviste - Administrateur (replace the default profile already created)
 

--- a/deployment/scripts/mongod/v8.0/007_fix_groups_for_collect_profiles.js.j2
+++ b/deployment/scripts/mongod/v8.0/007_fix_groups_for_collect_profiles.js.j2
@@ -1,0 +1,34 @@
+db = db.getSiblingDB('iam');
+
+print('START_007_fix_groups_for_collect_profiles.js');
+
+// Remove profiles that were incorrectly created for tenant 1
+db.profiles.deleteMany({
+    _id: {
+        $in: [
+            'PROFIL_{{ vitamui_platform_informations.cas_tenant | default(-1) }}-COLLECT_APP-ORIGINATING_AGENCY',
+            'PROFIL_{{ vitamui_platform_informations.cas_tenant | default(-1) }}-COLLECT_APP-ARCHIVISTE_COLLECT_MANAGEMENT'
+            'PROFIL_{{ vitamui_platform_informations.proof_tenant | default(1) }}-COLLECT_APP-ORIGINATING_AGENCY',
+            'PROFIL_{{ vitamui_platform_informations.proof_tenant | default(1) }}-COLLECT_APP-ARCHIVISTE_COLLECT_MANAGEMENT'
+       ]
+    }
+});
+
+// Modify groups to remove these profiles
+db.groups.updateMany(
+    { "identifier": { $in: [{{ vitamui_platform_informations.cas_tenant | default(-1) }}, {{ vitamui_platform_informations.proof_tenant | default(1) }}] } },
+    {
+        $pull: {
+            "profileIds": {
+                $in: [
+                    'PROFIL_{{ vitamui_platform_informations.cas_tenant | default(-1) }}-COLLECT_APP-ORIGINATING_AGENCY',
+                    'PROFIL_{{ vitamui_platform_informations.cas_tenant | default(-1) }}-COLLECT_APP-ARCHIVISTE_COLLECT_MANAGEMENT'
+                    'PROFIL_{{ vitamui_platform_informations.proof_tenant | default(1) }}-COLLECT_APP-ORIGINATING_AGENCY',
+                    'PROFIL_{{ vitamui_platform_informations.proof_tenant | default(1) }}-COLLECT_APP-ARCHIVISTE_COLLECT_MANAGEMENT'
+                ]
+            }
+        }
+    }
+);
+
+print('END_007_fix_groups_for_collect_profiles.js');


### PR DESCRIPTION
Deux profils étaient créés par erreur pour le tenant 1 : `PROFIL_1-COLLECT_APP-ORIGINATING_AGENCY` et `PROFIL_1-COLLECT_APP-ARCHIVISTE_COLLECT_MANAGEMENT`.

On supprime les profils et on modifie les groupes existants pour arrêter de les utiliser.

À CP en 8.0