### PR TITLE
CP V8.0 - Bug #14476: Fix getDcName function.

### DIFF
--- a/deployment/pki/scripts/lib/certs.sh
+++ b/deployment/pki/scripts/lib/certs.sh
@@ -277,7 +277,7 @@ function getConsulDomain {
 function getDcName {
     # Get DC_NAME
     VITAMUI_SITE_NAME=$(read_ansible_var "vitamui_site_name" "hosts_vitamui_consul_server[0]")
-    if [[ "$VITAMUI_SITE_NAME" =~ "VARIABLEISNOTDEFINED" ]]; then
+    if [[ -z "$VITAMUI_SITE_NAME" || "$VITAMUI_SITE_NAME" =~ "VARIABLEISNOTDEFINED" ]]; then
         VITAM_SITE_NAME=$(read_ansible_var "vitam_site_name" "hosts_cas_server[0]")
         echo $VITAM_SITE_NAME
     else


### PR DESCRIPTION
## Description

Also check if DC Name is empty to properly get the vitam_site_name instead. This happens when group `hosts_vitamui_consul_server` is empty ([WARNING]: No hosts matched, nothing to do).

> Cherry-Pick from #2587

## Type de changement

* PKI
* Correction

## Contributeur

* Programme Vitam