### PR TITLE
Bug #13835 [Metadata] Missing selector when editing metadata with an Enum list.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/services/edit-object.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-editor/services/edit-object.service.ts
@@ -268,10 +268,14 @@ export class EditObjectService {
     const hint = Control?.Comment;
     const cardinality = EffectiveCardinality || schemaElement.Cardinality;
 
+    const isSelectComponent = displayRule && kind === 'primitive-array' && options?.length;
+    if (isSelectComponent) displayRule.ui.component = 'select';
+
     return {
       ...partialEditObject,
       required: this.schemaService.isRequired(schemaElement as ProfiledSchemaElement),
       virtual: this.schemaService.isVirtual(schemaElement),
+      displayRule,
       pattern,
       options,
       hint,

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-viewer/models/ui.model.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/object-viewer/models/ui.model.ts
@@ -39,11 +39,11 @@ import { Layout } from './layout.model';
 import { WithPath } from './with-path.model';
 
 export interface Ui extends WithPath {
-  readonly component?: ComponentType;
   readonly layout?: Layout;
   readonly favoriteKeys?: string[];
   readonly open?: boolean;
   readonly display?: boolean;
+  component?: ComponentType;
   label?: string;
   disabled?: boolean;
 }


### PR DESCRIPTION
il faut que le champ de saisie soit un composant Sélecteur (ENUM) dont la liste de valeurs est alimentée par celles déclarées dans le PUA.
