### PR TITLE
Bugs #14376: orphan count is sometimes undefined in leaves-tree component

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/filing-holding-scheme/filing-holding-scheme.component.ts
@@ -137,6 +137,7 @@ export class FilingHoldingSchemeComponent implements OnInit, OnDestroy {
             node.count = 0;
             node.hidden = true;
           }
+          this.requestResultsInFilingPlan = 0;
         }
         // fullNodes is a Graph .
         // keeps last child with result only


### PR DESCRIPTION
Parfois `this.requestResultsInFilingPlan` n'est pas initialisé, ce qui fait que le compte des noeuds orphelins est faux :
`const orphans = this.requestTotalResults - this.requestResultsInFilingPlan;`