### PR TITLE
Bug #14485 [Archive Search] Loss of edit mode when clicking outside the tab.

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-description-tab/archive-unit-description-tab.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-description-tab/archive-unit-description-tab.component.ts
@@ -160,9 +160,8 @@ export class ArchiveUnitDescriptionTabComponent implements OnDestroy {
   }
 
   onCancel() {
-    if (!this.isModified()) return this.backToDisplayMode();
-    if (this.dialog.openDialogs.length > 0) {
-      return; // A dialog is already open
+    if (!this.isModified() || this.dialog.openDialogs.length > 0) {
+      return; // form not modified or dialog already open
     }
     this.subscriptions.add(
       this.dialog


### PR DESCRIPTION
Dans l'app recherche, lorsque je passe en mode édition d'une UA, si je clique en dehors du panneau avant de commencer les modifications, le mode édition se désactive.