### PR TITLE
Bug #13788 fix vitamui log rotation compression

### DIFF
--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -24,6 +24,7 @@ vitamui_defaults:
     jvm_log: false
     accesslogs: true
     access_retention_days: 365
+    access_logrotate: enabled # or disabled
     log:
       logback_max_file_size: "10MB"
       logback_max_history: 365

--- a/deployment/roles/vitamui/defaults/main.yml
+++ b/deployment/roles/vitamui/defaults/main.yml
@@ -14,6 +14,7 @@ jvm_log: "{{ vitamui_defaults.services.jvm_log | default(false) | bool }}"
 accesslogs: "{{ vitamui_defaults.services.accesslogs | default('true') | lower }}"
 access_retention_days: "{{ vitamui_defaults.services.access_retention_days | default(365) }}"
 access_total_size_cap: "{{ vitamui_defaults.services.access_total_size_cap | default('5GB') }}"
+access_logrotate: "{{ vitamui_defaults.services.access_logrotate | default('enabled') }}"
 
 log:
   logback_max_file_size: "{{ vitamui_defaults.services.log.logback_max_file_size | default('10MB') }}"

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -239,3 +239,18 @@
     - name: printing error logs
       fail:
         msg: "{{ journalctl_logs.stdout_lines }}"
+
+- name: Enable logrotate for vitamui
+  template:
+    src: logrotate.d.vitamui.j2
+    dest: /etc/logrotate.d/{{ service_name }}
+    owner: root
+    group: root
+    mode: 0644
+  when: vitamui_struct.access_logrotate | default(access_logrotate) | lower == 'enabled'
+
+- name: Disable logrotate for vitamui
+  file:
+    path: /etc/logrotate.d/{{ service_name }}
+    state: absent
+  when: vitamui_struct.access_logrotate | default(access_logrotate) | lower == 'disabled'

--- a/deployment/roles/vitamui/templates/logrotate.d.vitamui.j2
+++ b/deployment/roles/vitamui/templates/logrotate.d.vitamui.j2
@@ -1,0 +1,9 @@
+{{ vitamui_folder_log }}/accesslog*.log {{ vitamui_folder_log }}/management_accesslog*.log {
+    daily
+    rotate {{ vitamui_struct.access_retention_days | default(access_retention_days) }}
+    compress
+    missingok
+    notifempty
+    create 640 root root
+    dateext
+}


### PR DESCRIPTION
# Description

## Problem
The `accesslogs` and `management_accesslogs` files of VitamUI were not compressed during daily rotation.

## Resolution
1. Creation of `/etc/logrotate.d/vitamui` with the following configuration:
   - **Log targeting**: `/vitamui/log/*/accesslog*.log /vitamui/log/*/management_accesslog*.log`
   - **Detailed options**:
     - `"daily"`: Rotation performed once a day.
     - `"rotate 7"`: Retention of the last 7 versions of the logs before deletion.
     - `"compress"`: Compression of rotated logs in gzip format (.gz).
     - `"missingok"`: Ignores errors if a targeted log file does not exist.
     - `"notifempty"`: Does not rotate files if they are empty.
     - `"create 640 root root"`: Creates a new log file after rotation with permissions 640 (read/write for root, read for the root group).
     - `"dateext"`: Adds the date to the name of rotated files (e.g., -20250326).

2. Verification that `logrotate` is scheduled in `/etc/cron.daily/` for automatic daily execution.

## Result
The logs are now rotated daily and compressed in .gz format, as required.
## Type of Change

* Ansible Management
* Fix

## Contributor

* Program Vitam

