### PR TITLE
bug #14350 : Reclassification fix error when checking children

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.spec.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.spec.ts
@@ -57,6 +57,7 @@ import {
   SearchCriteriaStatusEnum,
   SchemaService,
   VitamuiRoles,
+  UnitType,
 } from 'vitamui-library';
 import { ArchiveSharedDataService } from '../../core/archive-shared-data.service';
 import { ArchiveService } from '../archive.service';
@@ -250,6 +251,81 @@ describe('ArchiveSearchComponent', () => {
       it('should have 2 buttons ', () => {
         const elementBtn = fixture.nativeElement.querySelectorAll('button[type=button]');
         expect(elementBtn.length).toBe(2);
+      });
+    });
+
+    describe('checkChildrenBoxChange', () => {
+      it('should include the unselected child when parent is checked, into the list listOfUAIdToExclude', () => {
+        component.isAllChecked = true;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: false } as HTMLInputElement });
+        const unit = { '#id': '1234', '#unitups': [''], '#allunitups': [''], '#unitType': UnitType.HOLDING_UNIT, '#opi': '1234' };
+        component.checkChildrenBoxChange(unit, event);
+        expect(component.listOfUAIdToExclude.length).toBe(1);
+        expect(component.listOfUAIdToExclude[0]).toEqual({ value: '1234', id: '1234' });
+        expect(component.listOfUAIdToInclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeTrue();
+        expect(component.selectedItemCount).toBe(0);
+        expect(component.itemNotSelected).toBe(0);
+        expect(component.selectedHoldingUnitItemCount).toBe(0);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should exclude the selected child when parent is checked, from the list listOfUAIdToExclude', () => {
+        component.isAllChecked = true;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: true } as HTMLInputElement });
+        const unit = { '#id': '1234', '#unitups': [''], '#allunitups': [''], '#unitType': UnitType.HOLDING_UNIT, '#opi': '1234' };
+        component.checkChildrenBoxChange(unit, event);
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.listOfUAIdToInclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.selectedItemCount).toBe(1);
+        expect(component.itemNotSelected).toBe(0);
+        expect(component.selectedHoldingUnitItemCount).toBe(1);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should include the selected child when parent is unchecked, into the list listOfUAIdToInclude', () => {
+        component.isAllChecked = false;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: true } as HTMLInputElement });
+        const unit = { '#id': '1234', '#unitups': [''], '#allunitups': [''], '#unitType': UnitType.HOLDING_UNIT, '#opi': '1234' };
+        component.checkChildrenBoxChange(unit, event);
+        expect(component.listOfUAIdToInclude.length).toBe(1);
+        expect(component.listOfUAIdToInclude[0]).toEqual({ value: '1234', id: '1234' });
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.selectedItemCount).toBe(1);
+        expect(component.itemNotSelected).toBe(0);
+        expect(component.selectedHoldingUnitItemCount).toBe(1);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should not include the unselected child when parent is unchecked, into the list listOfUAIdToInclude', () => {
+        component.isAllChecked = false;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: false } as HTMLInputElement });
+        const unit = { '#id': '1234', '#unitups': [''], '#allunitups': [''], '#unitType': UnitType.HOLDING_UNIT, '#opi': '1234' };
+        component.checkChildrenBoxChange(unit, event);
+        expect(component.listOfUAIdToInclude.length).toBe(0);
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.selectedItemCount).toBe(0);
+        expect(component.itemNotSelected).toBe(0);
+        expect(component.selectedHoldingUnitItemCount).toBe(0);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should not increase selectedHoldingUnitItemCount if unitType is not HOLDING_UNIT', () => {
+        component.isAllChecked = false;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: true } as HTMLInputElement });
+        const unit = { '#id': '1234', '#unitups': [''], '#allunitups': [''], '#unitType': UnitType.FILING_UNIT, '#opi': '1234' };
+        component.checkChildrenBoxChange(unit, event);
+        expect(component.listOfUAIdToInclude.length).toBe(1);
+        expect(component.listOfUAIdToInclude[0]).toEqual({ value: '1234', id: '1234' });
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.selectedItemCount).toBe(1);
+        expect(component.itemNotSelected).toBe(0);
+        expect(component.selectedHoldingUnitItemCount).toBe(0);
+        expect(event.stopPropagation).toHaveBeenCalled();
       });
     });
   });

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -160,7 +160,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
   pageNumbers = 0;
   totalResults = 0;
   selectedItemCount = 0;
-  private selectedHoldingUnitItemCount = 0;
+  selectedHoldingUnitItemCount = 0;
   itemNotSelected = 0;
   numberOfHoldingUnitTypeOnComputedRules = 0;
   additionalSearchCriteriaCategoryIndex = 0;
@@ -921,8 +921,12 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
         if (this.selectedItemCount === this.totalResults) {
           this.isIndeterminate = false;
         }
-        this.listOfUAIdToInclude.push({ value: id, id });
-        this.listOfUAIdToExclude.splice(0, this.listOfUAIdToExclude.length);
+        if (this.isAllChecked) {
+          this.listOfUAIdToExclude = this.listOfUAIdToExclude.filter((element) => element.id !== id);
+        } else {
+          this.listOfUAIdToInclude.push({ value: id, id });
+          this.listOfUAIdToExclude.splice(0, this.listOfUAIdToExclude.length);
+        }
       } else {
         this.listOfUAIdToInclude = this.listOfUAIdToInclude.filter((element) => element.id !== id);
         if (this.selectedItemCount > 0) {

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.spec.ts
@@ -205,6 +205,57 @@ describe('ArchiveSearchCollectComponent', () => {
       expect(component.isAllChecked).toBeFalsy();
       expect(component.itemNotSelected).toBe(0);
     });
+
+    describe('checkChildrenBoxChange', () => {
+      it('should include the unselected child when parent is checked, into the list listOfUAIdToExclude', () => {
+        component.isAllChecked = true;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: false } as HTMLInputElement });
+        component.checkChildrenBoxChange('1234', event);
+        expect(component.listOfUAIdToExclude.length).toBe(1);
+        expect(component.listOfUAIdToExclude[0]).toEqual({ value: '1234', id: '1234' });
+        expect(component.listOfUAIdToInclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeTrue();
+        expect(component.itemSelected).toBe(0);
+        expect(component.itemNotSelected).toBe(0);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should exclude the selected child when parent is checked, from the list listOfUAIdToExclude', () => {
+        component.isAllChecked = true;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: true } as HTMLInputElement });
+        component.checkChildrenBoxChange('1234', event);
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.listOfUAIdToInclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.itemSelected).toBe(1);
+        expect(component.itemNotSelected).toBe(0);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should include the selected child when parent is unchecked, into the list listOfUAIdToInclude', () => {
+        component.isAllChecked = false;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: true } as HTMLInputElement });
+        component.checkChildrenBoxChange('1234', event);
+        expect(component.listOfUAIdToInclude.length).toBe(1);
+        expect(component.listOfUAIdToInclude[0]).toEqual({ value: '1234', id: '1234' });
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.itemSelected).toBe(1);
+        expect(component.itemNotSelected).toBe(0);
+      });
+
+      it('should not include the unselected child when parent is unchecked, into the list listOfUAIdToInclude', () => {
+        component.isAllChecked = false;
+        const event: Event = jasmine.createSpyObj<Event>(['stopPropagation'], { target: { checked: false } as HTMLInputElement });
+        component.checkChildrenBoxChange('1234', event);
+        expect(component.listOfUAIdToInclude.length).toBe(0);
+        expect(component.listOfUAIdToExclude.length).toBe(0);
+        expect(component.isIndeterminate).toBeFalsy();
+        expect(component.itemSelected).toBe(0);
+        expect(component.itemNotSelected).toBe(0);
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('queryParams', () => {

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -679,8 +679,12 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
         if (this.itemSelected === this.totalResults) {
           this.isIndeterminate = false;
         }
-        this.listOfUAIdToInclude.push({ value: id, id });
-        this.listOfUAIdToExclude.splice(0, this.listOfUAIdToExclude.length);
+        if (this.isAllChecked) {
+          this.listOfUAIdToExclude = this.listOfUAIdToExclude.filter((element) => element.id !== id);
+        } else {
+          this.listOfUAIdToInclude.push({ value: id, id });
+          this.listOfUAIdToExclude.splice(0, this.listOfUAIdToExclude.length);
+        }
       } else {
         this.listOfUAIdToInclude = this.listOfUAIdToInclude.filter((element) => element.id !== id);
         if (this.itemSelected > 0) {


### PR DESCRIPTION
## Description

When we check a children and `this.isAllChecked` is `true`, it is considered as you pushed an AU's Id into `this.listOfUAIdToInclude`. Instead, we must remove from `this.listOfUAIdToExclude` the Id checked
