### PR TITLE
Bug #14483 [COLLECTE] The right-side panel does not appear when clicking on a tree or a plan.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.html
@@ -10,18 +10,20 @@
   <i class="vitamui-icon icon {{ expanded ? 'vitamui-icon-chevron-down' : 'vitamui-icon-chevron-right' }}"></i>
 </button>
 
-<mat-checkbox
-  id="enable{{ node?.id }}"
-  [(ngModel)]="node.checked"
-  [(indeterminate)]="node.disabledChild"
-  [disabled]="node.disabled"
-  (ngModelChange)="onCheckboxClick()"
-  (click)="onCheckboxClick()"
-  [vitamuiTooltip]="node?.title"
-  [vitamuiTooltipShowDelay]="300"
->
-  <label class="node-label" (click)="onLabelClick($event)">
-    <i class="mr-1 vitamui-icon {{ icon }}"></i>
-    {{ node?.title }}
-  </label>
-</mat-checkbox>
+<div (click)="onLabelClick($event)">
+  <mat-checkbox
+    id="enable{{ node?.id }}"
+    [(ngModel)]="node.checked"
+    [(indeterminate)]="node.disabledChild"
+    [disabled]="node.disabled"
+    (ngModelChange)="onCheckboxClick()"
+    (click)="onCheckboxClick()"
+    [vitamuiTooltip]="node?.title"
+    [vitamuiTooltipShowDelay]="300"
+  >
+    <label class="node-label">
+      <i class="mr-1 vitamui-icon {{ icon }}"></i>
+      {{ node?.title }}
+    </label>
+  </mat-checkbox>
+</div>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.spec.ts
@@ -103,7 +103,7 @@ describe('VitamuiTreeNodeComponent', () => {
   it('should emit labelClick event when label is clicked', () => {
     // When click on the checkbox
     const nativeElement = fixture.nativeElement;
-    const label = nativeElement.querySelector('label');
+    const label = nativeElement.querySelector('div');
     label.dispatchEvent(new Event('click'));
     fixture.detectChanges();
 
@@ -120,7 +120,7 @@ describe('VitamuiTreeNodeComponent', () => {
 
     // When click on the checkbox
     const nativeElement = fixture.nativeElement;
-    const label = nativeElement.querySelector('label');
+    const label = nativeElement.querySelector('div');
     label.dispatchEvent(new Event('click'));
     fixture.detectChanges();
 


### PR DESCRIPTION
Fix le problème d'un élément désactivé avec l'attribut [disabled] n'est plus cliquable, même avec (click) attaché dessus.
(Les événements comme mousedown, mouseup, et click ne se propagent plus pour les éléments désactivés)