### PR TITLE
Bug #14462: Fix form when formatType is null

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-format-tab/ingest-contract-format-tab.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-format-tab/ingest-contract-format-tab.component.ts
@@ -89,7 +89,7 @@ export class IngestContractFormatTabComponent implements OnInit {
   previousValue = (): any => {
     return {
       everyFormatType: this._ingestContract.everyFormatType,
-      formatType: this._ingestContract.formatType.sort() ?? null,
+      formatType: this._ingestContract.formatType ? this._ingestContract.formatType.sort() : null,
       formatUnidentifiedAuthorized: this._ingestContract.formatUnidentifiedAuthorized,
     };
   };

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -276,7 +276,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
   writeValue(preselectedOptionKeys: string | string[]) {
     this.preselectedOptionKeys = preselectedOptionKeys
       ? Array.isArray(preselectedOptionKeys)
-        ? preselectedOptionKeys
+        ? preselectedOptionKeys.sort()
         : [preselectedOptionKeys]
       : null;
     // When the component is reset this method is called with selectedOptionKeys = null


### PR DESCRIPTION
## Description

Evite d'appeler une méthode sur formatType quand formatType est null et améliore la préséléction dans le multi-select

## Type de changement

*Indiquer le ou les types de changements*

* Correction