### PR TITLE
Bug #14486 [COLLECTE | Reclassification ] : The 'Unassigned' folder does not appear after removing the parent folder.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -59,7 +59,7 @@
             type="button"
             class="btn primary"
             [disabled]="!(searchCriteriaKeys && searchCriteriaKeys.length !== 0)"
-            (click)="submit()"
+            (click)="submit(true)"
           >
             {{ 'COLLECT.LAUNCH_SEARCH_ACTION' | translate }}
           </button>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -535,7 +535,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     );
   }
 
-  submit() {
+  submit(refreshArchiveUnitsWithoutAttachment?: boolean) {
     this.listOfUAIdToInclude = [];
     this.listOfUAIdToExclude = [];
 
@@ -554,6 +554,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
       this.rulesFacetsCanBeComputed = this.archiveHelperService.checkIfRulesFacetsCanBeComputed(this.searchCriterias);
       this.searchArchiveUnits(this.rulesFacetsCanBeComputed);
       this.showingFacets = this.rulesFacetsCanBeComputed;
+      if (refreshArchiveUnitsWithoutAttachment) this.existsArchiveUnitWithoutAttachment();
     }
   }
 


### PR DESCRIPTION
Il faudrait revoir le comportement lors du clic sur le bouton "Lancer une recherche", car les dossiers sans rattachement ne s’affichent qu’après un rafraîchissement manuel de la page via le navigateur.