### PR TITLE
Bug #14523: Migrate ontology profile for existing tenants.

### DIFF
--- a/api/api-iam/iam/src/main/resources/dev/customer-init.yml
+++ b/api/api-iam/iam/src/main/resources/dev/customer-init.yml
@@ -375,9 +375,9 @@ customer-init:
       roles:
         - ROLE_GET_ONTOLOGIES
         - ROLE_IMPORT_ONTOLOGY
-        - ROLE_DELETE_SCHEMAS
         - ROLE_IMPORT_SCHEMAS
-
+        - ROLE_GET_SCHEMAS
+        - ROLE_DELETE_SCHEMAS
 
   #- name: profileName
   #  description: desc

--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -373,9 +373,9 @@ customer-init:
       roles:
         - ROLE_GET_ONTOLOGIES
         - ROLE_IMPORT_ONTOLOGY
-        - ROLE_DELETE_SCHEMAS
         - ROLE_IMPORT_SCHEMAS
-
+        - ROLE_GET_SCHEMAS
+        - ROLE_DELETE_SCHEMAS
 
   # Other Default profiles for admin group
   admin-profiles:

--- a/deployment/scripts/mongod/v8.1/0-03_update_ontology_app.js.j2
+++ b/deployment/scripts/mongod/v8.1/0-03_update_ontology_app.js.j2
@@ -24,6 +24,50 @@ dbIam.applications.updateOne({
     },
 });
 
+// CREATING NEW PROFILES FOR ONTOLOGY_APP on existing tenants
+
+// Get sequence for profiles
+var maxIdProfile = dbIam.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;
+
+// For each tenants (except cas and system tenant)
+dbIam.tenants.find({
+    "identifier": {
+        $nin: [
+            {{ vitamui_platform_informations.cas_tenant | default(-1) }},
+            {{ vitamui_platform_informations.proof_tenant | default(1) }}
+        ]
+    }
+}).forEach(function (tenant) {
+    dbIam.profiles.insertOne({
+        "_id": "PROFIL_" + tenant.identifier + "-ONTOLOGY_APP-ADMIN",
+        "identifier": NumberInt(maxIdProfile++),
+        "name": "Profil pour la consultation des ontologies et gestion des schémas",
+        "description": "Consultation des ontologies et gestion des schémas",
+        "tenantIdentifier": NumberInt(tenant.identifier),
+        "applicationName": "ONTOLOGY_APP",
+        "level": "",
+        "enabled": true,
+        "readonly": true,
+        "customerId": tenant.customerId,
+        "roles": [
+            { "name": "ROLE_GET_ONTOLOGIES" },
+            { "name": "ROLE_IMPORT_ONTOLOGY" },
+            { "name": "ROLE_IMPORT_SCHEMAS" },
+            { "name": "ROLE_GET_SCHEMAS" },
+            { "name": "ROLE_DELETE_SCHEMAS" }
+        ]
+    });
+});
+
+// Update sequence
+dbIam.sequences.updateOne({
+    "_id": "profile_identifier"
+}, {
+    $set: {
+        "sequence": NumberInt(maxIdProfile)
+    }
+});
+
 dbSecurity = db.getSiblingDB('{{ mongodb.security.db | default('security') }}')
 dbSecurity.contexts.updateOne({
     "_id": "ui_referential_context"


### PR DESCRIPTION
## Description

Lors d'une montée de version, les profils associés à l'application ONTOLOGY ne sont pas créés pour les organisations existantes. Hors, ils sont disponibles lors de la création d'une nouvelle organisation.

Ce correctif a pour but de réaligner le comportement entre des organisations migrées (dans le cadre d'une MDV vers la V8.1) ou créées après migration.

## Type de changement

* Correction
* Migration

## Contributeur

* Programme Vitam