### PR TITLE
CP V7.0 - Bug #13168: fix duplicate profiles identifier

### DIFF
--- a/deployment/scripts/mongod/1.0.0/222_pastis_profiles_ref.js.j2
+++ b/deployment/scripts/mongod/1.0.0/222_pastis_profiles_ref.js.j2
@@ -4,6 +4,7 @@ print("START 222_pastis_profiles_ref.js");
 
 // -------- VITAM ADMINISTRATION -----
 
+var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identifier'}).sequence;
 
 db.profiles.insert({
   "_id": "system_pastis",
@@ -35,5 +36,13 @@ db.profiles.insert({
    ]
 });
 
+
+db.sequences.updateOne({
+    "_id": "profile_identifier"
+}, {
+	$set: {
+		"sequence": NumberInt(maxIdProfile)
+	}
+});
 
 print("END 222_pastis_profiles_ref.js");

--- a/deployment/scripts/mongod/7.0/02_fix_duplicate_profiles_identifier.js.j2
+++ b/deployment/scripts/mongod/7.0/02_fix_duplicate_profiles_identifier.js.j2
@@ -1,0 +1,37 @@
+print("START 02_fix_duplicate_profiles_identifier.js");
+
+db = db.getSiblingDB('{{ mongodb.iam.db }}')
+
+const duplicates = db.profiles.aggregate([
+  {
+    $group: {
+      _id: "$identifier",
+      count: { $sum: 1 },
+      docs: { $push: "$_id" }
+    }
+  },
+  {
+    $match: { count: { $gt: 1 } }
+  }
+]).toArray();
+
+var maxIdProfile = db.getCollection('sequences').findOne({'_id': 'profile_identifier'}).sequence;
+
+duplicates.forEach(dup => {
+  dup.docs.slice(1).forEach((docId, index) => { // Skip first, update the rest
+    db.profiles.updateOne(
+      { _id: docId },
+      { $set: { identifier: NumberInt(maxIdProfile++) } }
+    );
+  });
+});
+
+db.sequences.updateOne({
+    "_id": "profile_identifier"
+}, {
+	$set: {
+		"sequence": NumberInt(maxIdProfile)
+	}
+});
+
+print("END 02_fix_duplicate_profiles_identifier.js");


### PR DESCRIPTION
## Description

Cette PR corrige le script de création d'un profil sans mise à jour de la séquence ce qui créé 2 profils avec le même identifiant, et ajout d'un script de check et correction de profiles déjà créés.

> Cherry-Pick from #2633 & #2649

## Contributeur

* VAS (Vitam Accessible en Service)