### PR TITLE
Bugs #14334: reactivate external identifiers configuration

### DIFF
--- a/deployment/roles/vitamui/templates/iam/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam/application.yml.j2
@@ -69,6 +69,19 @@ security:
     hostname-verification: true
 {% endif %}
 
+list-enable-external-identifiers:
+  tenants:
+{% if vitam_vars.functional_administration.vitam_tenants_usage_external is iterable %}
+{% for tenant in vitam_vars.functional_administration.vitam_tenants_usage_external %}
+{% if tenant.identifiers is defined %}
+    {{ tenant.name }}:
+{% for external in tenant.identifiers %}
+      - {{ external }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+
 login:
 {% if vitamui.cas_server.base_url is defined %}
   url: {{ vitamui.cas_server.base_url }}


### PR DESCRIPTION
La configuration des identifiants externes par tenant (dans `list-enable-external-identifiers`) avait sauté avec la fusion internal external.