### PR TITLE
CP V7.1 - Bugs #14334: list-enable-external-identifiers should be configured on iam-internal, not iam-external

### DIFF
--- a/deployment/roles/vitamui/templates/iam-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-external/application.yml.j2
@@ -85,19 +85,6 @@ iam-external:
 
 customer.init.config.file: {{ vitamui_folder_conf }}/customer-init.yml
 
-list-enable-external-identifiers:
-  tenants:
-{% if vitam_vars.functional_administration.vitam_tenants_usage_external is iterable %}
-{% for tenant in vitam_vars.functional_administration.vitam_tenants_usage_external %}
-{% if tenant.identifiers is defined %}
-    {{ tenant.name }}:
-{% for external in tenant.identifiers %}
-      - {{ external }}
-{% endfor %}
-{% endif %}
-{% endfor %}
-{% endif %}
-
 cas:
 {% if vitamui.cas_server.base_url is defined %}
   external-url: "{{ vitamui.cas_server.base_url}}"

--- a/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
@@ -66,6 +66,19 @@ security:
     hostname-verification: {{ vitamui_defaults.services.ssl_hostname_verification | default(true) | bool }}
 {% endif %}
 
+list-enable-external-identifiers:
+  tenants:
+{% if vitam_vars.functional_administration.vitam_tenants_usage_external is iterable %}
+{% for tenant in vitam_vars.functional_administration.vitam_tenants_usage_external %}
+{% if tenant.identifiers is defined %}
+    {{ tenant.name }}:
+{% for external in tenant.identifiers %}
+      - {{ external }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+
 login:
 {% if vitamui.cas_server.base_url is defined %}
   url: {{ vitamui.cas_server.base_url }}


### PR DESCRIPTION
La configuration faite pour la propriété list-enable-external-identifiers doit être faite sur iam-internal, pas sur iam-external.

Voir https://github.com/ProgrammeVitam/vitam-ui/pull/2672