### PR TITLE
bug #14554 : Missing filter boxes

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/access-rule-search/access-rule-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/access-rule-search/access-rule-search.component.ts
@@ -48,6 +48,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   ACCESS_RULE,
   ORIGIN_WAITING_RECALCULATE,
   ORIGIN_HAS_NO_ONE,
@@ -101,6 +102,7 @@ export class AccessRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.accessRuleCriteriaForm = this.formBuilder.group({
       accessRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -362,46 +364,21 @@ export class AccessRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
+          [...searchCriteria.entries()].filter(([key]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.ACCESS_RULE,
-              );
               this.accessAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_HAS_AT_LEAST_ONE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.ACCESS_RULE,
-          );
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_INHERITE_AT_LEAST_ONE },
-            ORIGIN_INHERITE_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.ACCESS_RULE,
-          );
+          this.queryParamsService
+            .builder()
+            .addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE)
+            .addQueryParam(RULE_TYPE, ORIGIN_INHERITE_AT_LEAST_ONE)
+            .navigate({ replaceUrl: true });
           this.accessAdditionalCriteria.set(ORIGIN_INHERITE_AT_LEAST_ONE, true);
           this.accessAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/appraisal-rule-search/appraisal-rule-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/appraisal-rule-search/appraisal-rule-search.component.ts
@@ -48,6 +48,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   APPRAISAL_RULE,
   FINAL_ACTION_TYPE_ELIMINATION,
   FINAL_ACTION_TYPE_KEEP,
@@ -117,6 +118,7 @@ export class AppraisalRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.appraisalRuleCriteriaForm = this.formBuilder.group({
       appraisalRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -484,46 +486,21 @@ export class AppraisalRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => keysList.includes(key)),
+          [...searchCriteria.entries()].filter(([key]) => keysList.includes(key)),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.ACCESS_RULE,
-              );
               this.appraisalAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_HAS_AT_LEAST_ONE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.APPRAISAL_RULE,
-          );
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_INHERITE_AT_LEAST_ONE },
-            ORIGIN_INHERITE_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.APPRAISAL_RULE,
-          );
+          this.queryParamsService
+            .builder()
+            .addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE)
+            .addQueryParam(RULE_TYPE, ORIGIN_INHERITE_AT_LEAST_ONE)
+            .navigate({ replaceUrl: true });
           this.appraisalAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
           this.appraisalAdditionalCriteria.set(ORIGIN_INHERITE_AT_LEAST_ONE, true);
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/dissemination-rule-search/dissemination-rule-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/dissemination-rule-search/dissemination-rule-search.component.ts
@@ -48,6 +48,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   DISSEMINATION_RULE,
   ORIGIN_WAITING_RECALCULATE,
   ORIGIN_HAS_NO_ONE,
@@ -101,6 +102,7 @@ export class DisseminationRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.disseminationRuleCriteriaForm = this.formBuilder.group({
       disseminationRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -365,46 +367,21 @@ export class DisseminationRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
+          [...searchCriteria.entries()].filter(([key]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.ACCESS_RULE,
-              );
               this.disseminationAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_HAS_AT_LEAST_ONE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.DISSEMINATION_RULE,
-          );
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_INHERITE_AT_LEAST_ONE },
-            ORIGIN_INHERITE_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.DISSEMINATION_RULE,
-          );
+          this.queryParamsService
+            .builder()
+            .addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE)
+            .addQueryParam(RULE_TYPE, ORIGIN_INHERITE_AT_LEAST_ONE)
+            .navigate({ replaceUrl: true });
           this.disseminationAdditionalCriteria.set(ORIGIN_INHERITE_AT_LEAST_ONE, true);
           this.disseminationAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/reuse-rule-search/reuse-rule-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/reuse-rule-search/reuse-rule-search.component.ts
@@ -48,6 +48,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   REUSE_RULE,
   ORIGIN_WAITING_RECALCULATE,
   ORIGIN_HAS_NO_ONE,
@@ -101,6 +102,7 @@ export class ReuseRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.reuseRuleCriteriaForm = this.formBuilder.group({
       reuseRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -362,46 +364,21 @@ export class ReuseRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
+          [...searchCriteria.entries()].filter(([key]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.ACCESS_RULE,
-              );
               this.reuseAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_HAS_AT_LEAST_ONE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.REUSE_RULE,
-          );
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_INHERITE_AT_LEAST_ONE },
-            ORIGIN_INHERITE_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.REUSE_RULE,
-          );
+          this.queryParamsService
+            .builder()
+            .addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE)
+            .addQueryParam(RULE_TYPE, ORIGIN_INHERITE_AT_LEAST_ONE)
+            .navigate({ replaceUrl: true });
           this.reuseAdditionalCriteria.set(ORIGIN_INHERITE_AT_LEAST_ONE, true);
           this.reuseAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/storage-rule-search/storage-rule-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search-by-mgt-rules/storage-rule-search/storage-rule-search.component.ts
@@ -49,6 +49,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   STORAGE_RULE,
   FINAL_ACTION_TYPE_COPY,
   FINAL_ACTION_TYPE_TRANSFER,
@@ -116,6 +117,7 @@ export class StorageRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.storageRuleCriteriaForm = this.formBuilder.group({
       storageRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -491,46 +493,21 @@ export class StorageRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => keysList.includes(key)),
+          [...searchCriteria.entries()].filter(([key]) => keysList.includes(key)),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.ACCESS_RULE,
-              );
               this.storageAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_HAS_AT_LEAST_ONE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.STORAGE_RULE,
-          );
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { id: RULE_TYPE, value: ORIGIN_INHERITE_AT_LEAST_ONE },
-            ORIGIN_INHERITE_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.STORAGE_RULE,
-          );
+          this.queryParamsService
+            .builder()
+            .addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE)
+            .addQueryParam(RULE_TYPE, ORIGIN_INHERITE_AT_LEAST_ONE)
+            .navigate({ replaceUrl: true });
           this.storageAdditionalCriteria.set(ORIGIN_INHERITE_AT_LEAST_ONE, true);
           this.storageAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/access-rule-search/access-rule-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/access-rule-search/access-rule-search.component.ts
@@ -49,6 +49,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   ACCESS_RULE,
   ORIGIN_WAITING_RECALCULATE,
   ORIGIN_HAS_NO_ONE,
@@ -101,6 +102,7 @@ export class AccessRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.accessRuleCriteriaForm = this.formBuilder.group({
       accessRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -341,36 +343,17 @@ export class AccessRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriteria: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
+          [...searchCriteria.entries()].filter(([key]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
         );
 
         if (filteredCriteria && filteredCriteria.size > 0) {
-          filteredCriteria.forEach((value, key) => {
+          filteredCriteria.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.ACCESS_RULE,
-              );
               this.accessAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { value: ORIGIN_HAS_AT_LEAST_ONE, id: RULE_TYPE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.ACCESS_RULE,
-          );
+          this.queryParamsService.builder().addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE).navigate({ replaceUrl: true });
           this.accessAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }
       });

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/appraisal-rule-search/appraisal-rule-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/appraisal-rule-search/appraisal-rule-search.component.ts
@@ -49,6 +49,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   APPRAISAL_RULE,
   FINAL_ACTION_TYPE_ELIMINATION,
   FINAL_ACTION_TYPE_KEEP,
@@ -116,6 +117,7 @@ export class AppraisalRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.appraisalRuleCriteriaForm = this.formBuilder.group({
       appraisalRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -442,36 +444,17 @@ export class AppraisalRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => keysList.includes(key)),
+          [...searchCriteria.entries()].filter(([key]) => keysList.includes(key)),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.APPRAISAL_RULE,
-              );
               this.appraisalAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { value: ORIGIN_HAS_AT_LEAST_ONE, id: RULE_TYPE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.APPRAISAL_RULE,
-          );
+          this.queryParamsService.builder().addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE).navigate({ replaceUrl: true });
           this.appraisalAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }
       });

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/dissemination-rule-search/dissemination-rule-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/dissemination-rule-search/dissemination-rule-search.component.ts
@@ -49,6 +49,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   DISSEMINATION_RULE,
   ORIGIN_WAITING_RECALCULATE,
   ORIGIN_HAS_NO_ONE,
@@ -103,6 +104,7 @@ export class DisseminationRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.disseminationRuleCriteriaForm = this.formBuilder.group({
       disseminationRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -345,36 +347,17 @@ export class DisseminationRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
+          [...searchCriteria.entries()].filter(([key]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.DISSEMINATION_RULE,
-              );
               this.disseminationAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { value: ORIGIN_HAS_AT_LEAST_ONE, id: RULE_TYPE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.DISSEMINATION_RULE,
-          );
+          this.queryParamsService.builder().addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE).navigate({ replaceUrl: true });
           this.disseminationAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }
       });

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/reuse-rule-search/reuse-rule-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/reuse-rule-search/reuse-rule-search.component.ts
@@ -49,6 +49,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   REUSE_RULE,
   ORIGIN_WAITING_RECALCULATE,
   ORIGIN_HAS_NO_ONE,
@@ -101,6 +102,7 @@ export class ReuseRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.reuseRuleCriteriaForm = this.formBuilder.group({
       reuseRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -341,36 +343,17 @@ export class ReuseRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
+          [...searchCriteria.entries()].filter(([key]) => key === RULE_ORIGIN + RULE_TYPE_SUFFIX),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.REUSE_RULE,
-              );
               this.reuseAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { value: ORIGIN_HAS_AT_LEAST_ONE, id: RULE_TYPE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.REUSE_RULE,
-          );
+          this.queryParamsService.builder().addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE).navigate({ replaceUrl: true });
           this.reuseAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }
       });

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/storage-rule-search/storage-rule-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/storage-rule-search/storage-rule-search.component.ts
@@ -49,6 +49,7 @@ import {
   diff,
   CriteriaSearchCriteria,
   SearchCriteriaValue,
+  QueryParamsService,
   STORAGE_RULE,
   FINAL_ACTION_TYPE_COPY,
   FINAL_ACTION_TYPE_TRANSFER,
@@ -114,6 +115,7 @@ export class StorageRuleSearchComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private archiveExchangeDataService: ArchiveSharedDataService,
     private ruleValidator: RuleValidator,
+    private queryParamsService: QueryParamsService,
   ) {
     this.storageRuleCriteriaForm = this.formBuilder.group({
       storageRuleIdentifier: [null, [ManagementRuleValidators.ruleIdPattern], this.ruleValidator.uniqueRuleId()],
@@ -209,36 +211,17 @@ export class StorageRuleSearchComponent implements OnInit, OnDestroy {
       )
       .subscribe((searchCriteria) => {
         const filteredCriterias: Map<string, CriteriaSearchCriteria> = new Map(
-          [...searchCriteria.entries()].filter(([key, _]) => keysList.includes(key)),
+          [...searchCriteria.entries()].filter(([key]) => keysList.includes(key)),
         );
 
         if (filteredCriterias && filteredCriterias.size > 0) {
-          filteredCriterias.forEach((value, key) => {
+          filteredCriterias.forEach((value) => {
             value.values.forEach((searchCriteria: SearchCriteriaValue) => {
-              this.addCriteria(
-                key,
-                { value: searchCriteria.value.value, id: searchCriteria.value.id },
-                searchCriteria.value.value,
-                true,
-                value.operator,
-                true,
-                CriteriaDataType.STRING,
-                SearchCriteriaTypeEnum.STORAGE_RULE,
-              );
               this.storageAdditionalCriteria.set(searchCriteria.value.value, true);
             });
           });
         } else {
-          this.addCriteria(
-            RULE_ORIGIN + RULE_TYPE_SUFFIX,
-            { value: ORIGIN_HAS_AT_LEAST_ONE, id: RULE_TYPE },
-            ORIGIN_HAS_AT_LEAST_ONE,
-            true,
-            CriteriaOperator.EXISTS,
-            true,
-            CriteriaDataType.STRING,
-            SearchCriteriaTypeEnum.STORAGE_RULE,
-          );
+          this.queryParamsService.builder().addQueryParam(RULE_TYPE, ORIGIN_HAS_AT_LEAST_ONE).navigate({ replaceUrl: true });
           this.storageAdditionalCriteria.set(ORIGIN_HAS_AT_LEAST_ONE, true);
         }
       });


### PR DESCRIPTION
## Description

Sur Archive-search, sur la recherche par règles de gestion (DUA, DUC,...) , nous pouvions constater deux critères cochés mais seulement un filtre apparent. Correction sur Archive-Search et Collecte (par souci de cohérence), bien que sur cette dernière seul une case est cochée par règle
