### PR TITLE
Bug #14488 [External MDD] MDDs are not saved after modification in the Search APP; a required field appears in edit mode.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/archive-unit-editor/archive-unit-editor.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/archive-unit-editor/archive-unit-editor.service.ts
@@ -190,7 +190,7 @@ export class ArchiveUnitEditorService {
       jsonPatch.push({ op: 'replace', path: key, value: consistentUpdatedValue[key] });
     });
 
-    return jsonPatch;
+    return this.transformJsonPatch(jsonPatch);
   }
 
   public toJsonPatchDto(): JsonPatchDto {
@@ -227,5 +227,31 @@ export class ArchiveUnitEditorService {
     if (archiveUnitProfileId) return this.schemaService.getArchiveUnitProfileSchema(archiveUnitProfileId);
 
     return this.schemaService.getSchema(this.collection.value);
+  }
+
+  private transformJsonPatch(jsonPatch: JsonPatch): JsonPatch {
+    const transformedPatch: JsonPatch = [];
+    const otherMetadataFields = this.template.value
+      .filter((element) => element.ui.Path.startsWith('OtherMetadata'))
+      .map((item) => item.Path);
+
+    jsonPatch.forEach((cmd) => {
+      // Check if the path is in the list of fields to be exploded
+      if (otherMetadataFields.includes(cmd.path) && typeof cmd.value === 'object' && !Array.isArray(cmd.value)) {
+        // Decompose the object into multiple patch operations
+        Object.entries(cmd.value).forEach(([key, val]) => {
+          transformedPatch.push({
+            op: cmd.op,
+            path: `${cmd.path}.${key}`, // Concatenate the parent path and the key
+            value: val,
+          });
+        });
+      } else {
+        // Keep the operation unchanged if it doesn't match criteria
+        transformedPatch.push(cmd);
+      }
+    });
+
+    return transformedPatch;
   }
 }


### PR DESCRIPTION
La sauvegarde des métadonnées externes ne se fait pas côté back-end.

Actuellement, lorsqu’on modifie ces métadonnées, une requête de ce type est envoyée au back-end :

 ```json
{
    "id": "aeaqaaaaaefafvuqacsu4amwhi2zfkyaaada",
    "jsonPatch": [
        {
            "op": "add",
            "path": "MyObject",
            "value": {
                "MyText": "ter",
                "MyKeyword": "sa",
                "MyDouble": "de"
            }
        }
    ]
}
```

Cette requête ne renvoie pas d’erreur, mais les données ne sont pas enregistrées en base de données. Pour que cela fonctionne correctement, j’ai dû la modifier de cette façon :
 
```json
 {
    "id": "aeaqaaaaaefafvuqacsu4amwhi2zfkyaaada",
    "jsonPatch": [
        {
            "op": "add",
            "path": "MyObject.MyText",
            "value": "ter"
        },
        {
            "op": "add",
            "path": "MyObject.MyKeyword",
            "value": "sa"
        },
        {
            "op": "add",
            "path": "MyObject.MyDouble",
            "value": "de"
        }
    ]
}
```