### PR TITLE
bug #14532 : Reclassification error

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -413,7 +413,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     this.listOfUACriteriaSearch = this.prepareListOfUACriteriaSearch();
     const reclassificationCriteria = {
       criteriaList: this.listOfUACriteriaSearch,
-      pageNumber: this.currentPage,
+      pageNumber: 0,
       size: PAGE_SIZE,
       language: this.translateService.currentLang,
       tenantIdentifier: this.tenantIdentifier,


### PR DESCRIPTION
## Description

Le paramètre `pageNumber` (pour le reclassement Collecte) doit être configuré à 0, sinon une partie des résultats sont manquants. Il doit adopter le même comportement que sur Archive-Search
