### PR TITLE
Bugs #14474: ensure that client certificate is sent to IAM and do not allow anonymous authentication

### DIFF
--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/ApiWebSecurityConfig.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/ApiWebSecurityConfig.java
@@ -48,6 +48,7 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,24 +96,28 @@ public abstract class ApiWebSecurityConfig extends WebSecurityConfigurerAdapter 
 
     @Override
     protected void configure(final HttpSecurity http) throws Exception {
+        // @formatter:off
         http
             .authorizeRequests()
-            .antMatchers(getAuthList())
-            .permitAll()
-            .anyRequest()
-            .authenticated()
+                .antMatchers(getAuthList())
+                .permitAll()
             .and()
-            .cors()
-            .configurationSource(request -> getCorsConfiguration())
+            .authorizeRequests()
+                .anyRequest()
+                .authenticated()
             .and()
-            .exceptionHandling()
-            .authenticationEntryPoint(getUnauthorizedHandler())
+                .cors()
+                .configurationSource(this::getCorsConfiguration)
             .and()
-            .csrf()
-            .disable()
+                .exceptionHandling()
+                .authenticationEntryPoint(getUnauthorizedHandler())
+            .and()
+                .csrf()
+                .disable()
             .addFilterAt(getRequestHeadersAuthenticationFilter(), BasicAuthenticationFilter.class)
             .sessionManagement()
-            .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        // @formatter:on
     }
 
     private CorsConfiguration getCorsConfiguration() {
@@ -176,5 +181,9 @@ public abstract class ApiWebSecurityConfig extends WebSecurityConfigurerAdapter 
             tokenExtractors.add(TokenExtractor.bearerExtractor());
         }
         return tokenExtractors;
+    }
+
+    private CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+        return getCorsConfiguration();
     }
 }

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/service/SecurityService.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/service/SecurityService.java
@@ -46,6 +46,7 @@ import fr.gouv.vitamui.commons.rest.client.HttpContext;
 import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
 import fr.gouv.vitamui.iam.security.authentication.AuthenticationToken;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Collections;
@@ -59,12 +60,11 @@ import java.util.stream.Collectors;
 public class SecurityService {
 
     public AuthenticationToken getAuthentication() {
-        final AuthenticationToken authenticationToken = (AuthenticationToken) SecurityContextHolder.getContext()
-            .getAuthentication();
-        if (authenticationToken == null) {
-            throw new UnAuthorizedException("Unable to get the security context. You probably are not authenticated.");
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof AuthenticationToken authenticationToken) {
+            return authenticationToken;
         }
-        return authenticationToken;
+        throw new UnAuthorizedException("Unable to get the security context. You probably are not authenticated.");
     }
 
     /**

--- a/deployment/roles/vitamui/templates/archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search/application.yml.j2
@@ -68,6 +68,10 @@ archive-search:
 {% if vitamui.iam.secure | default(secure) | bool == true %}
     secure: {{ vitamui.iam.secure | default(secure) | lower }}
     ssl-configuration:
+      keystore:
+        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
+        key-password: {{ password_keystore }}
+        type: JKS
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
         key-password: {{ password_truststore }}

--- a/deployment/roles/vitamui/templates/collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect/application.yml.j2
@@ -77,6 +77,10 @@ collect:
 {% if vitamui.iam.secure | default(secure) | bool == true %}
     secure: {{ vitamui.iam.secure | default(secure) | lower }}
     ssl-configuration:
+      keystore:
+        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
+        key-password: {{ password_keystore }}
+        type: JKS
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
         key-password: {{ password_truststore }}

--- a/deployment/roles/vitamui/templates/ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest/application.yml.j2
@@ -65,6 +65,10 @@ ingest:
 {% if vitamui.iam.secure | default(secure) | bool == true %}
     secure: {{ vitamui.iam.secure | default(secure) | lower }}
     ssl-configuration:
+      keystore:
+        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
+        key-password: {{ password_keystore }}
+        type: JKS
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
         key-password: {{ password_truststore }}

--- a/deployment/roles/vitamui/templates/pastis/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis/application.yml.j2
@@ -87,6 +87,10 @@ pastis:
 {% if vitamui.iam.secure | default(secure) | bool == true %}
     secure: {{ vitamui.iam.secure | default(secure) | lower }}
     ssl-configuration:
+      keystore:
+        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
+        key-password: {{ password_keystore }}
+        type: JKS
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
         key-password: {{ password_truststore }}

--- a/deployment/roles/vitamui/templates/referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential/application.yml.j2
@@ -75,6 +75,10 @@ referential:
 {% if vitamui.iam.secure | default(secure) | bool == true %}
     secure: {{ vitamui.iam.secure | default(secure) | lower }}
     ssl-configuration:
+      keystore:
+        key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
+        key-password: {{ password_keystore }}
+        type: JKS
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
         key-password: {{ password_truststore }}


### PR DESCRIPTION
- ApiWebSecurityConfig: désactivation de l'authentification anonyme. Soit on a le header Authorization soit on a un certificat client (via la requête ou positionné dans le header par l'API GW)
- SecurityService: code plus robuste
- */application.yml.j2: ajout du certificat client
