### PR TITLE
Bug #14578: add controls to check the access to tenants

### DIFF
--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/security/WebSecurityConfig.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/security/WebSecurityConfig.java
@@ -29,6 +29,7 @@ package fr.gouv.vitamui.archives.search.server.security;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.ApiWebSecurityConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -36,8 +37,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 
 /**
  * The security configuration.
- *
- *
  */
 @EnableWebSecurity
 @Configuration
@@ -47,8 +46,9 @@ public class WebSecurityConfig extends ApiWebSecurityConfig {
     public WebSecurityConfig(
         final ApiAuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, securityService, env);
     }
 }

--- a/api/api-archive-search/archive-search/src/main/resources/application-dev.yml
+++ b/api/api-archive-search/archive-search/src/main/resources/application-dev.yml
@@ -23,7 +23,7 @@ multipart:
 
 spring.servlet.multipart.max-file-size: -1
 spring.servlet.multipart.max-request-size: -1
-
+cas.tenant.identifier: -1
 server:
   host:
   port: 8089

--- a/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/rest/ApiArchiveSearchControllerTest.java
+++ b/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/rest/ApiArchiveSearchControllerTest.java
@@ -40,6 +40,7 @@ import fr.gouv.vitamui.archives.search.server.security.WebSecurityConfig;
 import fr.gouv.vitamui.commons.api.domain.IdDto;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
@@ -50,4 +51,7 @@ public abstract class ApiArchiveSearchControllerTest<T extends IdDto> extends Ap
 
     @MockBean
     private ApiAuthenticationProvider apiAuthenticationProvider;
+
+    @MockBean
+    private SecurityService securityService;
 }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/security/WebSecurityConfig.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/security/WebSecurityConfig.java
@@ -30,6 +30,7 @@ package fr.gouv.vitamui.collect.server.security;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.ApiWebSecurityConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -37,8 +38,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 
 /**
  * The security configuration.
- *
- *
  */
 @EnableWebSecurity
 @Configuration
@@ -48,8 +47,9 @@ public class WebSecurityConfig extends ApiWebSecurityConfig {
     public WebSecurityConfig(
         final ApiAuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, securityService, env);
     }
 }

--- a/api/api-collect/collect/src/main/resources/application-dev.yml
+++ b/api/api-collect/collect/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ multipart:
 
 spring.servlet.multipart.max-file-size: -1
 spring.servlet.multipart.max-request-size: -1
-
+cas.tenant.identifier: -1
 server:
   host:
   port: 8090

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/rest/ApiCollectControllerTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/rest/ApiCollectControllerTest.java
@@ -33,6 +33,7 @@ import fr.gouv.vitamui.collect.server.security.WebSecurityConfig;
 import fr.gouv.vitamui.commons.api.domain.IdDto;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
@@ -43,4 +44,7 @@ public abstract class ApiCollectControllerTest<T extends IdDto> extends ApiContr
 
     @MockBean
     private ApiAuthenticationProvider apiAuthenticationProvider;
+
+    @MockBean
+    protected SecurityService securityService;
 }

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/rest/TransactionArchiveUnitControllerTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/rest/TransactionArchiveUnitControllerTest.java
@@ -46,7 +46,6 @@ import fr.gouv.vitamui.commons.api.dtos.VitamUiOntologyDto;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
 import fr.gouv.vitamui.commons.vitam.api.dto.ResultsDto;
-import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,9 +79,6 @@ class TransactionArchiveUnitControllerTest extends ApiCollectControllerTest<IdDt
 
     @MockBean
     private ExternalParametersService externalParametersService;
-
-    @MockBean
-    private SecurityService securityService;
 
     private TransactionArchiveUnitController transactionArchiveUnitController;
 

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/ApiWebSecurityConfig.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/ApiWebSecurityConfig.java
@@ -32,8 +32,10 @@ package fr.gouv.vitamui.iam.security.config;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.filter.RequestHeadersAuthenticationFilter;
+import fr.gouv.vitamui.iam.security.filter.TenantHeaderFilter;
 import fr.gouv.vitamui.iam.security.filter.TokenExtractor;
 import fr.gouv.vitamui.iam.security.filter.X509CertificateExtractor;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.context.annotation.Bean;
@@ -62,31 +64,37 @@ import static org.springframework.http.HttpMethod.PUT;
 
 /**
  * The security configuration.
- *
  */
 @Getter
 @Setter
 public abstract class ApiWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private static final String GATEWAY_ENABLED = "gateway.enabled";
+    private static final String CAS_TENANT_IDENTIFIER = "cas.tenant.identifier";
 
     private static final String CLIENT_CERTIFICATE_HEADER_NAME = "server.ssl.client-certificate-header-name";
 
     protected AuthenticationProvider apiAuthenticationProvider;
     protected RestExceptionHandler restExceptionHandler;
+    protected SecurityService securityService;
     protected Environment env;
     private final boolean isGatewayEnabled;
+    private final Integer casTenantIdentifier;
 
     public ApiWebSecurityConfig(
         final AuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
         super();
         this.apiAuthenticationProvider = apiAuthenticationProvider;
         this.restExceptionHandler = restExceptionHandler;
+        this.securityService = securityService;
         this.env = env;
+
         this.isGatewayEnabled = env.getProperty(GATEWAY_ENABLED, Boolean.class, false);
+        this.casTenantIdentifier = env.getProperty(CAS_TENANT_IDENTIFIER, Integer.class, -1);
     }
 
     @Override
@@ -115,6 +123,7 @@ public abstract class ApiWebSecurityConfig extends WebSecurityConfigurerAdapter 
                 .csrf()
                 .disable()
             .addFilterAt(getRequestHeadersAuthenticationFilter(), BasicAuthenticationFilter.class)
+            .addFilterAt(getTenantHeaderFilter(), BasicAuthenticationFilter.class)
             .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         // @formatter:on
@@ -158,6 +167,10 @@ public abstract class ApiWebSecurityConfig extends WebSecurityConfigurerAdapter 
             getX509CertificateExtractors(),
             getTokenExtractors()
         );
+    }
+
+    protected TenantHeaderFilter getTenantHeaderFilter() {
+        return new TenantHeaderFilter(securityService, casTenantIdentifier);
     }
 
     // This is a temporary patch to allow mTLS authentication behind reverse proxy or full mTLS during migration

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilter.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilter.java
@@ -1,0 +1,107 @@
+/*
+ *
+ *  Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ *  and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ *  contact@programmevitam.fr
+ *
+ *  This software is a computer program whose purpose is to implement
+ *  implement a digital archiving front-office system for the secure and
+ *  efficient high volumetry VITAM solution.
+ *
+ *  This software is governed by the CeCILL-C license under French law and
+ *  abiding by the rules of distribution of free software.  You can  use,
+ *  modify and/ or redistribute the software under the terms of the CeCILL-C
+ *  license as circulated by CEA, CNRS and INRIA at the following URL
+ *  "http://www.cecill.info".
+ *
+ *  As a counterpart to the access to the source code and  rights to copy,
+ *  modify and redistribute granted by the license, users are provided only
+ *  with a limited warranty  and the software's author,  the holder of the
+ *  economic rights,  and the successive licensors  have only  limited
+ *  liability.
+ *
+ *  In this respect, the user's attention is drawn to the risks associated
+ *  with loading,  using,  modifying and/or developing or reproducing the
+ *  software by the user in light of its specific status of free software,
+ *  that may mean  that it is complicated to manipulate,  and  that  also
+ *  therefore means  that it is reserved for developers  and  experienced
+ *  professionals having in-depth computer knowledge. Users are therefore
+ *  encouraged to load and test the software's suitability as regards their
+ *  requirements in conditions enabling the security of their systems and/or
+ *  data to be ensured and,  more generally, to use and operate it in the
+ *  same conditions as regards security.
+ *
+ *  The fact that you are presently reading this means that you have had
+ *  knowledge of the CeCILL-C license and that you accept its terms.
+ *
+ */
+
+package fr.gouv.vitamui.iam.security.filter;
+
+import fr.gouv.vitamui.commons.api.CommonConstants;
+import fr.gouv.vitamui.commons.api.domain.Role;
+import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
+import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+public class TenantHeaderFilter extends OncePerRequestFilter {
+
+    public static final String ROLE_CROSS_TENANTS_SUFFIX = "_ALL_TENANTS";
+    private final SecurityService securityService;
+    private final Integer casTenant;
+
+    public TenantHeaderFilter(SecurityService securityService, Integer casTenant) {
+        this.securityService = securityService;
+        this.casTenant = casTenant;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        String tenantIdHeader = request.getHeader(CommonConstants.X_TENANT_ID_HEADER);
+        //The control only when the header is set
+        if (StringUtils.isNotBlank(tenantIdHeader)) {
+            try {
+                AuthUserDto user = securityService.getUser();
+                Integer requestTenantId = Integer.parseInt(tenantIdHeader);
+                Integer sessionTenantId = user.getProofTenantIdentifier();
+                if (!Objects.equals(requestTenantId, sessionTenantId)) {
+                    List<Role> userRoles = SecurityService.getRoles(securityService.getUser());
+                    boolean hasAnyCrossTenantRole = userRoles
+                        .stream()
+                        .anyMatch(r -> r.getName().endsWith(ROLE_CROSS_TENANTS_SUFFIX));
+                    if (!hasAnyCrossTenantRole) {
+                        if (!casTenant.equals(requestTenantId)) {
+                            // Check if the user has access to this tenant
+                            try {
+                                securityService.getTenant(requestTenantId);
+                            } catch (ApplicationServerException e) {
+                                log.error("User not allowed on tenant {}", tenantIdHeader);
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized access to tenant");
+                                return;
+                            }
+                        }
+                    }
+                }
+            } catch (NumberFormatException e) {
+                log.warn("Invalid tenant ID format: {}", tenantIdHeader);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid tenant ID format");
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/api/api-iam/iam-security/src/test/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilterTest.java
+++ b/api/api-iam/iam-security/src/test/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilterTest.java
@@ -1,0 +1,204 @@
+/*
+ *
+ *  Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ *  and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ *  contact@programmevitam.fr
+ *
+ *  This software is a computer program whose purpose is to implement
+ *  implement a digital archiving front-office system for the secure and
+ *  efficient high volumetry VITAM solution.
+ *
+ *  This software is governed by the CeCILL-C license under French law and
+ *  abiding by the rules of distribution of free software.  You can  use,
+ *  modify and/ or redistribute the software under the terms of the CeCILL-C
+ *  license as circulated by CEA, CNRS and INRIA at the following URL
+ *  "http://www.cecill.info".
+ *
+ *  As a counterpart to the access to the source code and  rights to copy,
+ *  modify and redistribute granted by the license, users are provided only
+ *  with a limited warranty  and the software's author,  the holder of the
+ *  economic rights,  and the successive licensors  have only  limited
+ *  liability.
+ *
+ *  In this respect, the user's attention is drawn to the risks associated
+ *  with loading,  using,  modifying and/or developing or reproducing the
+ *  software by the user in light of its specific status of free software,
+ *  that may mean  that it is complicated to manipulate,  and  that  also
+ *  therefore means  that it is reserved for developers  and  experienced
+ *  professionals having in-depth computer knowledge. Users are therefore
+ *  encouraged to load and test the software's suitability as regards their
+ *  requirements in conditions enabling the security of their systems and/or
+ *  data to be ensured and,  more generally, to use and operate it in the
+ *  same conditions as regards security.
+ *
+ *  The fact that you are presently reading this means that you have had
+ *  knowledge of the CeCILL-C license and that you accept its terms.
+ *
+ */
+
+package fr.gouv.vitamui.iam.security.filter;
+
+import fr.gouv.vitamui.commons.api.CommonConstants;
+import fr.gouv.vitamui.commons.api.domain.GroupDto;
+import fr.gouv.vitamui.commons.api.domain.ProfileDto;
+import fr.gouv.vitamui.commons.api.domain.Role;
+import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
+import fr.gouv.vitamui.iam.common.utils.DtoFactory;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class TenantHeaderFilterTest {
+
+    private static final String PROFILE_ID = "PROFILE_ID";
+
+    @Mock
+    private SecurityService securityService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private TenantHeaderFilter tenantHeaderFilter;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        tenantHeaderFilter = new TenantHeaderFilter(securityService, 999); // assume casTenant = 999
+    }
+
+    @Test
+    void testNoTenantHeader() throws ServletException, IOException {
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn(null);
+
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(securityService);
+    }
+
+    @Test
+    void testInvalidTenantHeader() throws ServletException, IOException {
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("invalid");
+
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid tenant ID format");
+        verifyNoInteractions(filterChain);
+    }
+
+    @Test
+    void testMatchingTenantId() throws ServletException, IOException {
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("123");
+        AuthUserDto user = mock(AuthUserDto.class);
+        when(user.getProofTenantIdentifier()).thenReturn(123);
+        when(securityService.getUser()).thenReturn(user);
+
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void testCrossTenantRoleAllowsAccess() throws ServletException, IOException {
+        Integer tenantIdentifier = 123;
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("124");
+        GroupDto groupDto = new GroupDto();
+        groupDto.setProfiles(
+            List.of(
+                buildProfileDto(
+                    PROFILE_ID,
+                    "PROFILE_NAME",
+                    "CUSTOMER_ID",
+                    tenantIdentifier,
+                    "APP_NAME",
+                    List.of(new Role("ROLE_1"), new Role("ROLE_2"), new Role("_ALL_TENANTS"))
+                )
+            )
+        );
+        final AuthUserDto user = new AuthUserDto();
+        user.setProfileGroup(groupDto);
+        user.setProofTenantIdentifier(tenantIdentifier);
+        when(securityService.getUser()).thenReturn(user);
+        when(securityService.getTenant(anyInt())).thenCallRealMethod();
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void testUnauthorizedTenantAccess() throws ServletException, IOException {
+        Integer tenantIdentifier = 123;
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("124");
+        GroupDto groupDto = new GroupDto();
+        groupDto.setProfiles(
+            List.of(
+                buildProfileDto(
+                    PROFILE_ID,
+                    "PROFILE_NAME",
+                    "CUSTOMER_ID",
+                    tenantIdentifier,
+                    "APP_NAME",
+                    List.of(new Role("ROLE_1"), new Role("ROLE_2"))
+                )
+            )
+        );
+        final AuthUserDto user = new AuthUserDto();
+        user.setProfileGroup(groupDto);
+        user.setProofTenantIdentifier(tenantIdentifier);
+        when(securityService.getUser()).thenReturn(user);
+        when(securityService.getTenant(anyInt())).thenCallRealMethod();
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized access to tenant");
+        verifyNoMoreInteractions(filterChain);
+    }
+
+    public static ProfileDto buildProfileDto(
+        final String id,
+        final String name,
+        final String customerId,
+        final Integer tenantId,
+        final String applicationName,
+        final List<Role> roles
+    ) {
+        final ProfileDto profileDto = DtoFactory.buildProfileDto(
+            name,
+            "description",
+            false,
+            "level",
+            tenantId,
+            applicationName,
+            new ArrayList<String>(),
+            customerId
+        );
+        profileDto.setId(id);
+        profileDto.setRoles(roles);
+        return profileDto;
+    }
+}

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/security/WebSecurityConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/security/WebSecurityConfig.java
@@ -38,6 +38,7 @@ package fr.gouv.vitamui.iam.server.security;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.ApiWebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -56,8 +57,9 @@ public class WebSecurityConfig extends ApiWebSecurityConfig {
     public WebSecurityConfig(
         final IamApiAuthenticationProvider iamApiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
-        super(iamApiAuthenticationProvider, restExceptionHandler, env);
+        super(iamApiAuthenticationProvider, restExceptionHandler, securityService, env);
     }
 }

--- a/api/api-iam/iam/src/main/resources/application-dev.yml
+++ b/api/api-iam/iam/src/main/resources/application-dev.yml
@@ -63,6 +63,7 @@ cas-client:
     hostname-verification: false
 
 cas.reset.password.url: /cas/extras/resetPassword?username={username}&firstname={firstname}&lastname={lastname}&language={language}&customerId={customerId}&ttl=1day
+cas.tenant.identifier: -1
 
 login:
   url: http://dev.vitamui.com:8080/cas/login

--- a/api/api-iam/iam/src/main/resources/application.yml
+++ b/api/api-iam/iam/src/main/resources/application.yml
@@ -43,3 +43,4 @@ subrogation.ttl: 30
 cas.reset.password.url: /extras/resetPassword?username={username}&firstname={firstname}&lastname={lastname}&language={language}&customerId={customerId}&ttl=1day
 
 user.connection.tracing.enabled: false
+

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/common/rest/ApiIamControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/common/rest/ApiIamControllerTest.java
@@ -2,6 +2,7 @@ package fr.gouv.vitamui.iam.server.common.rest;
 
 import fr.gouv.vitamui.commons.api.domain.IdDto;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.customer.dao.CustomerRepository;
 import fr.gouv.vitamui.iam.server.security.IamApiAuthenticationProvider;
 import fr.gouv.vitamui.iam.server.security.WebSecurityConfig;
@@ -19,4 +20,7 @@ public abstract class ApiIamControllerTest<T extends IdDto> extends ApiCrudContr
 
     @MockBean
     private CustomerRepository repository;
+
+    @MockBean
+    private SecurityService securityService;
 }

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/GroupExternalControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/GroupExternalControllerTest.java
@@ -5,7 +5,6 @@ import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.domain.GroupDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
-import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.rest.ApiIamControllerTest;
 import fr.gouv.vitamui.iam.server.group.service.GroupService;
 import org.junit.Test;
@@ -32,9 +31,6 @@ public class GroupExternalControllerTest extends ApiIamControllerTest<GroupDto> 
 
     @MockBean
     private GroupService service;
-
-    @MockBean
-    private SecurityService securityService;
 
     private GroupController mockedController = MvcUriComponentsBuilder.on(GroupController.class);
 

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/ProfileControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/ProfileControllerTest.java
@@ -5,7 +5,6 @@ import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.domain.ProfileDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
-import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.rest.ApiIamControllerTest;
 import fr.gouv.vitamui.iam.server.profile.service.ProfileService;
 import fr.gouv.vitamui.iam.server.utils.IamServerUtilsTest;
@@ -29,9 +28,6 @@ public class ProfileControllerTest extends ApiIamControllerTest<ProfileDto> {
 
     @MockBean
     private ProfileService profileService;
-
-    @MockBean
-    private SecurityService securityService;
 
     @Test
     public void testGetAllProfiles() {

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/ProfileExternalControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/ProfileExternalControllerTest.java
@@ -5,7 +5,6 @@ import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.domain.ProfileDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
-import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.rest.ApiIamControllerTest;
 import fr.gouv.vitamui.iam.server.profile.service.ProfileService;
 import fr.gouv.vitamui.iam.server.utils.ApiIamServerUtils;
@@ -33,9 +32,6 @@ public class ProfileExternalControllerTest extends ApiIamControllerTest<ProfileD
 
     @MockBean
     private ProfileService profileExternalService;
-
-    @MockBean
-    private SecurityService securityService;
 
     private ProfileController mockedController = MvcUriComponentsBuilder.on(ProfileController.class);
 

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/UserExternalControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/UserExternalControllerTest.java
@@ -6,7 +6,6 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.domain.UserDto;
 import fr.gouv.vitamui.commons.api.enums.UserStatusEnum;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
-import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.rest.ApiIamControllerTest;
 import fr.gouv.vitamui.iam.server.user.service.ConnectionHistoryService;
 import fr.gouv.vitamui.iam.server.user.service.UserService;
@@ -35,9 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class UserExternalControllerTest extends ApiIamControllerTest<UserDto> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserExternalControllerTest.class);
-
-    @MockBean
-    private SecurityService securityService;
 
     @MockBean
     private UserService userService;

--- a/api/api-iam/iam/src/test/resources/application.yml
+++ b/api/api-iam/iam/src/test/resources/application.yml
@@ -38,6 +38,7 @@ logbook.scheduling.sendEventToVitamTasks.enabled: false
 customer.init.config.file: src/test/resources/customer-init.yml
 
 cas.reset.password.url: /extras/resetPassword?username={username}&firstname={firstname}&lastname={lastname}&language={language}&customerId={customerId}&ttl=1day
+cas.tenant.identifier: -1
 
 address:
   max-street-length: 250

--- a/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/security/WebSecurityConfig.java
+++ b/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/security/WebSecurityConfig.java
@@ -41,6 +41,7 @@ package fr.gouv.vitamui.ingest.server.security;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.ApiWebSecurityConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -57,8 +58,9 @@ public class WebSecurityConfig extends ApiWebSecurityConfig {
     public WebSecurityConfig(
         final ApiAuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, securityService, env);
     }
 }

--- a/api/api-ingest/ingest/src/main/resources/application-dev.yml
+++ b/api/api-ingest/ingest/src/main/resources/application-dev.yml
@@ -51,7 +51,7 @@ ingest:
         key-password: changeme
         type: JKS
       hostname-verification: false
-
+cas.tenant.identifier: -1
 # Jaeger
 opentracing:
   jaeger:

--- a/api/api-pastis/pastis/src/main/java/fr/gouv/vitamui/pastis/server/security/WebSecurityConfig.java
+++ b/api/api-pastis/pastis/src/main/java/fr/gouv/vitamui/pastis/server/security/WebSecurityConfig.java
@@ -41,6 +41,7 @@ package fr.gouv.vitamui.pastis.server.security;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.ApiWebSecurityConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -57,8 +58,9 @@ public class WebSecurityConfig extends ApiWebSecurityConfig {
     public WebSecurityConfig(
         final ApiAuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, securityService, env);
     }
 }

--- a/api/api-pastis/pastis/src/main/resources/application-dev.yml
+++ b/api/api-pastis/pastis/src/main/resources/application-dev.yml
@@ -32,7 +32,7 @@ multipart:
 
 spring.servlet.multipart.max-file-size: -1
 spring.servlet.multipart.max-request-size: -1
-
+cas.tenant.identifier: -1
 server:
   host:
   port: 8015

--- a/api/api-pastis/pastis/src/test/java/fr/gouv/vitamui/pastis/server/rest/ControllerTest.java
+++ b/api/api-pastis/pastis/src/test/java/fr/gouv/vitamui/pastis/server/rest/ControllerTest.java
@@ -6,6 +6,7 @@ import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
 import fr.gouv.vitamui.commons.test.rest.AbstractRestControllerMockMvcTest;
 import fr.gouv.vitamui.iam.security.authentication.AuthenticationToken;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
 
@@ -15,6 +16,9 @@ public abstract class ControllerTest extends AbstractRestControllerMockMvcTest {
 
     @MockBean
     private ApiAuthenticationProvider apiAuthenticationProvider;
+
+    @MockBean
+    protected SecurityService securityService;
 
     @Override
     protected Authentication buildUserAuthenticated() {

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/security/WebSecurityConfig.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/security/WebSecurityConfig.java
@@ -39,6 +39,7 @@ package fr.gouv.vitamui.referential.server.security;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.ApiWebSecurityConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -46,8 +47,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 
 /**
  * The security configuration.
- *
- *
  */
 @EnableWebSecurity
 @Configuration
@@ -57,8 +56,9 @@ public class WebSecurityConfig extends ApiWebSecurityConfig {
     public WebSecurityConfig(
         final ApiAuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final SecurityService securityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, securityService, env);
     }
 }

--- a/api/api-referential/referential/src/main/resources/application-dev.yml
+++ b/api/api-referential/referential/src/main/resources/application-dev.yml
@@ -15,7 +15,7 @@ spring:
     multipart:
       max-file-size: -1
       max-request-size: -1
-
+cas.tenant.identifier: -1
 server:
   host:
   port: 8087

--- a/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/rest/ApiReferentialControllerTest.java
+++ b/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/rest/ApiReferentialControllerTest.java
@@ -39,6 +39,7 @@ package fr.gouv.vitamui.referential.server.rest;
 import fr.gouv.vitamui.commons.api.domain.IdDto;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
+import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.server.security.WebSecurityConfig;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -48,4 +49,7 @@ public abstract class ApiReferentialControllerTest<T extends IdDto> extends ApiC
 
     @MockBean
     private ApiAuthenticationProvider apiAuthenticationProvider;
+
+    @MockBean
+    private SecurityService securityService;
 }

--- a/deployment/roles/vitamui/templates/archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search/application.yml.j2
@@ -14,6 +14,8 @@ spring:
     mongodb:
       uri: mongodb://{{ mongodb.archivesearch.user }}:{{ mongodb.archivesearch.password }}@{{ mongodb.host }}:{{ mongodb.mongod_port }}/{{ mongodb.archivesearch.db }}?replicaSet={{ mongod_replicaset_name }}&connectTimeoutMS={{ mongod_client_connect_timeout_ms }}
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 server:
   address: {{ ip_service }}
   port: {{ vitamui_struct.port_service }}

--- a/deployment/roles/vitamui/templates/collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect/application.yml.j2
@@ -23,6 +23,8 @@ logging:
   level:
     fr.gouv.vitamui.collect.server: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 server:
   address: {{ ip_service }}
   port: {{ vitamui_struct.port_service }}

--- a/deployment/roles/vitamui/templates/iam/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam/application.yml.j2
@@ -102,6 +102,7 @@ cas-client:
 {% endif %}
 
 cas.reset.password.url: {{ vitamui.cas_server.base_url | default('/cas') }}{{ vitamui.cas_server.reset_password_url | default('/extras/resetPassword?username={username}&firstname={firstname}&lastname={lastname}&language={language}&customerId={customerId}&ttl=1day') }}
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
 
 login.attempts.maximum.failures: {{ vitamui_struct.login_max_failure | default(5) }}
 login.attempts.time.interval: {{ vitamui_struct.login_interval|default(20) }}

--- a/deployment/roles/vitamui/templates/ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest/application.yml.j2
@@ -44,6 +44,8 @@ management:
     ssl:
       enabled: false
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 gateway:
   enabled: true
 

--- a/deployment/roles/vitamui/templates/pastis/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis/application.yml.j2
@@ -66,6 +66,8 @@ management:
     ssl:
       enabled: false
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 gateway:
   enabled: true
 

--- a/deployment/roles/vitamui/templates/referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential/application.yml.j2
@@ -14,7 +14,7 @@ spring:
     multipart:
       max-file-size: -1
       max-request-size: -1
-
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
   level:


### PR DESCRIPTION
## Description

L'objectif de cette PR  est de controller le header X-Tenant-ID envoyé par le front pour s'assurer de l'accès selon ces règles:
1. Accès aux tenats autorisés s'il dispose d'un profil sur ces tenants
2. Accès à un autre tenant s'il dipose d'un role avec suffix '_ALL_TENANTS'
3. Gestion des accès pour tenant CAS



## Contributeur


* VAS (Vitam Accessible en Service)
