### PR TITLE
Bug #14273: fix infinite scroll

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -602,7 +602,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
           this.archiveSharedDataService.emitTotalResults(this.totalResults);
         } else if (pagedResult.results) {
           this.hasResults = true;
-          pagedResult.results.forEach((elt) => this.archiveUnits.push(elt));
+          this.archiveUnits = [...this.archiveUnits, ...pagedResult.results];
         }
         this.pageNumbers = pagedResult.pageNumbers;
         this.waitingToGetFixedCount = this.totalResults === this.DEFAULT_RESULT_THRESHOLD;


### PR DESCRIPTION
## Description

le scroll infini (affiche des archives suivantes quand on arrive en bas de page) était cassé. On doit remplacer la réference de archiveUnits pour que mat-table recalcule archiveUnits. 

## Type de changement

*Indiquer le ou les types de changements*

* Correction