### PR TITLE
Bug #14532 [Collect Reclassement] When UAs have no parent, the 'Move' and 'Remove to another parent folder' actions should be greyed out.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -405,7 +405,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   }
 
   launchReclassification() {
-    this.archiveUnitGuidSelected = this.isAllChecked
+    this.archiveUnitGuidSelected = this.isAllSelected()
       ? this.archiveUnits.map((unit) => unit['#id'])
       : this.listOfUAIdToInclude.map((unit) => unit.id);
     let unitUps = this.archiveUnits
@@ -1332,5 +1332,9 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
         const hasAUWithoutAttachment = response.results != null && !isEmpty(response.results);
         this.archiveExchangeDataService.emitHasAUWithoutAttachment(hasAUWithoutAttachment);
       });
+  }
+
+  private isAllSelected(): boolean {
+    return this.totalResults === this.itemSelected;
   }
 }


### PR DESCRIPTION
lorsqu’on a des UAs sans parent, les actions "Déplacer" et "Retirer vers un autre dossier parent" devraient être grisées.