### PR TITLE
Bug #14467: display object information if archive unit is RecordGrp

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/collect-object-group-details-tab/collect-object-group-details-tab.component.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/collect-object-group-details-tab/collect-object-group-details-tab.component.spec.ts
@@ -247,7 +247,7 @@ describe('CollectObjectGroupDetailsTabComponent', () => {
     expect(response).toBeTruthy();
   });
 
-  it('should return false', () => {
+  it('should return true', () => {
     // Given
     component.archiveUnit = {
       '#allunitups': [],
@@ -266,7 +266,7 @@ describe('CollectObjectGroupDetailsTabComponent', () => {
     const response = component.unitHasObject();
 
     // Then
-    expect(response).toBeFalsy();
+    expect(response).toBeTruthy();
   });
 
   it('should return true', () => {

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/collect-object-group-details-tab/collect-object-group-details-tab.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/collect-object-group-details-tab/collect-object-group-details-tab.component.ts
@@ -68,6 +68,7 @@ export class CollectObjectGroupDetailsTabComponent implements OnChanges {
   unitObject: ApiUnitObject;
   versionsWithQualifiersOrdered: Array<VersionWithQualifierDto>;
   hasDownloadDocumentRole = false;
+  private allowedDescriptionLevel = [DescriptionLevel.ITEM, DescriptionLevel.RECORD_GRP];
 
   constructor(
     private archiveCollectService: ArchiveCollectService,
@@ -88,7 +89,7 @@ export class CollectObjectGroupDetailsTabComponent implements OnChanges {
   }
 
   unitHasObject(): boolean {
-    return this.archiveUnit.DescriptionLevel === DescriptionLevel.ITEM && !!this.archiveUnit['#object'];
+    return this.allowedDescriptionLevel.includes(this.archiveUnit.DescriptionLevel) && !!this.archiveUnit['#object'];
   }
 
   onClickDownloadObject(event: Event, versionWithQualifier: VersionWithQualifierDto) {


### PR DESCRIPTION
## Description

display object information if the archive unit has RecordGrp in its DescriptionLevel and if object exists

## Type de changement

*Indiquer le ou les types de changements*

* Correction