### PR TITLE
Bug #14420 [Collect & App Search] Saved filters are displayed as keys instead of being translated.

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -103,7 +103,6 @@ import { PuaUpdateDialogComponent, PuaUpdateDialogComponentData } from './pua-up
 const PAGE_SIZE = 10;
 const FILTER_DEBOUNCE_TIME_MS = 400;
 const ELIMINATION_TECHNICAL_ID = 'ELIMINATION_TECHNICAL_ID';
-const ALL_ARCHIVE_UNIT_TYPES = 'ALL_ARCHIVE_UNIT_TYPES';
 
 @Component({
   selector: 'app-archive-search',
@@ -745,9 +744,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
           this.addCriteria(
             c,
             value,
-            c === ALL_ARCHIVE_UNIT_TYPES
-              ? this.translateService.instant('ARCHIVE_SEARCH.SEARCH_CRITERIA_FILTER.FIELDS.UNIT_TYPE.' + value.id)
-              : value.value,
+            value.value,
             criteria.keyTranslated,
             criteria.operator,
             SearchCriteriaTypeEnum.FIELDS,

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -1154,9 +1154,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
             this.nbQueryCriteria,
             c,
             value,
-            c === ALL_ARCHIVE_UNIT_TYPES
-              ? this.translateService.instant('COLLECT.SEARCH_CRITERIA_FILTER.FIELDS.UNIT_TYPE.' + value.id)
-              : value.value,
+            value.value,
             criteria.keyTranslated,
             criteria.operator,
             SearchCriteriaTypeEnum.FIELDS,


### PR DESCRIPTION
Les filtres sauvegardés s'affichent en clé au lieu d’être traduits.