### PR TITLE
CP V7.0 - Bug #14578: add controls to check the access to tenants

### DIFF
--- a/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/security/WebSecurityConfig.java
+++ b/api/api-archive-search/archive-search-internal/src/main/java/fr/gouv/vitamui/archive/internal/server/security/WebSecurityConfig.java
@@ -28,6 +28,7 @@ package fr.gouv.vitamui.archive.internal.server.security;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.InternalApiWebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -40,8 +41,9 @@ public class WebSecurityConfig extends InternalApiWebSecurityConfig {
     public WebSecurityConfig(
         final AuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final InternalSecurityService internalSecurityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, internalSecurityService, env);
     }
 }

--- a/api/api-archive-search/archive-search-internal/src/main/resources/application-dev.yml
+++ b/api/api-archive-search/archive-search-internal/src/main/resources/application-dev.yml
@@ -22,6 +22,7 @@ multipart:
 
 spring.servlet.multipart.max-file-size: -1
 spring.servlet.multipart.max-request-size: -1
+cas.tenant.identifier: -1
 
 server-identity:
   identityName: vitamui-dev

--- a/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/rest/ArchiveSearchInternalControllerTest.java
+++ b/api/api-archive-search/archive-search-internal/src/test/java/fr/gouv/vitamui/archive/internal/server/rest/ArchiveSearchInternalControllerTest.java
@@ -37,7 +37,6 @@ import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -60,7 +59,7 @@ public class ArchiveSearchInternalControllerTest {
     @MockBean
     private InternalApiAuthenticationProvider internalApiAuthenticationProvider;
 
-    @Mock
+    @MockBean
     private InternalSecurityService internalSecurityService;
 
     @MockBean

--- a/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/security/WebSecurityConfig.java
+++ b/api/api-collect/collect-internal/src/main/java/fr/gouv/vitamui/collect/internal/server/security/WebSecurityConfig.java
@@ -29,6 +29,7 @@ package fr.gouv.vitamui.collect.internal.server.security;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.InternalApiWebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -45,8 +46,9 @@ public class WebSecurityConfig extends InternalApiWebSecurityConfig {
     public WebSecurityConfig(
         final AuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final InternalSecurityService internalSecurityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, internalSecurityService, env);
     }
 }

--- a/api/api-collect/collect-internal/src/main/resources/application-dev.yml
+++ b/api/api-collect/collect-internal/src/main/resources/application-dev.yml
@@ -28,6 +28,7 @@ server-identity:
   identityRole: collect-internal
   identityServerId: 1
 
+cas.tenant.identifier: -1
 server:
   host:
   port: 7090

--- a/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/security/WebSecurityConfig.java
+++ b/api/api-iam/iam-internal/src/main/java/fr/gouv/vitamui/iam/internal/server/security/WebSecurityConfig.java
@@ -38,6 +38,7 @@ package fr.gouv.vitamui.iam.internal.server.security;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.InternalApiWebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -45,8 +46,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 
 /**
  * The security configuration.
- *
- *
  */
 
 @Configuration
@@ -57,8 +56,9 @@ public class WebSecurityConfig extends InternalApiWebSecurityConfig {
     public WebSecurityConfig(
         final IamApiAuthenticationProvider iamApiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final InternalSecurityService internalSecurityService,
         final Environment env
     ) {
-        super(iamApiAuthenticationProvider, restExceptionHandler, env);
+        super(iamApiAuthenticationProvider, restExceptionHandler, internalSecurityService, env);
     }
 }

--- a/api/api-iam/iam-internal/src/main/resources/application-dev.yml
+++ b/api/api-iam/iam-internal/src/main/resources/application-dev.yml
@@ -53,6 +53,8 @@ cas-client:
 
 cas.reset.password.url: /cas/extras/resetPassword?username={username}&firstname={firstname}&lastname={lastname}&language={language}&ttl=1day
 
+cas.tenant.identifier: -1
+
 login:
   url: http://dev.vitamui.com:8080/cas/login
 

--- a/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/common/rest/ApiIamControllerTest.java
+++ b/api/api-iam/iam-internal/src/test/java/fr/gouv/vitamui/iam/internal/server/common/rest/ApiIamControllerTest.java
@@ -6,6 +6,7 @@ import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.internal.server.customer.dao.CustomerRepository;
 import fr.gouv.vitamui.iam.internal.server.security.IamApiAuthenticationProvider;
 import fr.gouv.vitamui.iam.internal.server.security.WebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
@@ -20,4 +21,7 @@ public abstract class ApiIamControllerTest<T extends IdDto> extends ApiCrudContr
 
     @MockBean
     private CustomerRepository repository;
+
+    @MockBean
+    private InternalSecurityService securityService;
 }

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/AbstractApiWebSecurityConfig.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/AbstractApiWebSecurityConfig.java
@@ -99,9 +99,13 @@ public abstract class AbstractApiWebSecurityConfig extends WebSecurityConfigurer
             .and()
             .csrf()
             .disable()
-            .addFilterAt(getRequestHeadersAuthenticationFilter(), BasicAuthenticationFilter.class)
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        configureFilters(http);
+    }
+
+    protected void configureFilters(HttpSecurity http) throws Exception {
+        http.addFilterAt(getRequestHeadersAuthenticationFilter(), BasicAuthenticationFilter.class);
     }
 
     @Override

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/ExternalApiWebSecurityConfig.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/ExternalApiWebSecurityConfig.java
@@ -46,8 +46,6 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 
 /**
  * The security configuration.
- *
- *
  */
 @Getter
 @Setter

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/InternalApiWebSecurityConfig.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/config/InternalApiWebSecurityConfig.java
@@ -38,31 +38,51 @@ package fr.gouv.vitamui.iam.security.config;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.filter.InternalRequestHeadersAuthenticationFilter;
+import fr.gouv.vitamui.iam.security.filter.TenantHeaderFilter;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 /**
  * The security configuration.
- *
- *
  */
 @Getter
 @Setter
 public class InternalApiWebSecurityConfig extends AbstractApiWebSecurityConfig {
 
+    private static final String CAS_TENANT_IDENTIFIER = "cas.tenant.identifier";
+
+    private final InternalSecurityService internalSecurityService;
+    private final Integer casTenantIdentifier;
+
     public InternalApiWebSecurityConfig(
         final AuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final InternalSecurityService internalSecurityService,
         final Environment env
     ) {
         super(apiAuthenticationProvider, restExceptionHandler, env);
+        this.internalSecurityService = internalSecurityService;
+        this.casTenantIdentifier = env.getProperty(CAS_TENANT_IDENTIFIER, Integer.class, -1);
     }
 
     @Override
     protected AbstractPreAuthenticatedProcessingFilter getRequestHeadersAuthenticationFilter() throws Exception {
         return new InternalRequestHeadersAuthenticationFilter(authenticationManager());
+    }
+
+    @Override
+    protected void configureFilters(HttpSecurity http) throws Exception {
+        http.addFilterAt(getRequestHeadersAuthenticationFilter(), BasicAuthenticationFilter.class);
+        http.addFilterAt(getTenantHeaderFilter(), BasicAuthenticationFilter.class);
+    }
+
+    protected TenantHeaderFilter getTenantHeaderFilter() {
+        return new TenantHeaderFilter(internalSecurityService, casTenantIdentifier);
     }
 }

--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilter.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilter.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ *  and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ *  contact@programmevitam.fr
+ *
+ *  This software is a computer program whose purpose is to implement
+ *  implement a digital archiving front-office system for the secure and
+ *  efficient high volumetry VITAM solution.
+ *
+ *  This software is governed by the CeCILL-C license under French law and
+ *  abiding by the rules of distribution of free software.  You can  use,
+ *  modify and/ or redistribute the software under the terms of the CeCILL-C
+ *  license as circulated by CEA, CNRS and INRIA at the following URL
+ *  "http://www.cecill.info".
+ *
+ *  As a counterpart to the access to the source code and  rights to copy,
+ *  modify and redistribute granted by the license, users are provided only
+ *  with a limited warranty  and the software's author,  the holder of the
+ *  economic rights,  and the successive licensors  have only  limited
+ *  liability.
+ *
+ *  In this respect, the user's attention is drawn to the risks associated
+ *  with loading,  using,  modifying and/or developing or reproducing the
+ *  software by the user in light of its specific status of free software,
+ *  that may mean  that it is complicated to manipulate,  and  that  also
+ *  therefore means  that it is reserved for developers  and  experienced
+ *  professionals having in-depth computer knowledge. Users are therefore
+ *  encouraged to load and test the software's suitability as regards their
+ *  requirements in conditions enabling the security of their systems and/or
+ *  data to be ensured and,  more generally, to use and operate it in the
+ *  same conditions as regards security.
+ *
+ *  The fact that you are presently reading this means that you have had
+ *  knowledge of the CeCILL-C license and that you accept its terms.
+ *
+ */
+
+package fr.gouv.vitamui.iam.security.filter;
+
+import fr.gouv.vitamui.commons.api.CommonConstants;
+import fr.gouv.vitamui.commons.api.domain.Role;
+import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
+import fr.gouv.vitamui.commons.api.logger.VitamUILogger;
+import fr.gouv.vitamui.commons.api.logger.VitamUILoggerFactory;
+import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class TenantHeaderFilter extends OncePerRequestFilter {
+
+    private static final VitamUILogger LOGGER = VitamUILoggerFactory.getInstance(TenantHeaderFilter.class);
+
+    public static final String ROLE_CROSS_TENANTS_SUFFIX = "_ALL_TENANTS";
+    private final InternalSecurityService securityService;
+    private final Integer casTenant;
+
+    public TenantHeaderFilter(InternalSecurityService securityService, Integer casTenant) {
+        this.securityService = securityService;
+        this.casTenant = casTenant;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        String tenantIdHeader = request.getHeader(CommonConstants.X_TENANT_ID_HEADER);
+        //The control only when the header is set
+        if (StringUtils.isNotBlank(tenantIdHeader)) {
+            try {
+                AuthUserDto user = securityService.getUser();
+                Integer requestTenantId = Integer.parseInt(tenantIdHeader);
+                Integer sessionTenantId = user.getProofTenantIdentifier();
+                if (!Objects.equals(requestTenantId, sessionTenantId)) {
+                    List<Role> userRoles = InternalSecurityService.getRoles(securityService.getUser());
+                    boolean hasAnyCrossTenantRole = userRoles
+                        .stream()
+                        .anyMatch(r -> r.getName().endsWith(ROLE_CROSS_TENANTS_SUFFIX));
+                    if (!hasAnyCrossTenantRole) {
+                        if (!casTenant.equals(requestTenantId)) {
+                            // Check if the user has access to this tenant
+                            try {
+                                securityService.getTenant(requestTenantId);
+                            } catch (ApplicationServerException e) {
+                                LOGGER.error("User not allowed on tenant {}", tenantIdHeader);
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized access to tenant");
+                                return;
+                            }
+                        }
+                    }
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid tenant ID format: {}", tenantIdHeader);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid tenant ID format");
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/api/api-iam/iam-security/src/test/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilterTest.java
+++ b/api/api-iam/iam-security/src/test/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilterTest.java
@@ -1,0 +1,204 @@
+/*
+ *
+ *  Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ *  and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ *  contact@programmevitam.fr
+ *
+ *  This software is a computer program whose purpose is to implement
+ *  implement a digital archiving front-office system for the secure and
+ *  efficient high volumetry VITAM solution.
+ *
+ *  This software is governed by the CeCILL-C license under French law and
+ *  abiding by the rules of distribution of free software.  You can  use,
+ *  modify and/ or redistribute the software under the terms of the CeCILL-C
+ *  license as circulated by CEA, CNRS and INRIA at the following URL
+ *  "http://www.cecill.info".
+ *
+ *  As a counterpart to the access to the source code and  rights to copy,
+ *  modify and redistribute granted by the license, users are provided only
+ *  with a limited warranty  and the software's author,  the holder of the
+ *  economic rights,  and the successive licensors  have only  limited
+ *  liability.
+ *
+ *  In this respect, the user's attention is drawn to the risks associated
+ *  with loading,  using,  modifying and/or developing or reproducing the
+ *  software by the user in light of its specific status of free software,
+ *  that may mean  that it is complicated to manipulate,  and  that  also
+ *  therefore means  that it is reserved for developers  and  experienced
+ *  professionals having in-depth computer knowledge. Users are therefore
+ *  encouraged to load and test the software's suitability as regards their
+ *  requirements in conditions enabling the security of their systems and/or
+ *  data to be ensured and,  more generally, to use and operate it in the
+ *  same conditions as regards security.
+ *
+ *  The fact that you are presently reading this means that you have had
+ *  knowledge of the CeCILL-C license and that you accept its terms.
+ *
+ */
+
+package fr.gouv.vitamui.iam.security.filter;
+
+import fr.gouv.vitamui.commons.api.CommonConstants;
+import fr.gouv.vitamui.commons.api.domain.GroupDto;
+import fr.gouv.vitamui.commons.api.domain.ProfileDto;
+import fr.gouv.vitamui.commons.api.domain.Role;
+import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
+import fr.gouv.vitamui.iam.common.utils.DtoFactory;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class TenantHeaderFilterTest {
+
+    private static final String PROFILE_ID = "PROFILE_ID";
+
+    @Mock
+    private InternalSecurityService securityService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private TenantHeaderFilter tenantHeaderFilter;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        tenantHeaderFilter = new TenantHeaderFilter(securityService, -1);
+    }
+
+    @Test
+    void testNoTenantHeader() throws ServletException, IOException {
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn(null);
+
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(securityService);
+    }
+
+    @Test
+    void testInvalidTenantHeader() throws ServletException, IOException {
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("invalid");
+
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid tenant ID format");
+        verifyNoInteractions(filterChain);
+    }
+
+    @Test
+    void testMatchingTenantId() throws ServletException, IOException {
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("123");
+        AuthUserDto user = mock(AuthUserDto.class);
+        when(user.getProofTenantIdentifier()).thenReturn(123);
+        when(securityService.getUser()).thenReturn(user);
+
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void testCrossTenantRoleAllowsAccess() throws ServletException, IOException {
+        Integer tenantIdentifier = 123;
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("124");
+        GroupDto groupDto = new GroupDto();
+        groupDto.setProfiles(
+            List.of(
+                buildProfileDto(
+                    PROFILE_ID,
+                    "PROFILE_NAME",
+                    "CUSTOMER_ID",
+                    tenantIdentifier,
+                    "APP_NAME",
+                    List.of(new Role("ROLE_1"), new Role("ROLE_2"), new Role("_ALL_TENANTS"))
+                )
+            )
+        );
+        final AuthUserDto user = new AuthUserDto();
+        user.setProfileGroup(groupDto);
+        user.setProofTenantIdentifier(tenantIdentifier);
+        when(securityService.getUser()).thenReturn(user);
+        when(securityService.getTenant(anyInt())).thenCallRealMethod();
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void testUnauthorizedTenantAccess() throws ServletException, IOException {
+        Integer tenantIdentifier = 123;
+        when(request.getHeader(CommonConstants.X_TENANT_ID_HEADER)).thenReturn("124");
+        GroupDto groupDto = new GroupDto();
+        groupDto.setProfiles(
+            List.of(
+                buildProfileDto(
+                    PROFILE_ID,
+                    "PROFILE_NAME",
+                    "CUSTOMER_ID",
+                    tenantIdentifier,
+                    "APP_NAME",
+                    List.of(new Role("ROLE_1"), new Role("ROLE_2"))
+                )
+            )
+        );
+        final AuthUserDto user = new AuthUserDto();
+        user.setProfileGroup(groupDto);
+        user.setProofTenantIdentifier(tenantIdentifier);
+        when(securityService.getUser()).thenReturn(user);
+        when(securityService.getTenant(anyInt())).thenCallRealMethod();
+        tenantHeaderFilter.doFilterInternal(request, response, filterChain);
+
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized access to tenant");
+        verifyNoMoreInteractions(filterChain);
+    }
+
+    public static ProfileDto buildProfileDto(
+        final String id,
+        final String name,
+        final String customerId,
+        final Integer tenantId,
+        final String applicationName,
+        final List<Role> roles
+    ) {
+        final ProfileDto profileDto = DtoFactory.buildProfileDto(
+            name,
+            "description",
+            false,
+            "level",
+            tenantId,
+            applicationName,
+            new ArrayList<String>(),
+            customerId
+        );
+        profileDto.setId(id);
+        profileDto.setRoles(roles);
+        return profileDto;
+    }
+}

--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/security/WebSecurityConfig.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/security/WebSecurityConfig.java
@@ -38,6 +38,7 @@ package fr.gouv.vitamui.ingest.internal.server.security;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.InternalApiWebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -45,8 +46,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 
 /**
  * The security configuration.
- *
- *
  */
 
 @Configuration
@@ -56,8 +55,9 @@ public class WebSecurityConfig extends InternalApiWebSecurityConfig {
     public WebSecurityConfig(
         final AuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final InternalSecurityService internalSecurityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, internalSecurityService, env);
     }
 }

--- a/api/api-ingest/ingest-internal/src/main/resources/application-dev.yml
+++ b/api/api-ingest/ingest-internal/src/main/resources/application-dev.yml
@@ -23,6 +23,7 @@ server-identity:
   identityRole: ingest-internal
   identityServerId: 1
 
+cas.tenant.identifier: -1
 server:
   host:
   port: 7088

--- a/api/api-ingest/ingest-internal/src/test/java/fr/gouv/vitamui/ingest/internal/server/rest/IngestInternalControllerTest.java
+++ b/api/api-ingest/ingest-internal/src/test/java/fr/gouv/vitamui/ingest/internal/server/rest/IngestInternalControllerTest.java
@@ -49,7 +49,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -73,7 +72,7 @@ public class IngestInternalControllerTest {
     @MockBean
     private InternalApiAuthenticationProvider internalApiAuthenticationProvider;
 
-    @Mock
+    @MockBean
     private InternalSecurityService internalSecurityService;
 
     @MockBean

--- a/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/security/WebSecurityConfig.java
+++ b/api/api-referential/referential-internal/src/main/java/fr/gouv/vitamui/referential/internal/server/security/WebSecurityConfig.java
@@ -38,6 +38,7 @@ package fr.gouv.vitamui.referential.internal.server.security;
 
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.iam.security.config.InternalApiWebSecurityConfig;
+import fr.gouv.vitamui.iam.security.service.InternalSecurityService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -45,8 +46,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 
 /**
  * The security configuration.
- *
- *
  */
 
 @Configuration
@@ -56,8 +55,9 @@ public class WebSecurityConfig extends InternalApiWebSecurityConfig {
     public WebSecurityConfig(
         final AuthenticationProvider apiAuthenticationProvider,
         final RestExceptionHandler restExceptionHandler,
+        final InternalSecurityService internalSecurityService,
         final Environment env
     ) {
-        super(apiAuthenticationProvider, restExceptionHandler, env);
+        super(apiAuthenticationProvider, restExceptionHandler, internalSecurityService, env);
     }
 }

--- a/api/api-referential/referential-internal/src/main/resources/application-dev.yml
+++ b/api/api-referential/referential-internal/src/main/resources/application-dev.yml
@@ -37,7 +37,7 @@ clients:
   iam-internal:
     server-host: localhost
     server-port: 7083
-
+cas.tenant.identifier: -1
 swagger:
   file-path: file:../../../tools/swagger/docs/api-internal/referential-internal/swagger.json
 

--- a/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
@@ -45,7 +45,7 @@ management:
     port: {{ vitamui_struct.port_admin }}
     ssl:
       enabled: false
-
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
 clients:
   iam-internal:
     server-host: {{ vitamui.iam_internal.host }}

--- a/deployment/roles/vitamui/templates/collect-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect-internal/application.yml.j2
@@ -20,6 +20,8 @@ logging:
   level:
     fr.gouv.vitamui.collect.internal.server: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 server:
   port: {{ vitamui_struct.port_service }}
 {% if vitamui_struct.secure | default(secure) | lower == "true" %}

--- a/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam-internal/application.yml.j2
@@ -16,6 +16,8 @@ logging:
   level:
     fr.gouv.vitamui.iam.internal.server: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 server:
   port: {{ vitamui_struct.port_service }}
 {% if vitamui_struct.secure | default(secure) | lower == "true" %}

--- a/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest-internal/application.yml.j2
@@ -40,6 +40,8 @@ server:
       file-date-format: ".yyyy-MM-dd"
       suffix: ".log"
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 management:
   server:
     port: {{ vitamui_struct.port_admin }}

--- a/deployment/roles/vitamui/templates/pastis-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis-external/application.yml.j2
@@ -31,6 +31,7 @@ logging:
   level:
     fr.gouv.vitamui.pastis.server: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
 
 server:
   port: {{ vitamui_struct.port_service }}

--- a/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential-internal/application.yml.j2
@@ -17,6 +17,8 @@ logging:
   level:
     fr.gouv.vitamui.referential.internal.server: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
 
+cas.tenant.identifier: {{ vitamui_platform_informations.cas_tenant }}
+
 server:
   port: {{ vitamui_struct.port_service }}
 {% if vitamui_struct.secure | default(secure) | lower == "true" %}


### PR DESCRIPTION
## Description

> Cherry-Picked from #2700

L'objectif de cette PR  est de controller le header X-Tenant-ID envoyé par le front pour s'assurer de l'accès selon ces règles:
1. Accès aux tenats autorisés s'il dispose d'un profil sur ces tenants
2. Accès à un autre tenant s'il dipose d'un role avec suffix '_ALL_TENANTS'
3. Gestion des accès pour tenant CAS

## Contributeur

* VAS (Vitam Accessible en Service)