### PR TITLE
CP V8.0 - Bug #14704: Fix typo in Pastis role.

### DIFF
--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -250,7 +250,7 @@ customer-init:
       app-name: PASTIS_APP
       level:
       roles:
-        - ROL_GET_PASTIS
+        - ROLE_GET_PASTIS
         - ROLE_GET_ARCHIVE_PROFILES_UNIT
         - ROLE_UPDATE_ARCHIVE_PROFILES_UNIT
         - ROLE_CREATE_ARCHIVE_PROFILES_UNIT

--- a/deployment/scripts/mongod/2.0.0/57_fix_typo_pastis_role.js.j2
+++ b/deployment/scripts/mongod/2.0.0/57_fix_typo_pastis_role.js.j2
@@ -1,0 +1,15 @@
+print("START 57_fix_typo_pastis_role.js");
+
+dbIam = db.getSiblingDB('{{ mongodb.iam.db | default('iam') }}')
+
+dbIam.profiles.updateMany(
+  { "roles.name": "ROL_GET_PASTIS" },
+  { $set: { "roles.$[elem].name": "ROLE_GET_PASTIS" } },
+  {
+    arrayFilters: [
+      { "elem.name": "ROL_GET_PASTIS" }
+    ]
+  }
+)
+
+print("END 57_fix_typo_pastis_role.js");

--- a/docs/fr/architecture/sections/architecture.md
+++ b/docs/fr/architecture/sections/architecture.md
@@ -1246,7 +1246,7 @@ La liste de profils crées par défaut pour chaque tenant :
         Description: Pastis-Gestion des profils documentaires
         Application: PASTIS_APP
         Rôles:
-            - ROL_GET_PASTIS
+            - ROLE_GET_PASTIS
             - ROLE_GET_ARCHIVE_PROFILES_UNIT
             - ROLE_UPDATE_ARCHIVE_PROFILES_UNIT
             - ROLE_CREATE_ARCHIVE_PROFILES_UNIT


### PR DESCRIPTION
## Description

> Cherry-Picked from #2729 

This bug impact only when creating a new organization. For migrated ones, the role is properly named.

Also provides a dedicated script to fix organizations created with this typo.

## Type de changement

* Correction

## Contributeur

* Programme Vitam