### PR TITLE
Bug #14669 - [PASTIS] The "Allow metadata" toggle is not saved when creating/updating a PUA.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/profile.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/profile.service.ts
@@ -98,6 +98,7 @@ export class ProfileService implements OnDestroy {
   public profileVersion: ProfileVersion;
   public profileName: string;
   public profileId: string;
+  public controlSchema = new BehaviorSubject<string>(null);
   public retrievedProfiles = new BehaviorSubject<ProfileDescription[]>(null);
   protected data: ProfileDescription[];
 
@@ -234,7 +235,8 @@ export class ProfileService implements OnDestroy {
   }
 
   createArchivalUnitProfile(archivalUnitProfile: ArchivalProfileUnit) {
-    return this.puaService.create(archivalUnitProfile);
+    const profile = this.updateControlSchema(archivalUnitProfile);
+    return this.puaService.create(profile);
   }
 
   updateProfilePa(profile: Profile): Observable<Profile | null> {
@@ -245,7 +247,11 @@ export class ProfileService implements OnDestroy {
   }
 
   updateProfilePua(archivalUnitProfile: ArchivalProfileUnit) {
-    return this.puaService.updateProfilePua(archivalUnitProfile);
+    const profile: ArchivalProfileUnit = {
+      ...archivalUnitProfile,
+      controlSchema: this.controlSchema.getValue(),
+    };
+    return this.puaService.updateProfilePua(profile);
   }
 
   updateProfileFilePa(profile: Profile, file: File) {
@@ -271,5 +277,30 @@ export class ProfileService implements OnDestroy {
 
   isMode(mode: ProfileType): boolean {
     return this.profileType === mode;
+  }
+
+  private updateControlSchema(archivalUnitProfile: ArchivalProfileUnit): ArchivalProfileUnit {
+    try {
+      const parsedControlSchema = JSON.parse(archivalUnitProfile.controlSchema);
+      const additionalProperties = JSON.parse(this.controlSchema.getValue())?.additionalProperties;
+
+      if (parsedControlSchema) {
+        parsedControlSchema.additionalProperties = additionalProperties;
+
+        if (parsedControlSchema.patternProperties?.['#management']) {
+          parsedControlSchema.patternProperties['#management'].additionalProperties = additionalProperties;
+        } else {
+          console.warn("patternProperties['#management'] is undefined");
+        }
+      }
+
+      return {
+        ...archivalUnitProfile,
+        controlSchema: JSON.stringify(parsedControlSchema),
+      };
+    } catch (error) {
+      console.error('Error in updateControlSchema:', error);
+      return archivalUnitProfile;
+    }
   }
 }

--- a/ui/ui-frontend/projects/pastis/src/app/profile/list-profile/list-profile.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/list-profile/list-profile.component.ts
@@ -252,6 +252,7 @@ export class ListProfileComponent extends SidenavPage<ProfileDescription> implem
   }
 
   editProfile(element: ProfileDescription) {
+    this.profileService.controlSchema.next(element?.controlSchema);
     this.router.navigate([this.pastisConfig.pastisEditPage, element.id], {
       state: element,
       relativeTo: this.route,

--- a/ui/ui-frontend/projects/pastis/src/app/user-actions/create-notice/create-notice.component.html
+++ b/ui/ui-frontend/projects/pastis/src/app/user-actions/create-notice/create-notice.component.html
@@ -39,7 +39,7 @@
     <div *ngIf="modePUA" class="row">
       <div class="col-10 form-control">
         <div class="d-flex justify-content-between align-items-center py-1 px-2 mb-2">
-          <vitamui-common-slide-toggle formControlName="allowMetadata">
+          <vitamui-common-slide-toggle formControlName="additionalProperties">
             {{ 'PROFILE.POP_UP_CREATION_NOTICE.ALLOW_METADATA' | translate }}
           </vitamui-common-slide-toggle>
         </div>

--- a/ui/ui-frontend/projects/pastis/src/app/user-actions/create-notice/create-notice.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/user-actions/create-notice/create-notice.component.ts
@@ -67,6 +67,7 @@ export class CreateNoticeComponent implements OnInit, OnDestroy {
   profileType: ProfileType;
   profileVersion: ProfileVersion;
   modePUA = false;
+  controlSchema: any;
 
   subscriptions = new Subscription();
   externalIdentifierEnabled: boolean;
@@ -109,12 +110,14 @@ export class CreateNoticeComponent implements OnInit, OnDestroy {
       { key: 'ACTIVE', label: this.translateService.instant('PROFILE.POP_UP_CREATION_NOTICE.CHOICE.PROFIL_ACTIF') },
       { key: 'INACTIVE', label: this.translateService.instant('PROFILE.POP_UP_CREATION_NOTICE.CHOICE.PROFIL_INACTIF') },
     ];
+
+    this.controlSchema = JSON.parse(this.profileService.controlSchema.getValue());
     this.form = this.formBuilder.group({
       identifier: [{ value: this.notice.identifier, disabled: this.editNotice }, Validators.required],
       name: [this.notice.name, Validators.required],
       status: [this.notice.status],
       description: [this.notice.description],
-      allowMetadata: [false],
+      additionalProperties: [this.controlSchema?.additionalProperties],
     });
 
     this.applicationService
@@ -190,6 +193,7 @@ export class CreateNoticeComponent implements OnInit, OnDestroy {
       this.fileService.noticeEditable.next(this.form.getRawValue());
       this.fileService.setNotice(true);
     }
+    this.updateControlSchema();
     this.dialogRef.close({
       success: true,
       action: 'none',
@@ -197,5 +201,30 @@ export class CreateNoticeComponent implements OnInit, OnDestroy {
       profileType: this.profileType,
       profileVersion: this.profileVersion,
     });
+  }
+
+  private updateControlSchema(): void {
+    const additionalProps = this.form.controls.additionalProperties.value;
+
+    const updatedPatternProperties = {
+      ...this.controlSchema?.patternProperties,
+      '#management': {
+        ...this.controlSchema?.patternProperties?.['#management'],
+        additionalProperties: additionalProps,
+      },
+    };
+
+    this.controlSchema = this.controlSchema
+      ? {
+          ...this.controlSchema,
+          additionalProperties: additionalProps,
+          patternProperties: updatedPatternProperties,
+        }
+      : {
+          ...this.controlSchema,
+          additionalProperties: additionalProps,
+        };
+
+    this.profileService.controlSchema.next(JSON.stringify(this.controlSchema));
   }
 }


### PR DESCRIPTION
Le changement d’état du toggle "Autoriser les métadatas" n'est pas pris en compte dans le backend.