### PR TITLE
CP V7.0 - Bug #14420 [Collect & App Search] Saved filters are displayed as keys instead of being translated.

### DIFF
--- a/ui/ui-frontend-common/src/assets/shared-i18n/en.json
+++ b/ui/ui-frontend-common/src/assets/shared-i18n/en.json
@@ -3530,6 +3530,7 @@
       },
       "DUA_TITLE": "Administrative useful life",
       "FIELDS": {
+        "true": "Yes",
         "ORPHANS_NODE": "Position",
         "ALL_ARCHIVE_UNIT_TYPES": "Type",
         "ARCHIVE_UNIT_FILING_UNIT": "Filing plan",
@@ -4074,6 +4075,7 @@
       },
       "DUA_TITLE": "Administrative useful life",
       "FIELDS": {
+        "true": "Yes",
         "ORPHANS_NODE": "Position",
         "ALL_ARCHIVE_UNIT_TYPES": "Type",
         "ARCHIVE_UNIT_FILING_UNIT": "Filing plan",

--- a/ui/ui-frontend-common/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend-common/src/assets/shared-i18n/fr.json
@@ -4306,6 +4306,7 @@
         "ORIGIN_INHERITE_AT_LEAST_ONE": "Héritées"
       },
       "FIELDS": {
+        "true": "Oui",
         "ORPHANS_NODE": "Position",
         "ID": "ID",
         "TITLE_OR_DESCRIPTION": "Intitulé ou Description",
@@ -4883,6 +4884,7 @@
         "ORIGIN_INHERITE_AT_LEAST_ONE": "Héritées"
       },
       "FIELDS": {
+        "true": "Oui",
         "ORPHANS_NODE": "Position",
         "ID": "ID",
         "TITLE_OR_DESCRIPTION": "Intitulé ou Description",

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -742,9 +742,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
             this.nbQueryCriteria,
             c,
             value,
-            c === ALL_ARCHIVE_UNIT_TYPES
-              ? this.translateService.instant('ARCHIVE_SEARCH.SEARCH_CRITERIA_FILTER.FIELDS.UNIT_TYPE.' + value.id)
-              : value.value,
+            value.value,
             criteria.keyTranslated,
             criteria.operator,
             SearchCriteriaTypeEnum.FIELDS,

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -893,9 +893,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
             this.nbQueryCriteria,
             c,
             value,
-            c === ALL_ARCHIVE_UNIT_TYPES
-              ? this.translateService.instant('COLLECT.SEARCH_CRITERIA_FILTER.FIELDS.UNIT_TYPE.' + value.id)
-              : value.value,
+            value.value,
             criteria.keyTranslated,
             criteria.operator,
             SearchCriteriaTypeEnum.FIELDS,


### PR DESCRIPTION
CP V7.0 - Bug #14420 [Collect & App Search] Saved filters are displayed as keys instead of being translated.