### PR TITLE
Bug #14744: Fix ansible errors.

### DIFF
--- a/deployment/ansible-vitamui-exploitation/troubleshoot.yml
+++ b/deployment/ansible-vitamui-exploitation/troubleshoot.yml
@@ -38,7 +38,7 @@
 
 # Init troubleshoot
 
-- hosts: vitam
+- hosts: hosts_vitamui
   gather_facts: no
   roles:
     - init_troubleshoot

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -204,7 +204,7 @@
 
     - name: Check whether service is listening on admin port (tcp check)
       wait_for:
-        host: "{{ ip_service }}"
+        host: "{{ ip_admin }}"
         port: "{{ vitamui_struct.port_admin }}"
         timeout: "{{ vitamui_struct.services.start_timeout | default(start_timeout) }}"
         state: started

--- a/deployment/roles/vitamui/tasks/prepare_api_gateway_conf.yml
+++ b/deployment/roles/vitamui/tasks/prepare_api_gateway_conf.yml
@@ -25,8 +25,9 @@
     - update_vitamui_certificates
 
 - name: Check trusted CA files present
-  fail: msg="CA certificates missing from {{ inventory_dir }}/certs/server/ca/ directory"
-  when: trusted_ca_certs | length == 0
+  fail:
+    msg: "CA certificates missing from {{ inventory_dir }}/certs/server/ca/ directory"
+  when: trusted_ca_certs.files | length == 0
 
 - name: Copy trusted CA certs
   copy:
@@ -35,7 +36,7 @@
     owner: "{{ vitamui_defaults.users.vitamui | default('vitamui') }}"
     group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
     mode: "{{ vitamui_defaults.folder.conf_permission | default('0440') }}"
-  with_items: "{{ trusted_ca_certs.files | map(attribute='path') }}"
+  with_items: "{{ trusted_ca_certs.files | map(attribute='path') | list }}"
   notify: restart service
   tags:
     - update_vitam_configuration


### PR DESCRIPTION
## Description

Small fixes during installation on VaS.
* Force list output for API-GW's CA, otherwise it doesn't work on older versions of ansible
* Wrong group for troubleshoot
* Wrong ip for check service

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam