### PR TITLE
CP V7.0 - Bug #14578: update role name to access to another tenants due to existing role with same name

### DIFF
--- a/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilter.java
+++ b/api/api-iam/iam-security/src/main/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilter.java
@@ -62,7 +62,7 @@ public class TenantHeaderFilter extends OncePerRequestFilter {
 
     private static final VitamUILogger LOGGER = VitamUILoggerFactory.getInstance(TenantHeaderFilter.class);
 
-    public static final String ROLE_CROSS_TENANTS_SUFFIX = "_ALL_TENANTS";
+    public static final String ROLE_CROSS_TENANTS_SUFFIX = "_OTHER_TENANTS";
     private final InternalSecurityService securityService;
     private final Integer casTenant;
 

--- a/api/api-iam/iam-security/src/test/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilterTest.java
+++ b/api/api-iam/iam-security/src/test/java/fr/gouv/vitamui/iam/security/filter/TenantHeaderFilterTest.java
@@ -137,7 +137,7 @@ public class TenantHeaderFilterTest {
                     "CUSTOMER_ID",
                     tenantIdentifier,
                     "APP_NAME",
-                    List.of(new Role("ROLE_1"), new Role("ROLE_2"), new Role("_ALL_TENANTS"))
+                    List.of(new Role("ROLE_1"), new Role("ROLE_2"), new Role("_OTHER_TENANTS"))
                 )
             )
         );


### PR DESCRIPTION
## Description

> Cherry-Picked from #2780 

## Contributeur

* VAS (Vitam Accessible en Service)