### PR TITLE
Bug #14733: "paginated" API (front & back)

### DIFF
--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/ProjectController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/ProjectController.java
@@ -84,7 +84,7 @@ public class ProjectController {
     private final ExternalParametersService externalParametersService;
 
     @Secured(ServicesData.ROLE_GET_PROJECTS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<CollectProjectDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,
@@ -114,7 +114,7 @@ public class ProjectController {
     }
 
     @ApiOperation(value = "Get transactions by project paginated")
-    @GetMapping(params = { "page", "size" }, value = "/{id}" + TRANSACTIONS)
+    @GetMapping(value = "/{id}" + TRANSACTIONS + "/paginated", params = { "page", "size" })
     @Secured(ServicesData.ROLE_GET_TRANSACTIONS)
     public PaginatedValuesDto<CollectTransactionDto> getTransactionsByProjectPaginated(
         @RequestParam final Integer page,

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ExternalParamProfileController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ExternalParamProfileController.java
@@ -100,7 +100,7 @@ public class ExternalParamProfileController implements CrudController<ExternalPa
         operationId = "externalParamProfile_getAllPaginated",
         summary = "Get external parameters profile, paginated result"
     )
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(path = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<ExternalParamProfileDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/SubrogationController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/SubrogationController.java
@@ -136,7 +136,7 @@ public class SubrogationController implements CrudController<SubrogationDto> {
 
     @Operation(operationId = "subrogations_getGenericUsers", summary = "Get all generic users with criteria")
     @Secured(ServicesData.ROLE_GET_USERS_SUBROGATIONS)
-    @GetMapping(path = "/users/generic", params = { "page", "size" })
+    @GetMapping(path = "/users/generic/paginated", params = { "page", "size" })
     public PaginatedValuesDto<UserDto> getGenericUsers(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/UserController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/UserController.java
@@ -110,7 +110,7 @@ public class UserController implements CrudController<UserDto> {
 
     @Operation(operationId = "users_getAllPaginated", summary = "Get all users, paginated")
     @Secured(ServicesData.ROLE_GET_USERS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<UserDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/rest/IngestController.java
+++ b/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/rest/IngestController.java
@@ -91,7 +91,7 @@ public class IngestController {
     }
 
     @Secured(ServicesData.ROLE_GET_ALL_INGEST)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<LogbookOperationDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AccessContractController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AccessContractController.java
@@ -100,7 +100,7 @@ public class AccessContractController {
     }
 
     @Secured(ServicesData.ROLE_GET_ACCESS_CONTRACTS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(path = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<AccessContractDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AccessionRegisterController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AccessionRegisterController.java
@@ -86,7 +86,7 @@ public class AccessionRegisterController {
         return accessionRegisterService.getAll();
     }
 
-    @GetMapping(value = RestApi.DETAILS, params = { "page", "size" })
+    @GetMapping(value = RestApi.DETAILS + "/paginated", params = { "page", "size" })
     @Secured(ServicesData.ROLE_GET_ACCESSION_REGISTER_DETAIL)
     public PaginatedValuesDto<AccessionRegisterDetailDto> getAccessionRegisterDetails(
         @RequestParam final Integer page,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AgencyController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AgencyController.java
@@ -105,7 +105,7 @@ public class AgencyController {
     }
 
     @Secured(ServicesData.ROLE_GET_AGENCIES)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(path = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<AgencyDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ArchivalProfileUnitController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ArchivalProfileUnitController.java
@@ -99,7 +99,7 @@ public class ArchivalProfileUnitController {
     }
 
     @Secured(ServicesData.ROLE_GET_ARCHIVE_PROFILES_UNIT)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<ArchivalProfileUnitDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ContextController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ContextController.java
@@ -94,7 +94,7 @@ public class ContextController {
     }
 
     @Secured(ServicesData.ROLE_GET_CONTEXTS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<ContextDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/FileFormatController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/FileFormatController.java
@@ -104,7 +104,7 @@ public class FileFormatController {
     }
 
     @Secured(ServicesData.ROLE_GET_FILE_FORMATS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<FileFormatDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/IngestContractController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/IngestContractController.java
@@ -98,7 +98,7 @@ public class IngestContractController {
     }
 
     @Secured(ServicesData.ROLE_GET_INGEST_CONTRACTS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<IngestContractDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ManagementContractController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ManagementContractController.java
@@ -93,7 +93,7 @@ public class ManagementContractController {
         return managementContractService.getAll();
     }
 
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     @Secured(ServicesData.ROLE_GET_MANAGEMENT_CONTRACT)
     public PaginatedValuesDto<ManagementContractDto> getAllPaginated(
         @RequestParam final Integer page,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OntologyController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OntologyController.java
@@ -107,7 +107,7 @@ public class OntologyController {
     }
 
     @Secured(ServicesData.ROLE_GET_ONTOLOGIES)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<OntologyDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OperationController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OperationController.java
@@ -108,7 +108,7 @@ public class OperationController {
     }
 
     @Secured(ServicesData.ROLE_GET_OPERATIONS)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<LogbookOperationDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ProfileController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ProfileController.java
@@ -104,7 +104,7 @@ public class ProfileController {
     }
 
     @Secured(ServicesData.ROLE_GET_ARCHIVE_PROFILES)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<ProfileDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/RuleController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/RuleController.java
@@ -108,7 +108,7 @@ public class RuleController {
     }
 
     @Secured(ServicesData.ROLE_GET_RULES)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(path = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<RuleDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/SecurityProfileController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/SecurityProfileController.java
@@ -97,7 +97,7 @@ public class SecurityProfileController {
     }
 
     @Secured(ServicesData.ROLE_GET_SECURITY_PROFILES)
-    @GetMapping(params = { "page", "size" })
+    @GetMapping(value = "/paginated", params = { "page", "size" })
     public PaginatedValuesDto<SecurityProfileDto> getAllPaginated(
         @RequestParam final Integer page,
         @RequestParam final Integer size,

--- a/commons/commons-test/src/test/java/fr/gouv/vitamui/commons/test/rest/AbstractMockMvcCrudControllerTest.java
+++ b/commons/commons-test/src/test/java/fr/gouv/vitamui/commons/test/rest/AbstractMockMvcCrudControllerTest.java
@@ -328,7 +328,7 @@ public abstract class AbstractMockMvcCrudControllerTest<T extends IdDto> extends
     private ResultActions testGetPaginatedEntities(final HttpHeaders httpHeaders, final UriComponentsBuilder builder) {
         ResultActions result = null;
         try {
-            result = super.perform(builder, "", HttpMethod.GET, status().isOk(), httpHeaders);
+            result = super.perform(builder.pathSegment("paginated"), "", HttpMethod.GET, status().isOk(), httpHeaders);
         } catch (final Exception e) {
             fail(e.getMessage());
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/core/api/archive-api.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/core/api/archive-api.service.ts
@@ -42,11 +42,11 @@ import {
   ApiUnitObject,
   ArchiveUnit,
   BASE_URL,
-  BaseHttpClient,
   IOntology,
   JsonPatchDto,
   MultiJsonPatchDto,
   PageRequest,
+  PaginatedHttpClient,
   PaginatedResponse,
   SearchCriteriaDto,
   SearchCriteriaHistory,
@@ -60,7 +60,7 @@ import { RuleSearchCriteriaDto } from '../../archive/models/ruleAction.interface
 @Injectable({
   providedIn: 'root',
 })
-export class ArchiveApiService extends BaseHttpClient<any> {
+export class ArchiveApiService extends PaginatedHttpClient<any> {
   baseUrl: string;
 
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/api/project-api.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/api/project-api.service.ts
@@ -40,19 +40,19 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
   BASE_URL,
-  BaseHttpClient,
   PageRequest,
   PaginatedResponse,
   Project,
   SearchCriteriaHistory,
   Transaction,
   VitamuiHttpHeaders,
+  PaginatedHttpClient,
 } from 'vitamui-library';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ProjectsApiService extends BaseHttpClient<any> {
+export class ProjectsApiService extends PaginatedHttpClient<any> {
   baseUrl: string;
   urlTransaction: string;
 
@@ -67,10 +67,6 @@ export class ProjectsApiService extends BaseHttpClient<any> {
   }
 
   // Manage projects
-
-  public getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Project>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
-  }
 
   public create(data: Project): Observable<Project> {
     return super.create(data);
@@ -154,7 +150,7 @@ export class ProjectsApiService extends BaseHttpClient<any> {
     headers?: HttpHeaders,
   ): Observable<PaginatedResponse<Transaction>> {
     const params = pageRequest.httpParams;
-    return this.http.get<PaginatedResponse<Transaction>>(`${this.apiUrl}/${projectId}/transactions`, {
+    return this.http.get<PaginatedResponse<Transaction>>(`${this.apiUrl}/${projectId}/transactions/paginated`, {
       params,
       headers,
     });

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
@@ -41,10 +41,8 @@ import { Observable } from 'rxjs';
 import {
   ApiUnitObject,
   BASE_URL,
-  BaseHttpClient,
   IOntology,
-  PageRequest,
-  PaginatedResponse,
+  PaginatedHttpClient,
   SearchCriteriaDto,
   SearchResponse,
   Transaction,
@@ -54,7 +52,7 @@ import {
 @Injectable({
   providedIn: 'root',
 })
-export class TransactionApiService extends BaseHttpClient<Transaction> {
+export class TransactionApiService extends PaginatedHttpClient<Transaction> {
   baseUrl: string;
 
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
@@ -67,10 +65,6 @@ export class TransactionApiService extends BaseHttpClient<Transaction> {
   }
 
   // Manage projects
-
-  public getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Transaction>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
-  }
 
   public getTransactionById(transactionId: string): Observable<Transaction> {
     return this.http.get<Transaction>(this.apiUrl + '/' + transactionId);

--- a/ui/ui-frontend/projects/identity/src/app/core/api/customer-api.service.ts
+++ b/ui/ui-frontend/projects/identity/src/app/core/api/customer-api.service.ts
@@ -37,13 +37,13 @@
 import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { BASE_URL, BaseHttpClient, Customer, Logger, Logo, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient, Customer, Logger, Logo, PageRequest, PaginatedResponse } from 'vitamui-library';
 import { AttachmentType } from '../../customer/attachment.enum';
 
 @Injectable({
   providedIn: 'root',
 })
-export class CustomerApiService extends BaseHttpClient<Customer> {
+export class CustomerApiService extends PaginatedHttpClient<Customer> {
   constructor(
     http: HttpClient,
     @Inject(BASE_URL) baseUrl: string,

--- a/ui/ui-frontend/projects/identity/src/app/core/api/user-api.service.ts
+++ b/ui/ui-frontend/projects/identity/src/app/core/api/user-api.service.ts
@@ -38,22 +38,18 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { BASE_URL, BaseHttpClient, CriteriaSearchQuery, PageRequest, PaginatedResponse, User } from 'vitamui-library';
+import { BASE_URL, CriteriaSearchQuery, PaginatedHttpClient, User } from 'vitamui-library';
 
 @Injectable({
   providedIn: 'root',
 })
-export class UserApiService extends BaseHttpClient<User> {
+export class UserApiService extends PaginatedHttpClient<User> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/users');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<User>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<User> {

--- a/ui/ui-frontend/projects/identity/src/app/group/group.service.spec.ts
+++ b/ui/ui-frontend/projects/identity/src/app/group/group.service.spec.ts
@@ -72,31 +72,31 @@ describe('GroupService', () => {
     expect(service).toBeTruthy();
   }));
 
-  it('should call /fake-api/groups?page=0&size=20&orderBy=name&direction=ASC', () => {
+  it('should call /fake-api/groups/paginated?page=0&size=20&orderBy=name&direction=ASC', () => {
     groupService.search().subscribe((response) => expect(response).toEqual([]), fail);
-    const req = httpTestingController.expectOne('/fake-api/groups?page=0&size=20&orderBy=name&direction=ASC');
+    const req = httpTestingController.expectOne('/fake-api/groups/paginated?page=0&size=20&orderBy=name&direction=ASC');
     expect(req.request.method).toEqual('GET');
     const result: any = { values: [] };
     req.flush(result);
   });
 
-  it('should call /fake-api/groups?page=42&size=15&orderBy=name&direction=DESC', () => {
+  it('should call /fake-api/groups/paginated?page=42&size=15&orderBy=name&direction=DESC', () => {
     groupService.search(new PageRequest(42, 15, 'name', Direction.DESCENDANT)).subscribe((response) => expect(response).toEqual([]), fail);
-    const req = httpTestingController.expectOne('/fake-api/groups?page=42&size=15&orderBy=name&direction=DESC');
+    const req = httpTestingController.expectOne('/fake-api/groups/paginated?page=42&size=15&orderBy=name&direction=DESC');
     expect(req.request.method).toEqual('GET');
     const result: any = { values: [] };
     req.flush(result);
   });
 
-  it('should call /fake-api/groups?page=0&size=15&orderBy=&direction=DESC', () => {
+  it('should call /fake-api/groups/paginated?page=0&size=15&orderBy=&direction=DESC', () => {
     groupService.search(new PageRequest(0, 15, '', Direction.DESCENDANT)).subscribe((response) => expect(response).toEqual([null]), fail);
-    let req = httpTestingController.expectOne('/fake-api/groups?page=0&size=15&orderBy=&direction=DESC');
+    let req = httpTestingController.expectOne('/fake-api/groups/paginated?page=0&size=15&orderBy=&direction=DESC');
     expect(req.request.method).toEqual('GET');
     let result: any = { pageNum: 0, hasMore: true, pageSize: 15, values: [null] };
     req.flush(result);
 
     groupService.loadMore().subscribe((response) => expect(response).toEqual([null, null]), fail);
-    req = httpTestingController.expectOne('/fake-api/groups?page=1&size=15&orderBy=&direction=DESC');
+    req = httpTestingController.expectOne('/fake-api/groups/paginated?page=1&size=15&orderBy=&direction=DESC');
     expect(req.request.method).toEqual('GET');
     result = { pageNum: 1, pageSize: 15, hasMore: false, values: [null] };
     req.flush(result);
@@ -104,13 +104,13 @@ describe('GroupService', () => {
 
   it('should not load more results', () => {
     groupService.search().subscribe((response) => expect(response).toEqual([null]), fail);
-    const req = httpTestingController.expectOne('/fake-api/groups?page=0&size=20&orderBy=name&direction=ASC');
+    const req = httpTestingController.expectOne('/fake-api/groups/paginated?page=0&size=20&orderBy=name&direction=ASC');
     expect(req.request.method).toEqual('GET');
     const result: any = { hasMore: false, pageSize: 20, pageNum: 0, values: [null] };
     req.flush(result);
 
     groupService.loadMore().subscribe((response) => expect(response).toEqual([null]), fail);
-    httpTestingController.expectNone('/fake-api/groups?page=1&size=20&orderBy=name&direction=ASC');
+    httpTestingController.expectNone('/fake-api/groups/paginated?page=1&size=20&orderBy=name&direction=ASC');
   });
 
   it('should return false', () => {
@@ -122,7 +122,7 @@ describe('GroupService', () => {
       expect(response).toEqual([null]);
       expect(groupService.canLoadMore).toBeTruthy();
     }, fail);
-    const req = httpTestingController.expectOne('/fake-api/groups?page=0&size=20&orderBy=name&direction=ASC');
+    const req = httpTestingController.expectOne('/fake-api/groups/paginated?page=0&size=20&orderBy=name&direction=ASC');
     expect(req.request.method).toEqual('GET');
     const result: any = { hasMore: true, values: [null] };
     req.flush(result);

--- a/ui/ui-frontend/projects/identity/src/app/subrogation/user-generic-api.service.ts
+++ b/ui/ui-frontend/projects/identity/src/app/subrogation/user-generic-api.service.ts
@@ -34,21 +34,16 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
-import { BaseHttpClient, BASE_URL, PageRequest, PaginatedResponse, SubrogationUser } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient, SubrogationUser } from 'vitamui-library';
 
 @Injectable({
   providedIn: 'root',
 })
-export class UserGenericApiService extends BaseHttpClient<SubrogationUser> {
+export class UserGenericApiService extends PaginatedHttpClient<SubrogationUser> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/subrogations/users/generic');
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<SubrogationUser>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 }

--- a/ui/ui-frontend/projects/ingest/src/app/core/api/ingest-api.service.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/core/api/ingest-api.service.ts
@@ -38,13 +38,13 @@ import { HttpClient, HttpEvent, HttpHeaders, HttpParams, HttpRequest } from '@an
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { BASE_URL, BaseHttpClient, PageRequest, PaginatedResponse, VitamuiHttpHeaders } from 'vitamui-library';
+import { BASE_URL, PageRequest, PaginatedHttpClient, PaginatedResponse, VitamuiHttpHeaders } from 'vitamui-library';
 import { IngestType } from '../common/ingest-type.enum';
 
 @Injectable({
   providedIn: 'root',
 })
-export class IngestApiService extends BaseHttpClient<any> {
+export class IngestApiService extends PaginatedHttpClient<any> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/ingest');
   }

--- a/ui/ui-frontend/projects/pastis/src/app/core/services/archival-profile-unit-api.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/archival-profile-unit-api.service.ts
@@ -38,17 +38,16 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BASE_URL, BaseHttpClient, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient, SKIP_ERROR_NOTIFICATION } from 'vitamui-library';
 import { ArchivalProfileUnit } from '../../models/archival-profile-unit';
 import { PastisConfiguration } from '../classes/pastis-configuration';
-import { SKIP_ERROR_NOTIFICATION } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class ArchivalProfileUnitApiService extends BaseHttpClient<ArchivalProfileUnit> {
+export class ArchivalProfileUnitApiService extends PaginatedHttpClient<ArchivalProfileUnit> {
   // @ts-ignore
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string, pastisConfiguration: PastisConfiguration) {
     // console.log('passage dans service archival API');
@@ -57,10 +56,6 @@ export class ArchivalProfileUnitApiService extends BaseHttpClient<ArchivalProfil
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<ArchivalProfileUnit>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<ArchivalProfileUnit> {

--- a/ui/ui-frontend/projects/pastis/src/app/core/services/archive-profile-api.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/archive-profile-api.service.ts
@@ -38,17 +38,16 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BASE_URL, BaseHttpClient, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient, SKIP_ERROR_NOTIFICATION } from 'vitamui-library';
 import { Profile } from '../../models/profile';
 import { PastisConfiguration } from '../classes/pastis-configuration';
-import { SKIP_ERROR_NOTIFICATION } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class ArchiveProfileApiService extends BaseHttpClient<Profile> {
+export class ArchiveProfileApiService extends PaginatedHttpClient<Profile> {
   // @ts-ignore
   constructor(
     http: HttpClient,
@@ -61,10 +60,6 @@ export class ArchiveProfileApiService extends BaseHttpClient<Profile> {
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Profile>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<Profile> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/accession-register-detail-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/accession-register-detail-api.service.ts
@@ -37,22 +37,14 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { AccessionRegisterDetail, BaseHttpClient, BASE_URL, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { AccessionRegisterDetail, BASE_URL, PaginatedHttpClient } from 'vitamui-library';
 
 @Injectable({
   providedIn: 'root',
 })
-export class AccessionRegisterDetailApiService extends BaseHttpClient<AccessionRegisterDetail> {
+export class AccessionRegisterDetailApiService extends PaginatedHttpClient<AccessionRegisterDetail> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/accession-register/details');
-  }
-
-  public getAllPaginated(
-    pageRequest: PageRequest,
-    embedded?: string,
-    headers?: HttpHeaders,
-  ): Observable<PaginatedResponse<AccessionRegisterDetail>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   exportAccessionRegisterCsv(criteria: any, headers?: HttpHeaders): Observable<Blob> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/context-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/context-api.service.ts
@@ -38,24 +38,20 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BaseHttpClient, BASE_URL, Context, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, Context, PaginatedHttpClient } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class ContextApiService extends BaseHttpClient<Context> {
+export class ContextApiService extends PaginatedHttpClient<Context> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/context');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Context>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<Context> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/file-format-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/file-format-api.service.ts
@@ -38,25 +38,20 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BASE_URL, BaseHttpClient, PageRequest, PaginatedResponse } from 'vitamui-library';
-import { FileFormat } from 'vitamui-library';
+import { BASE_URL, FileFormat, PaginatedHttpClient } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class FileFormatApiService extends BaseHttpClient<FileFormat> {
+export class FileFormatApiService extends PaginatedHttpClient<FileFormat> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/fileformat');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<FileFormat>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<FileFormat> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/ingest-contract-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/ingest-contract-api.service.ts
@@ -38,14 +38,14 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BASE_URL, BaseHttpClient, IngestContract, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, IngestContract, PaginatedHttpClient } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class IngestContractApiService extends BaseHttpClient<IngestContract> {
+export class IngestContractApiService extends PaginatedHttpClient<IngestContract> {
   constructor(
     http: HttpClient,
     @Inject(BASE_URL) private baseUrl: string,
@@ -55,10 +55,6 @@ export class IngestContractApiService extends BaseHttpClient<IngestContract> {
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<IngestContract>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<IngestContract> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/logbook-management-operation-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/logbook-management-operation-api.service.ts
@@ -34,16 +34,16 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { BaseHttpClient, BASE_URL, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient } from 'vitamui-library';
 import { OperationResponse } from '../../models/operation-response.interface';
 
 @Injectable({
   providedIn: 'root',
 })
-export class LogbookManagementOperationApiService extends BaseHttpClient<any> {
+export class LogbookManagementOperationApiService extends PaginatedHttpClient<any> {
   baseUrl: string;
 
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
@@ -66,9 +66,5 @@ export class LogbookManagementOperationApiService extends BaseHttpClient<any> {
 
   updateOperationProcessExecution(id: string, actionId: string): Observable<OperationResponse> {
     return this.http.post<OperationResponse>(`${this.apiUrl}/operations/update/${id}`, actionId);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<any>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 }

--- a/ui/ui-frontend/projects/referential/src/app/core/api/management-contracts-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/management-contracts-api.service.ts
@@ -68,24 +68,20 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BaseHttpClient, BASE_URL, ManagementContract, PageRequest, PaginatedResponse } from 'vitamui-library';
+import { BASE_URL, ManagementContract, PaginatedHttpClient } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class ManagementContractsApiService extends BaseHttpClient<ManagementContract> {
+export class ManagementContractsApiService extends PaginatedHttpClient<ManagementContract> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/management-contract');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<ManagementContract>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<ManagementContract> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/ontology-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/ontology-api.service.ts
@@ -38,25 +38,20 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BASE_URL, BaseHttpClient, PageRequest, PaginatedResponse } from 'vitamui-library';
-import { Ontology } from 'vitamui-library';
+import { BASE_URL, Ontology, PaginatedHttpClient } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class OntologyApiService extends BaseHttpClient<Ontology> {
+export class OntologyApiService extends PaginatedHttpClient<Ontology> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/ontology');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Ontology>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<Ontology> {

--- a/ui/ui-frontend/projects/referential/src/app/core/api/operation-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/operation-api.service.ts
@@ -38,12 +38,12 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { BaseHttpClient, BASE_URL, Event, PageRequest, PaginatedResponse, VitamuiHttpHeaders } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient, Event, PageRequest, PaginatedResponse, VitamuiHttpHeaders } from 'vitamui-library';
 
 @Injectable({
   providedIn: 'root',
 })
-export class OperationApiService extends BaseHttpClient<Event> {
+export class OperationApiService extends PaginatedHttpClient<Event> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/operation');
   }

--- a/ui/ui-frontend/projects/referential/src/app/core/api/security-profile-api.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/core/api/security-profile-api.service.ts
@@ -38,24 +38,20 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BaseHttpClient, BASE_URL, PageRequest, PaginatedResponse, SecurityProfile } from 'vitamui-library';
+import { BASE_URL, PaginatedHttpClient, SecurityProfile } from 'vitamui-library';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class SecurityProfileApiService extends BaseHttpClient<SecurityProfile> {
+export class SecurityProfileApiService extends PaginatedHttpClient<SecurityProfile> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/security-profile');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<SecurityProfile>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<SecurityProfile> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/agencies/agency-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/agencies/agency-api.service.ts
@@ -38,27 +38,22 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { PageRequest, PaginatedResponse } from '../vitamui-table';
-import { BaseHttpClient } from '../base-http-client';
 import { BASE_URL } from '../injection-tokens';
 import { Agency } from '../../../lib/models/agency';
+import { PaginatedHttpClient } from '../paginated-http-client';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class AgencyApiService extends BaseHttpClient<Agency> {
+export class AgencyApiService extends PaginatedHttpClient<Agency> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/agency');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Agency>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<Agency> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/access-contract-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/access-contract-api.service.ts
@@ -38,18 +38,17 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BaseHttpClient } from '../base-http-client';
 import { AccessContract } from '../../../lib/models/access-contract.interface';
 
 import { BASE_URL } from '../injection-tokens';
-import { PageRequest, PaginatedResponse } from '../vitamui-table';
+import { PaginatedHttpClient } from '../paginated-http-client';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class AccessContractApiService extends BaseHttpClient<AccessContract> {
+export class AccessContractApiService extends PaginatedHttpClient<AccessContract> {
   constructor(
     http: HttpClient,
     @Inject(BASE_URL) private baseUrl: string,
@@ -59,10 +58,6 @@ export class AccessContractApiService extends BaseHttpClient<AccessContract> {
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<AccessContract>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<AccessContract> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/external-param-profile-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/external-param-profile-api.service.ts
@@ -37,21 +37,16 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { BaseHttpClient } from '../base-http-client';
 import { BASE_URL } from '../injection-tokens';
 import { ExternalParamProfile } from '../models';
-import { PageRequest, PaginatedResponse } from '../vitamui-table';
+import { PaginatedHttpClient } from '../paginated-http-client';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ExternalParamProfileApiService extends BaseHttpClient<ExternalParamProfile> {
+export class ExternalParamProfileApiService extends PaginatedHttpClient<ExternalParamProfile> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/externalparamprofile');
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<ExternalParamProfile>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   create(externalParamProfile: ExternalParamProfile, headers?: HttpHeaders): Observable<ExternalParamProfile> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/profile-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/profile-api.service.ts
@@ -37,26 +37,21 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { BaseHttpClient } from '../base-http-client';
 import { BASE_URL } from '../injection-tokens';
 import { Profile } from '../models';
 import { CriteriaSearchQuery } from '../models/criteria/criteria.interface';
-import { PageRequest, PaginatedResponse } from '../vitamui-table';
+import { PaginatedHttpClient } from '../paginated-http-client';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ProfileApiService extends BaseHttpClient<Profile> {
+export class ProfileApiService extends PaginatedHttpClient<Profile> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/profiles');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Profile>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<Profile> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/rule-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/rule-api.service.ts
@@ -38,27 +38,22 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BaseHttpClient } from '../base-http-client';
 import { BASE_URL } from '../injection-tokens';
 import { Rule } from '../models/rule/rule.interface';
-import { PageRequest, PaginatedResponse } from '../vitamui-table';
+import { PaginatedHttpClient } from '../paginated-http-client';
 
 const HTTP_STATUS_OK = 200;
 
 @Injectable({
   providedIn: 'root',
 })
-export class RuleApiService extends BaseHttpClient<Rule> {
+export class RuleApiService extends PaginatedHttpClient<Rule> {
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
     super(http, baseUrl + '/rules');
   }
 
   getAllByParams(params: HttpParams, headers?: HttpHeaders) {
     return super.getAllByParams(params, headers);
-  }
-
-  getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<Rule>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   getOne(id: string, headers?: HttpHeaders): Observable<Rule> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/base-http-client.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/base-http-client.ts
@@ -40,7 +40,6 @@ import { map } from 'rxjs/operators';
 
 import { LogbookApiService } from './api/logbook-api.service';
 import { ApiEvent, IEvent } from './models';
-import { PageRequest, PaginatedResponse } from './vitamui-table';
 
 const HTTP_STATUS_OK = 200;
 
@@ -60,12 +59,6 @@ export abstract class BaseHttpClient<T extends { id: string }> {
 
   protected getAllByParams(params: HttpParams, headers?: HttpHeaders): Observable<T[]> {
     return this.http.get<T[]>(this.apiUrl, { params, headers });
-  }
-
-  protected getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<T>> {
-    const params = embedded ? pageRequest.httpParams.set('embedded', embedded) : pageRequest.httpParams;
-
-    return this.http.get<PaginatedResponse<T>>(this.apiUrl, { params, headers });
   }
 
   protected getOne(id: string, headers?: HttpHeaders): Observable<T> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/index.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/index.ts
@@ -125,7 +125,7 @@ export * from './missing-translation-handler';
 export * from './models/index';
 export * from './module-import-guard';
 export * from './ontology/index';
-export * from './paginated-api.interface';
+export * from './paginated-http-client';
 export * from './pipes/index';
 export * from './rule/index';
 export * from './schema/index';

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/paginated-http-client.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/paginated-http-client.ts
@@ -34,54 +34,16 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { PageRequest, PaginatedResponse } from './vitamui-table';
+import { BaseHttpClient } from './base-http-client';
+import { PaginatedApi } from './paginated-api.interface';
 
-import { BASE_URL, CriteriaSearchQuery, Group, PaginatedHttpClient } from 'vitamui-library';
+export abstract class PaginatedHttpClient<T extends { id: string }> extends BaseHttpClient<T> implements PaginatedApi<T> {
+  public getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<T>> {
+    const params = embedded ? pageRequest.httpParams.set('embedded', embedded) : pageRequest.httpParams;
 
-@Injectable({
-  providedIn: 'root',
-})
-export class GroupApiService extends PaginatedHttpClient<Group> {
-  constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
-    super(http, baseUrl + '/groups');
-  }
-
-  getAllByParams(params: HttpParams, headers?: HttpHeaders) {
-    return super.getAllByParams(params, headers);
-  }
-
-  getOne(id: string, headers?: HttpHeaders): Observable<Group> {
-    return super.getOne(id, headers);
-  }
-
-  getOneWithEmbedded(id: string, embedded: string, headers?: HttpHeaders): Observable<Group> {
-    return super.getOneWithEmbedded(id, embedded, headers);
-  }
-
-  checkExistsByParam(params: Array<{ key: string; value: string }>, headers?: HttpHeaders): Observable<boolean> {
-    return super.checkExistsByParam(params, headers);
-  }
-
-  create(group: Group, headers?: HttpHeaders): Observable<Group> {
-    return super.create(group, headers);
-  }
-
-  patch(groupPartial: { id: string; [key: string]: any }, headers?: HttpHeaders): Observable<Group> {
-    return super.patch(groupPartial, headers);
-  }
-
-  getLevels(query?: CriteriaSearchQuery, headers?: HttpHeaders): Observable<string[]> {
-    let params = new HttpParams();
-    if (query) {
-      params = params.set('criteria', JSON.stringify(query));
-    }
-
-    return this.http.get<string[]>(this.apiUrl + '/levels', { params, headers });
-  }
-
-  export(): Observable<HttpResponse<Blob>> {
-    return this.http.get(`${this.apiUrl}/export`, { observe: 'response', responseType: 'blob' });
+    return this.http.get<PaginatedResponse<T>>(`${this.apiUrl}/paginated`, { params, headers });
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/services/reclassification-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/services/reclassification-api.service.ts
@@ -36,18 +36,17 @@
  */
 
 import { Inject, Injectable } from '@angular/core';
-import { BaseHttpClient } from '../base-http-client';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { BASE_URL } from '../injection-tokens';
 import { SearchCriteriaDto, SearchResponse } from '../models';
 import { Observable } from 'rxjs';
-import { PageRequest, PaginatedResponse } from '../vitamui-table';
 import { ReclassificationCriteriaDto } from './reclassification.interface';
+import { PaginatedHttpClient } from '../paginated-http-client';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ReclassificationApiService extends BaseHttpClient<any> {
+export class ReclassificationApiService extends PaginatedHttpClient<any> {
   baseUrl: string;
 
   constructor(http: HttpClient, @Inject(BASE_URL) baseUrl: string) {
@@ -57,10 +56,6 @@ export class ReclassificationApiService extends BaseHttpClient<any> {
 
   getBaseUrl() {
     return this.baseUrl;
-  }
-
-  public getAllPaginated(pageRequest: PageRequest, embedded?: string, headers?: HttpHeaders): Observable<PaginatedResponse<any>> {
-    return super.getAllPaginated(pageRequest, embedded, headers);
   }
 
   searchArchiveUnitsByCriteria(criteriaDto: SearchCriteriaDto, transactionId: string, headers?: HttpHeaders) {


### PR DESCRIPTION
## Description

Les APIs avec pagination (page & size) terminent maintenant toutes par "/paginated".

Le code commun "getAllPaginated" dans Angular a été mis à jour en conséquence.

## Type de changement

* Correction
* Refactorisation de code

## Tests

* manuel

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)