### PR TITLE
Bug #14725: fix maven-deploy-plugin version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ def IMPORTANT_BRANCH_OR_TAG = (env.BRANCH_NAME =~ /(develop|master_.*)/).matches
 
 pipeline {
     agent {
-        label 'java21'
+        label 'build'
     }
 
     environment {
@@ -61,7 +61,7 @@ pipeline {
                         env.MVN_GOAL = 'deploy'
                     }
 
-                    env.MVN_COMMAND = "/usr/local/maven/bin/mvn --settings ${pwd()}/.ci/settings.xml --show-version --batch-mode --errors -DdeployAtEnd=true"
+                    env.MVN_COMMAND = "mvn --settings ${pwd()}/.ci/settings.xml --show-version --batch-mode --errors -DdeployAtEnd=true"
                     if (env.DO_CHECKS_AND_TESTS == 'false') {
                         // If checks and tests are disabled:
                         // - "-T1C" builds modules in parallel
@@ -88,6 +88,12 @@ pipeline {
                 sh 'sudo apt install -y build-essential make ruby ruby-dev rubygems jq'
                 sh 'sudo timedatectl set-timezone Europe/Paris'
                 sh 'sudo gem install fpm'
+                nvm('v18.20.3') { // We're installing correct Node version through NVM then update the path to make it available. Do NOT wrap your code in `nvm('...') {}` as it would override the whole PATH and then break tools (jdk, maven) configurations
+                    script {
+                        nvmPath = sh(script: 'dirname $(which node)', returnStdout: true).trim()
+                        env.PATH = "${nvmPath}:${env.PATH}"
+                    }
+                }
             }
         }
 
@@ -105,16 +111,14 @@ pipeline {
                     steps {
                         dir('ui/ui-frontend') {
                             script {
-                                nvm('v18.20.3') {
-                                    sh 'npm ci'
-                                    if (env.DO_CHECKS_AND_TESTS == 'true') {
-                                        sh 'npm run lint'
-                                    }
-                                    sh 'npm run build:vitamui-library'
-                                    sh 'npm run build:allModules'
-                                    if (env.DO_CHECKS_AND_TESTS == 'true') {
-                                        sh 'npm run ci:test'
-                                    }
+                                sh 'npm ci'
+                                if (env.DO_CHECKS_AND_TESTS == 'true') {
+                                    sh 'npm run lint'
+                                }
+                                sh 'npm run build:vitamui-library'
+                                sh 'npm run build:allModules'
+                                if (env.DO_CHECKS_AND_TESTS == 'true') {
+                                    sh 'npm run ci:test'
                                 }
                                 if (env.GOAL == 'publish') {
                                     // If the goal is to publish, we also generate .deb/.rpm
@@ -131,9 +135,7 @@ pipeline {
                     }
                     steps {
                         // TODO: generate .deb/.rpm by running Makefile directly in the Jenkinsfile instead of being run by a maven plugin
-                        nvm('v18.20.3') { // We need node for spotless (when env.DO_CHECKS_AND_TESTS == 'true')
-                            sh '${MVN_COMMAND} clean ${MVN_GOAL} -U -Pvitam,deb,rpm'
-                        }
+                        sh '${MVN_COMMAND} clean ${MVN_GOAL} -U -Pvitam,deb,rpm'
                     }
                 }
             }
@@ -163,9 +165,7 @@ pipeline {
             }
             steps {
                 dir('ui/ui-frontend') {
-                    nvm('v18.20.3') {
-                        sh 'npm run build:pastis-standalone'
-                    }
+                    sh 'npm run build:pastis-standalone'
                 }
                 sh '${MVN_COMMAND} deploy -Pstandalone --projects "api/api-pastis/pastis-standalone" -Dspotless.check.skip=true -Dmaven.test.skip -Dlicense.skip=true'
             }

--- a/Jenkinsfile.containers
+++ b/Jenkinsfile.containers
@@ -1,11 +1,11 @@
 /* groovylint-disable LineLength */
 pipeline {
     agent {
-        label 'java21'
+        label 'build'
     }
 
     environment {
-        MVN_BASE = "/usr/local/maven/bin/mvn --settings ${pwd()}/.ci/settings.xml"
+        MVN_BASE = "mvn --settings ${pwd()}/.ci/settings.xml"
         MVN_COMMAND = "${MVN_BASE} --show-version --batch-mode --errors --fail-at-end -DdeployAtEnd=true "
         M2_REPO = "${HOME}/.m2"
         CI = credentials("app-jenkins")

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <maven.asciidoctor.plugin.version>2.0.0</maven.asciidoctor.plugin.version>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.dependencycheck.version>6.1.1</maven.dependencycheck.version>
-        <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
+        <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <maven.directory.plugin.version>0.1</maven.directory.plugin.version>
         <maven.failsafe.plugin.version>2.21.0</maven.failsafe.plugin.version>


### PR DESCRIPTION
## Description

- upgrade de maven-deploy-plugin en 3.1.1 (au lieu de 2.8.2)
- utilisation de la version de maven configurée par les `tools` plutôt que via un chemin absolu (`/usr/local/maven/bin/mvn`)
- changement de la configuration de nvm dans le Jenkinfile pour éviter qu'il écrase les configurations des tools (jdk/mvn)
- en attendant d'avoir un label commun pour tous les agents, j'ai étendu les labels éligibles

## Type de changement

* Correction

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)