### PR TITLE
Bug #14677 - [Collect] The 'Submit' button remains active after validating a transaction in automatic flow mode with the 'Automatic transaction management' option enabled, until the page is refreshed.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -87,7 +87,11 @@
             >
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
-            <button mat-menu-item (click)="sendTransaction()" [disabled]="!hasSendTransactionRole || (isNotReady$ | async)">
+            <button
+              mat-menu-item
+              (click)="sendTransaction()"
+              [disabled]="!hasSendTransactionRole || (isNotReady$ | async) || (isNotOpen$ | async)"
+            >
               {{ 'COLLECT.INGEST_ACTION' | translate }}
             </button>
           </vitamui-common-menu-button>


### PR DESCRIPTION
fix problème dans [Collect] Le bouton "Verser" reste actif après validation d’une transaction en flux automatique avec l’option "Gestion automatique des transactions" activée, tant que la page n’est pas actualisée.