### PR TITLE
CP V8.0 - Bug #14677 - [Collect] The 'Submit' button remains active after validating a transaction in automatic flow mode with the 'Automatic transaction management' option enabled, until the page is refreshed.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -86,7 +86,11 @@
             >
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
-            <button mat-menu-item (click)="sendTransaction()" [disabled]="!hasSendTransactionRole || (isNotReady$ | async)">
+            <button
+              mat-menu-item
+              (click)="sendTransaction()"
+              [disabled]="!hasSendTransactionRole || (isNotReady$ | async) || (isNotOpen$ | async)"
+            >
               {{ 'COLLECT.INGEST_ACTION' | translate }}
             </button>
           </vitamui-common-menu-button>


### PR DESCRIPTION
CP V8.0 - Bug #14677

> Cherry-Picked from #2803