### PR TITLE
CP V8.1 - Bug #14804: Properly update ressources for ui-identity-admin during upgrade.

### DIFF
--- a/deployment/roles/nginx_webapp/tasks/install.yml
+++ b/deployment/roles/nginx_webapp/tasks/install.yml
@@ -12,12 +12,8 @@
   notify: reload nginx
 
 - name: Install static ressources for ui-identity-admin - Copy folder
-  copy:
-    src: "{{ frontend_data_dir }}/identity/"
-    dest: "{{ frontend_data_dir }}/identity-admin"
-    group: "{{ frontend_group }}"
-    owner: "{{ frontend_user }}"
-    remote_src: yes
+  command:
+    cmd: cp -va "{{ frontend_data_dir }}/identity/." "{{ frontend_data_dir }}/identity-admin"
   when: vitamui_struct.vitamui_component == "ui-identity-admin"
 
 - name: Get package facts


### PR DESCRIPTION
## Description

> Cherry-Picked from #2829

The copy task doesn't properly handle subdirectories causing assets to not be updated.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)