### PR TITLE
Bug #14822: Execute api-gw configuration after creating expected directories.

### DIFF
--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -44,13 +44,6 @@
   when: force_vitamui_version is defined and install_mode != "container"
 
 #### Configuration ####
-- name: Prepare api-gateway trusted certificates
-  include_tasks: "prepare_api_gateway_conf.yml"
-  when: vitamui_struct.vitamui_component == 'api-gateway'
-  tags:
-  - update_vitam_configuration
-  - update_vitamui_certificates
-
 - name: Check that the directories exist (must be removed when the RPM plugin will be patched)
   file:
     path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/{{ item }}/{{ vitamui_struct.vitamui_component }}"
@@ -78,6 +71,13 @@
     mode: "{{ vitamui_defaults.folder.folder_permission | default('0750') }}"
   notify: restart service
   when: install_mode != "container"
+
+- name: Prepare api-gateway trusted certificates
+  include_tasks: prepare_api_gateway_conf.yml
+  when: vitamui_struct.vitamui_component == 'api-gateway'
+  tags:
+    - update_vitamui_configuration
+    - update_vitamui_certificates
 
 - name: Deploy java_opts configuration in sysconfig subdir
   template:

--- a/deployment/roles/vitamui/tasks/prepare_api_gateway_conf.yml
+++ b/deployment/roles/vitamui/tasks/prepare_api_gateway_conf.yml
@@ -2,7 +2,7 @@
   set_fact:
     prefix: "trusted-ca-certs-"
   tags:
-    - update_vitam_configuration
+    - update_vitamui_configuration
     - update_vitamui_certificates
 
 - name: List existing CA certs
@@ -11,7 +11,7 @@
     patterns: "{{ prefix }}*.crt"
   register: existing_ca_certs
   tags:
-    - update_vitam_configuration
+    - update_vitamui_configuration
     - update_vitamui_certificates
 
 - name: List trusted CA files
@@ -21,7 +21,7 @@
   delegate_to: localhost
   register: trusted_ca_certs
   tags:
-    - update_vitam_configuration
+    - update_vitamui_configuration
     - update_vitamui_certificates
 
 - name: Check trusted CA files present
@@ -39,7 +39,7 @@
   with_items: "{{ trusted_ca_certs.files | map(attribute='path') | list }}"
   notify: restart service
   tags:
-    - update_vitam_configuration
+    - update_vitamui_configuration
     - update_vitamui_certificates
 
 - name: Store copied filenames in a variable
@@ -47,7 +47,7 @@
     # regex is used to prefix file-names
     copied_cert_files: "{{ trusted_ca_certs.files | map(attribute='path') | map('basename') | map('regex_replace', '^(.*)$', prefix + '\\1') | list }}"
   tags:
-    - update_vitam_configuration
+    - update_vitamui_configuration
     - update_vitamui_certificates
 
 - name: Deleting obsolete certs
@@ -56,6 +56,6 @@
     state: absent
   with_items: "{{ existing_ca_certs['files'] | map(attribute='path') | map('basename') | difference(copied_cert_files) }}"
   tags:
-    - update_vitam_configuration
+    - update_vitamui_configuration
     - update_vitamui_certificates
   notify: restart service


### PR DESCRIPTION
## Description

* Creating configuration directories before configuring api-gw.
* Update tags to proper name.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam