### PR TITLE
CP V7.0 - Bug #14677 & #14831 - [Collect] The 'Submit' button remains active after validating a transaction in automatic flow mode with the 'Automatic transaction management' option enabled, until the page is refreshed.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -75,7 +75,7 @@
             <button mat-menu-item (click)="validateTransaction()" [disabled]="isArchiveUnitsEmpty() || (isNotOpen$ | async)">
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
-            <button mat-menu-item (click)="sendTransaction()" [disabled]="(isNotReady$ | async) || (isNotOpen$ | async)">
+            <button mat-menu-item (click)="sendTransaction()" [disabled]="isNotReady$ | async">
               {{ 'COLLECT.INGEST_ACTION' | translate }}
             </button>
           </vitamui-common-menu-button>


### PR DESCRIPTION
> Cherry-Picked from #2847