### PR TITLE
CP V8.1 - Bug #14833: ui components are not properly installed in expected directories.

### DIFF
--- a/deployment/roles/nginx_webapp/tasks/install.yml
+++ b/deployment/roles/nginx_webapp/tasks/install.yml
@@ -13,7 +13,7 @@
 
 - name: Install static ressources for ui-identity-admin - Copy folder
   command:
-    cmd: cp -va "{{ frontend_data_dir }}/identity/." "{{ frontend_data_dir }}/identity-admin"
+    cmd: cp -va "{{ frontend_data_dir }}/ui-identity/." "{{ frontend_data_dir }}/ui-identity-admin"
   when: vitamui_struct.vitamui_component == "ui-identity-admin"
 
 - name: Get package facts
@@ -37,7 +37,7 @@
 - name: Add config.json file
   template:
     src: frontend/config.json.j2
-    dest: "{{ frontend_data_dir }}/{{ vitamui_struct.vitamui_component | regex_replace('^ui-', '') }}/assets/config.json"
+    dest: "{{ frontend_data_dir }}/{{ vitamui_struct.vitamui_component }}/assets/config.json"
     group: "{{ frontend_group }}"
     owner: "{{ frontend_user }}"
     mode: "{{ vitam_defaults.folder.conf_permission }}"

--- a/deployment/roles/nginx_webapp/tasks/uninstall.yml
+++ b/deployment/roles/nginx_webapp/tasks/uninstall.yml
@@ -20,5 +20,5 @@
     - "{{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}.key_pass"
     - "{{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}-ssl.conf"
     - "{{ nginx_conf_dir }}/{{ vitamui_struct.vitamui_component }}.conf"
-    - "{{ frontend_data_dir }}/{{ vitamui_struct.vitamui_component | regex_replace('^ui-', '') }}/assets/config.json"
+    - "{{ frontend_data_dir }}/{{ vitamui_struct.vitamui_component }}/assets/config.json"
   notify: reload nginx

--- a/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
@@ -7,7 +7,7 @@ server {
   listen  {{ ip_service }}:{{ vitamui_struct.port_service }};
   {% endif %}
 
-  root    {{ frontend_data_dir }}/{{ vitamui_struct.vitamui_component | regex_replace('^ui-', '') }};
+  root    {{ frontend_data_dir }}/{{ vitamui_struct.vitamui_component }};
 
   location ~* \.(jpg|jpeg|png|gif|ico|svg|ttf|woff|woff2|eot|css|js|json)$ {
     add_header X-Content-Type-Options "nosniff" always;

--- a/tools/packaging/Makefile-fronts
+++ b/tools/packaging/Makefile-fronts
@@ -28,7 +28,7 @@ FPM_PACK_REMOVE_SCRIPTS     = --after-remove "$(TEMPLATE_TMP_DIR)/after-remove-r
 # variable used to copy
 NAME_WITHOUT_SUFFIX  := $(subst ui-,,$(NAME))
 RESSOURCE_DIR_ORIGIN := $(abspath $(STAGING_ROOT)/../../../ui/ui-frontend/dist/$(NAME_WITHOUT_SUFFIX)/browser/*)
-RESSOURCE_DIR_DEST   := $(abspath $(STAGING_ROOT)/vitamui/data/$(NAME_WITHOUT_SUFFIX)/)
+RESSOURCE_DIR_DEST   := $(abspath $(STAGING_ROOT)/vitamui/data/$(NAME)/)
 
 clean:
 	@rm -Rf $(TEMPLATE_TMP_DIR) $(STAGING_ROOT)
@@ -39,7 +39,7 @@ $(STAGING_ROOT):
 stage: $(STAGING_ROOT)
 
 $(VITAMUI_DIRS): stage
-	@mkdir -p $(abspath $(STAGING_ROOT)/vitamui/$@/$(NAME_WITHOUT_SUFFIX))
+	@mkdir -p $(abspath $(STAGING_ROOT)/vitamui/$@/$(NAME))
 
 vitamui-dirs:  $(VITAMUI_DIRS)
 
@@ -48,7 +48,7 @@ template-files:
 	@for fic in  $(TEMPLATE_SRC) ; \
 	do \
 		sed  \
-			-e "s/__NAME__/$(NAME_WITHOUT_SUFFIX)/g" \
+			-e "s/__NAME__/$(NAME)/g" \
 			-e "s/__USER__/$(USER)/g" \
 			-e "s/__GROUP__/$(GROUP)/g" \
 			$$fic >  $(TEMPLATE_TMP_DIR)/`basename $$fic`; \


### PR DESCRIPTION
## Description

> Cherry-Picked from #2852 

For example: ui-referential was previously installed under the same directories than referential.

## Type de changement

* Build
* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)