### PR TITLE
CP V7.1 - Bug #14813: Remove old dropIndex commands.

### DIFF
--- a/deployment/scripts/mongod/v7.1/002_TRV-389_add_index_on_updatedDate_field_of_tokens_collection_ref.js
+++ b/deployment/scripts/mongod/v7.1/002_TRV-389_add_index_on_updatedDate_field_of_tokens_collection_ref.js
@@ -2,8 +2,6 @@ print("START 002_TRV-389_add_index_on_updatedDate_field_of_tokens_collection_ref
 
 db = db.getSiblingDB("iam");
 
-db.tokens.dropIndex("updatedDate_1");
-
 db.tokens.createIndex(
   {updatedDate: 1},
   {name: "idx_token_date", expireAfterSeconds: 0, background: true}


### PR DESCRIPTION
## Description

Remove unexisting index to avoid error during deployment: `MongoServerError: ns not found iam.tokens`

> Cherry-Picked from #2895 

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam