### PR TITLE
CP V8.1 - Bug #14853: Add missing translation keys for preservation operations.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
@@ -3507,7 +3507,17 @@
     "STP_FINALIZE_TRACEABILITY_LINKED_CHECKS.STARTED": "Successfully started the process of finalizing the secure log verification",
     "STP_FINALIZE_TRACEABILITY_LINKED_CHECKS": "Successfully completed the process of finalizing the secure log verification",
     "TRACEABILITY_FINALIZATION": "Successfully finalized the secure log verification",
-    "LINKED_CHECK_SECURISATION": "Successfully audited the secure log verification"
+    "LINKED_CHECK_SECURISATION": "Successfully audited the secure log verification",
+    "PRESERVATION_CHECK_RESOURCE_AVAILABILITY": "Check the availability of binary objects on the storage offer",
+    "PRESERVATION_UNIT_METADATA_SECURITY_CHECKS": "Check the security of archival units",
+    "PRESERVATION_TESSERACT_SPLIT_TEXT_CONTENT": "Split metadata",
+    "PRESERVATION_EXTRACTION_AU": "Extract descriptive metadata",
+    "STP_PRESERVATION_PREPARATION_INSERTION_AU_METADATA.STARTED": "Start of the process of preparing the insertion of metadata",
+    "STP_PRESERVATION_PREPARATION_INSERTION_AU_METADATA": "Process of preparing the insertion of metadata",
+    "PRESERVATION_PREPARATION_INSERTION_AU_METADATA": "Preparation of the insertion of archival units",
+    "STP_PRESERVATION_INSERTION_AU_METADATA.STARTED": "Start of the process of inserting metadata",
+    "STP_PRESERVATION_INSERTION_AU_METADATA": "Process of inserting metadata",
+    "PRESERVATION_INSERTION_AU_METADATA": "Indexation of archival units metadata"
   },
   "HTTP_INTERCEPTOR": {
     "HTTP_STATUS_CODE_FORBIDDEN": "You do not have the necessary rights to perform this operation.",

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
@@ -3507,7 +3507,17 @@
     "STP_FINALIZE_TRACEABILITY_LINKED_CHECKS.STARTED": "Succès du début du processus de la finalisation de la vérification des journaux sécurisés",
     "STP_FINALIZE_TRACEABILITY_LINKED_CHECKS": "Succès du processus de la finalisation de la vérification des journaux sécurisés",
     "TRACEABILITY_FINALIZATION": "Succès de la finalisation de la vérification des journaux sécurisés",
-    "LINKED_CHECK_SECURISATION": "Succès d'audit de la vérification des journaux sécurisés"
+    "LINKED_CHECK_SECURISATION": "Succès d'audit de la vérification des journaux sécurisés",
+    "PRESERVATION_CHECK_RESOURCE_AVAILABILITY": "Vérification de la disponibilité des objets binaires sur l'offre de stockage",
+    "PRESERVATION_UNIT_METADATA_SECURITY_CHECKS": "Vérification de la sécurité des unités archivistiques",
+    "PRESERVATION_TESSERACT_SPLIT_TEXT_CONTENT": "Découpage des métadonnées",
+    "PRESERVATION_EXTRACTION_AU": "Extraction des métadonnées descriptives",
+    "STP_PRESERVATION_PREPARATION_INSERTION_AU_METADATA.STARTED": "Début du processus de préparation de l'insertion des métadonnées",
+    "STP_PRESERVATION_PREPARATION_INSERTION_AU_METADATA": "Processus de préparation de l'insertion des métadonnées",
+    "PRESERVATION_PREPARATION_INSERTION_AU_METADATA": "Préparation de l'insertion des unités archivistiques",
+    "STP_PRESERVATION_INSERTION_AU_METADATA.STARTED": "Début du processus de l'insertion des métadonnées",
+    "STP_PRESERVATION_INSERTION_AU_METADATA": "Processus de l'insertion des métadonnées",
+    "PRESERVATION_INSERTION_AU_METADATA": "Indexation des métadonnées des unités archivistiques"
   },
   "HTTP_INTERCEPTOR": {
     "HTTP_STATUS_CODE_FORBIDDEN": "Vous n'avez pas les droits nécessaires pour effectuer cette opération.",


### PR DESCRIPTION
## Description

Ajout des clés de traduction manquantes pour l'affichage des opérations du Processus global de préservation.

> Cherry-Picked from #2897

## Type de changement

* Correction
* Traductions

## Contributeur

* Programme Vitam