### PR TITLE
Story #14907: Do not compile executed scripts during mongo_init.

### DIFF
--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -75,6 +75,30 @@
       mongod_eligible_files : "{{ (mongod_eligible_files| default([])) + [ {'name': item, 'version': item | regex_replace('^(.+)/(.+)$', '\\1') ,'finalname': 'vitamui_' + item | regex_replace('/', '_') | basename | regex_replace('\\.j2$')} ] }}"
     loop: "{{ mongod_files | difference(mongod_excluded_files| default([])) | sort }}" # Difference filter documentation states 'Items in the resulting list are returned in arbitrary order'. This is a workaround
 
+  - name: Prepare query to get already executed scripts from versioning.changelog
+    set_fact:
+      executed_scripts_query: "mongosh mongodb://{{ mongod_uri }}/versioning {{ mongo_credentials }} --quiet --eval 'var results = db.changelog.find({}, {filename: 1, _id: 0}).toArray(); var filenames = results.map(function(doc) { return doc.filename; }); print(JSON.stringify(filenames));'"
+
+  - name: Prepare query to get already executed scripts from versioning.changelog (docker)
+    set_fact:
+      executed_scripts_query: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"{{ executed_scripts_query }}\""
+    when: mongodb.docker is defined and mongodb.docker.enable
+
+  - name: Execute query to get already executed scripts
+    shell: "{{ executed_scripts_query }}"
+    no_log: "{{ hide_passwords_during_deploy }}"
+    register: executed_scripts_results
+    ignore_errors: true
+
+  - name: Parse executed scripts from query result
+    set_fact:
+      executed_scripts_list: "{{ executed_scripts_results.stdout | from_json | default([]) }}"
+    when: executed_scripts_results is defined and executed_scripts_results.rc == 0
+
+  - name: Filter out already executed scripts from eligible files
+    set_fact:
+      mongod_eligible_files: "{{ mongod_eligible_files | rejectattr('finalname', 'in', executed_scripts_list | default([])) | list | sort(attribute='finalname') }}"
+
   # We generate scripts and upload on remote host
   - name: Compute and copy script files
     template:
@@ -85,8 +109,8 @@
       mode: 0755
     loop: "{{ mongod_eligible_files | unique }}"
 
-  - name: "Prepare file"
-    include_tasks: "prepare_script.yml"
+  - name: Prepare file
+    include_tasks: prepare_script.yml
     when: mongodb.versioning is defined and mongodb.versioning.enable
     loop: "{{ mongod_eligible_files | unique }}"
     loop_control:
@@ -94,7 +118,7 @@
 
   - name: Compute main script file
     template:
-      src: "main_script.js.j2"
+      src: main_script.js.j2
       dest: "{{ mongod_output_dir_entry_point }}/main_script.js"
       owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
       group: "{{ vitamui_defaults.users.group | default('vitamui') }}"

--- a/deployment/roles/mongo_init/tasks/prepare_script.yml
+++ b/deployment/roles/mongo_init/tasks/prepare_script.yml
@@ -1,29 +1,30 @@
 ---
 
-- fail: msg="Variable '{{ mongo_file }}' is not defined"
+- fail:
+    msg: "Variable '{{ mongo_file }}' is not defined"
   when: mongo_file is undefined
 
-- name:
+- name: Debug file name to execute
   debug:
-    msg: ">>>> Execution of the file {{ mongo_file.finalname }}<<<<"
+    msg: ">>>> Execution of the file {{ mongo_file.finalname }} <<<<"
 
 - name: Check if the script exists
   stat:
     path: "{{ mongod_output_dir_entry_point }}/{{ mongo_file.finalname }}"
   register: stat_result
 
-- fail: msg="The file '{{ mongo_file.finalname }}' does not exist"
+- fail:
+    msg: "The file '{{ mongo_file.finalname }}' does not exist"
   when: not stat_result.stat.exists
 
-- name: Get script content.
+- name: Get script content
   shell: "cat {{ mongod_output_dir_entry_point }}/{{ mongo_file.finalname }}"
   register: script_content
 
 - name: Compute versionned script files
   template:
-    src: "versioned_script.js.j2"
+    src: versioned_script.js.j2
     dest: "{{ mongod_output_dir_entry_point }}/{{ mongo_file.finalname }}"
     owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
     group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
     mode: 0755
-


### PR DESCRIPTION
## Description

Vérification des scripts déjà exécutés pour éviter de calculer l'intégralité des templates scripts/mongod/ à chaque exécution de mongo_init.

## Type de changement

* Ansiblerie
* Refactorisation de code

## Contributeur

* Programme Vitam