### PR TITLE
Story #13529: Fixing missed JDK21 update.

### DIFF
--- a/api/api-pastis/pastis-standalone/pom.xml
+++ b/api/api-pastis/pastis-standalone/pom.xml
@@ -253,8 +253,8 @@
                                 <configuration>
                                     <target>
                                         <get
-                                                src="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_windows_hotspot_17.0.13_11.zip"
-                                                dest="${project.build.directory}/jdk17.zip"
+                                                src="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_windows_hotspot_21.0.7_6.zip"
+                                                dest="${project.build.directory}/jdk21.zip"
                                                 verbose="false"
                                                 usetimestamp="true"/>
                                     </target>
@@ -268,8 +268,8 @@
                                 <configuration>
                                     <tasks>
                                         <echo message="unzipping file"/>
-                                        <unzip src="${project.build.directory}/jdk17.zip"
-                                               dest="${project.build.directory}/jdk17/"/>
+                                        <unzip src="${project.build.directory}/jdk21.zip"
+                                               dest="${project.build.directory}/jdk21/"/>
                                     </tasks>
                                 </configuration>
                                 <goals>
@@ -299,8 +299,8 @@
                             <outfile>${project.build.directory}/${project.build.finalName}.exe</outfile>
                             <errTitle>Erreur</errTitle>
                             <jre>
-                                <minVersion>17</minVersion>
-                                <path>./jdk17/jdk-17.0.13+11</path>
+                                <minVersion>21</minVersion>
+                                <path>./jdk21/jdk-21.0.7+6</path>
                                 <requires64Bit/>
                                 <requiresJdk/>
                             </jre>

--- a/api/api-pastis/pastis-standalone/src/main/assembly/packaging-zip.xml
+++ b/api/api-pastis/pastis-standalone/src/main/assembly/packaging-zip.xml
@@ -12,7 +12,7 @@
             <outputDirectory>/</outputDirectory>
             <includes>
                 <include>*.exe</include>
-                <include>jdk17/jdk-17.0.13+11/**</include>
+                <include>jdk21/jdk-21.0.7+6/**</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <!-- override it to fix mockito java 21 issue -->
         <byte-buddy.version>1.15.5</byte-buddy.version>
-        
+
         <!--Plugins version -->
         <asciidoctorj.pdf.version>1.5.4</asciidoctorj.pdf.version>
         <jruby.complete.version>9.2.13.0</jruby.complete.version>
@@ -639,7 +639,7 @@
                                         <!-- If you want to changes default dependencies (only
                                         systemd),
                                         define them as a comma separated list of packages -->
-                                        <argument>DEPENDENCIES=systemd,java-17-openjdk</argument>
+                                        <argument>DEPENDENCIES=systemd</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -1030,7 +1030,6 @@
                     </snapshots>
                 </repository>
             </repositories>
-
         </profile>
 
     </profiles>


### PR DESCRIPTION
## Description

* Correction de la dépendance à java17 lors du build des packages rpm.
* Mise à jour de la JDK21 pour pastis-standalone.

## Type de changement

* Build
* Correction

## Contributeur

* Programme Vitam