### PR TITLE
CP V7.1 - Story #14907: Do not compile already executed scripts during mongo_init.

### DIFF
--- a/deployment/roles/checks/tasks/check_mongo_express.yml
+++ b/deployment/roles/checks/tasks/check_mongo_express.yml
@@ -2,15 +2,7 @@
 
 - name: Check if mongo_express is enabled on any host in the group
   set_fact:
-    mongo_express_enabled_on_a_host: >-
-      {{
-        groups['hosts_vitamui_mongod'] | map('extract', hostvars, 'mongo_express_enabled') |
-        select('defined') |
-        map('bool') |
-        select('equalto', true) |
-        list |
-        length > 0
-      }}
+    mongo_express_enabled_on_a_host: "{{ groups['hosts_vitamui_mongod'] | map('extract', hostvars, 'mongo_express_enabled') | select('defined') | map('bool') | list | sum > 0 }}"
 
 - name: Check mongo_express configuration
   fail:

--- a/deployment/roles/mongo_init/tasks/check_auth.yml
+++ b/deployment/roles/mongo_init/tasks/check_auth.yml
@@ -6,7 +6,7 @@
     mongo_no_auth: false
 
 - block:
-    - name: Check if authent is enabled
+    - name: Check if authentication is enabled
       command: "mongosh mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'"
       register: mongo_authent_enabled
       failed_when: false
@@ -19,8 +19,8 @@
   when: mongodb.docker is not defined or not mongodb.docker.enable
 
 - block:
-    - name: Load script in database (docker)
-      shell: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'\""
+    - name: Check if authentication is enabled (docker)
+      shell: "docker exec {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh mongodb://{{ mongod_uri }}/admin?replicaSet={{ mongod_replicaset_name }} -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --quiet --eval 'db.help()'\""
       failed_when: false
       register: mongo_authent_enabled
 
@@ -33,6 +33,6 @@
 # When authentication is required, we set mongodb admin credentials
 - name: Set mongodb authentication credentials
   set_fact:
-    mongo_credentials: " -u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --authenticationDatabase {{ mongodb.admin.db }} "
+    mongo_credentials: "-u {{ mongodb.admin.user }} -p {{ mongodb.admin.password }} --authenticationDatabase {{ mongodb.admin.db }}"
   when: not mongo_no_auth
   no_log: "{{ hide_passwords_during_deploy }}"

--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -75,6 +75,30 @@
       mongod_eligible_files : "{{ (mongod_eligible_files| default([])) + [ {'name': item, 'version': item | regex_replace('^(.+)/(.+)$', '\\1') ,'finalname': 'vitamui_' + item | regex_replace('/', '_') | basename | regex_replace('\\.j2$')} ] }}"
     loop: "{{ mongod_files | difference(mongod_excluded_files| default([])) | sort }}" # Difference filter documentation states 'Items in the resulting list are returned in arbitrary order'. This is a workaround
 
+  - name: Prepare query to get already executed scripts from versioning.changelog
+    set_fact:
+      executed_scripts_query: "mongosh mongodb://{{ mongod_uri }}/versioning {{ mongo_credentials }} --quiet --eval 'var results = db.changelog.find({}, {filename: 1, _id: 0}).toArray(); var filenames = results.map(function(doc) { return doc.filename; }); print(JSON.stringify(filenames));'"
+
+  - name: Prepare query to get already executed scripts from versioning.changelog (docker)
+    set_fact:
+      executed_scripts_query: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"{{ executed_scripts_query }}\""
+    when: mongodb.docker is defined and mongodb.docker.enable
+
+  - name: Execute query to get already executed scripts
+    shell: "{{ executed_scripts_query }}"
+    no_log: "{{ hide_passwords_during_deploy }}"
+    register: executed_scripts_results
+    ignore_errors: true
+
+  - name: Parse executed scripts from query result
+    set_fact:
+      executed_scripts_list: "{{ executed_scripts_results.stdout | from_json | default([]) }}"
+    when: executed_scripts_results is defined and executed_scripts_results.rc == 0
+
+  - name: Filter out already executed scripts from eligible files
+    set_fact:
+      mongod_eligible_files: "{{ mongod_eligible_files | rejectattr('finalname', 'in', executed_scripts_list | default([])) | list | sort(attribute='finalname') }}"
+
   # We generate scripts and upload on remote host
   - name: Compute and copy script files
     template:
@@ -85,8 +109,8 @@
       mode: 0755
     loop: "{{ mongod_eligible_files | unique }}"
 
-  - name: "Prepare file"
-    include_tasks: "prepare_script.yml"
+  - name: Prepare file
+    include_tasks: prepare_script.yml
     when: mongodb.versioning is defined and mongodb.versioning.enable
     loop: "{{ mongod_eligible_files | unique }}"
     loop_control:
@@ -94,7 +118,7 @@
 
   - name: Compute main script file
     template:
-      src: "main_script.js.j2"
+      src: main_script.js.j2
       dest: "{{ mongod_output_dir_entry_point }}/main_script.js"
       owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
       group: "{{ vitamui_defaults.users.group | default('vitamui') }}"

--- a/deployment/roles/mongo_init/tasks/main.yml
+++ b/deployment/roles/mongo_init/tasks/main.yml
@@ -2,7 +2,8 @@
 
 - block:
 
-  - fail: msg="Variable '{{ mongod_source_template_dir }}' is not defined"
+  - fail:
+      msg: "Variable '{{ mongod_source_template_dir }}' is not defined"
     when: mongod_source_template_dir is undefined
 
   - name: Unset mongo_nodes fact
@@ -34,7 +35,7 @@
     shell: "rm -Rf {{ mongod_output_dir_entry_point }}/*"
 
   # We sort directories by theirs versions
-  - name: List script files versions in the directory {{ mongod_source_template_dir }}
+  - name: "List script files versions in the directory {{ mongod_source_template_dir }}"
     delegate_to: localhost
     shell:
       cmd: find * -maxdepth 1 -type d | sort -V
@@ -42,7 +43,7 @@
     register: versions
 
   # For each version, we apply a second sort on the index of the script file.
-  - name: List script files in the directory {{ mongod_source_template_dir }}
+  - name: "List script files in the directory {{ mongod_source_template_dir }}"
     delegate_to: localhost
     shell:
       cmd: find {{ version }}/* -type f -print | sort -V -t '_' -k1
@@ -52,7 +53,7 @@
     loop_control:
       loop_var: version
 
-  - name: "Compute file scripts"
+  - name: Compute file scripts
     delegate_to: localhost
     set_fact:
       mongod_files: "{{ (mongod_files| default([])) + item.stdout_lines }}"
@@ -81,7 +82,7 @@
 
   - name: Prepare query to get already executed scripts from versioning.changelog (docker)
     set_fact:
-      executed_scripts_query: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"{{ executed_scripts_query }}\""
+      executed_scripts_query: "docker exec {{ mongodb.docker.image_name }} /bin/bash -c \"{{ executed_scripts_query }}\""
     when: mongodb.docker is defined and mongodb.docker.enable
 
   - name: Execute query to get already executed scripts
@@ -95,9 +96,19 @@
       executed_scripts_list: "{{ executed_scripts_results.stdout | from_json | default([]) }}"
     when: executed_scripts_results is defined and executed_scripts_results.rc == 0
 
-  - name: Filter out already executed scripts from eligible files
+  - name: Reset filtered eligible files list
     set_fact:
-      mongod_eligible_files: "{{ mongod_eligible_files | rejectattr('finalname', 'in', executed_scripts_list | default([])) | list | sort(attribute='finalname') }}"
+      mongod_eligible_files_filtered: []
+
+  - name: Add eligible files not in executed list
+    set_fact:
+      mongod_eligible_files_filtered: "{{ mongod_eligible_files_filtered + [item] }}"
+    with_items: "{{ mongod_eligible_files }}"
+    when: item.finalname not in (executed_scripts_list | default([]))
+
+  - name: Replace eligible files with filtered list sorted by finalname
+    set_fact:
+      mongod_eligible_files: "{{ mongod_eligible_files_filtered | sort(attribute='finalname') }}"
 
   # We generate scripts and upload on remote host
   - name: Compute and copy script files
@@ -130,14 +141,8 @@
     when: mongodb.docker is not defined or not mongodb.docker.enable
 
   - name: Load script in database test (docker)
-    command: "docker exec --tty {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh mongodb://{{ mongod_uri }}/admin {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js\""
+    shell: "docker exec {{ mongodb.docker.image_name }} /bin/bash -c \"mongosh mongodb://{{ mongod_uri }}/admin {{ mongo_credentials }} --quiet --file {{ mongodb.docker.internal_dir}}/app/mongod/main_script.js\""
     no_log: "{{ hide_passwords_during_deploy }}"
     when: mongodb.docker is defined and mongodb.docker.enable
-
-  # - name: "Execute file"
-  #   include_tasks: "execute_script.yml"
-  #   loop: "{{ mongod_eligible_files | unique }}"
-  #   loop_control:
-  #     loop_var: mongo_file
 
   run_once: true

--- a/deployment/roles/mongo_init/tasks/prepare_script.yml
+++ b/deployment/roles/mongo_init/tasks/prepare_script.yml
@@ -1,29 +1,30 @@
 ---
 
-- fail: msg="Variable '{{ mongo_file }}' is not defined"
+- fail:
+    msg: "Variable '{{ mongo_file }}' is not defined"
   when: mongo_file is undefined
 
-- name:
+- name: Debug file name to execute
   debug:
-    msg: ">>>> Execution of the file {{ mongo_file.finalname }}<<<<"
+    msg: ">>>> Execution of the file {{ mongo_file.finalname }} <<<<"
 
 - name: Check if the script exists
   stat:
     path: "{{ mongod_output_dir_entry_point }}/{{ mongo_file.finalname }}"
   register: stat_result
 
-- fail: msg="The file '{{ mongo_file.finalname }}' does not exist"
+- fail:
+    msg: "The file '{{ mongo_file.finalname }}' does not exist"
   when: not stat_result.stat.exists
 
-- name: Get script content.
+- name: Get script content
   shell: "cat {{ mongod_output_dir_entry_point }}/{{ mongo_file.finalname }}"
   register: script_content
 
 - name: Compute versionned script files
   template:
-    src: "versioned_script.js.j2"
+    src: versioned_script.js.j2
     dest: "{{ mongod_output_dir_entry_point }}/{{ mongo_file.finalname }}"
     owner: "{{ vitamui_defaults.users.vitamuidb | default('vitamuidb') }}"
     group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
     mode: 0755
-


### PR DESCRIPTION
## Description

Vérification des scripts déjà exécutés pour éviter de calculer l'intégralité des templates scripts/mongod/ à chaque exécution de mongo_init.

> Cherry-Picked from #2901

## Type de changement

* Ansiblerie
* Refactorisation de code

## Contributeur

* Programme Vitam