### PR TITLE
Story #14559: Clean code - Fix random test KO

### DIFF
--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/dao/CustomerRepositoryTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/dao/CustomerRepositoryTest.java
@@ -20,7 +20,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,14 +84,14 @@ public class CustomerRepositoryTest extends AbstractMongoTests {
         final Customer julien = IamServerUtilsTest.buildCustomer(
             "id1",
             "julien",
-            Integer.toString(ThreadLocalRandom.current().nextInt(1000000, 10000000)),
+            "123456",
             Arrays.asList("julien@vitamui.com", "pierre@vitamui.com")
         );
 
         final Customer moctar = IamServerUtilsTest.buildCustomer(
             "id2",
             "moctar",
-            Integer.toString(ThreadLocalRandom.current().nextInt(1000000, 10000000)),
+            "999999",
             Arrays.asList("julien@vitamui.com", "pierre@vitamui.com")
         );
 
@@ -124,7 +123,7 @@ public class CustomerRepositoryTest extends AbstractMongoTests {
         assertThat(customersFound.size()).isEqualTo(1);
         assertThat(customersFound.get(0)).usingRecursiveComparison().isEqualTo(julien);
 
-        term = julien.getCode().substring(0, 4);
+        term = julien.getCode();
         query = Query.query(
             MongoUtils.buildOrOperator(
                 (Criteria) MongoUtils.buildCriteriaContainsIgnoreCase("code", term),


### PR DESCRIPTION
Codes were random 7-digit numbers (as string). When searching by codes containing the 4 first letters of one randomly generated code, there was a non-null (>4/1000) chance to match other randomly generated codes. e.g.: codes "1234567" and "1234999" are both a match for "1234". Codes "1234567" and "99123499" are both a match for "1234".

## Type de changement

* Correction

## Contributeur

* VAS (Vitam Accessible en Service)