### PR TITLE
Fix #12346: do not apply titlecase on profile name

### DIFF
--- a/ui/ui-frontend/projects/identity/src/app/group/group-preview/profiles-tab/profiles-tab.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/group/group-preview/profiles-tab/profiles-tab.component.html
@@ -5,7 +5,7 @@
 <div class="d-flex justify-content-between align-items-center p-3 mb-2 vitamui-profile-list" *ngFor="let profile of profilesDisplay">
   <div>
     <div class="text caption light mb-1">{{ 'APPLICATION.' + profile.appId + '.NAME' | translate }}</div>
-    <div class="text medium">{{ profile?.tenantName }} : {{ profile?.profileName | titlecase }}</div>
+    <div class="text medium">{{ profile?.tenantName }} : {{ profile?.profileName }}</div>
   </div>
 
   <div>

--- a/ui/ui-frontend/projects/identity/src/app/group/group-preview/profiles-tab/profiles-tab.component.spec.ts
+++ b/ui/ui-frontend/projects/identity/src/app/group/group-preview/profiles-tab/profiles-tab.component.spec.ts
@@ -267,9 +267,7 @@ describe('ProfilesTabComponent', () => {
     expect(elRows.length).toBe(3);
     testhost.group.profiles.forEach((profile: any, index: number) => {
       const elDetails = elRows[index];
-      expect(elDetails.textContent).toContain(
-        profile.tenantName + ' : ' + profile.name.charAt(0).toUpperCase() + profile.name.substr(1).toLowerCase(),
-      );
+      expect(elDetails.textContent).toContain(profile.tenantName + ' : ' + profile.name);
     });
   });
 });


### PR DESCRIPTION
## Description

On n'applique plus `| titlecase` sur les nom de profils dans l'onglet "Profils" pour avoir la même casse que dans la création de profil

## Type de changement

* Correction

## Tests

* manuel

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)