### PR TITLE
CP V7.1 -  Bug #14831 - [Collect] The 'Submit' button remains active after validating a transaction in automatic flow mode with the 'Automatic transaction management' option enabled, until the page is refreshed.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -81,7 +81,7 @@
             <button
               mat-menu-item
               (click)="sendTransaction()"
-              [disabled]="(isNotReady$ | async) || disabledSendTransactions.has(transaction.id)"
+              [disabled]="(isNotReady$ | async)"
             >
               {{ 'COLLECT.INGEST_ACTION' | translate }}
             </button>


### PR DESCRIPTION
CP V7.1 -  Bug #14831 - [Collect] The 'Submit' button remains active after validating a transaction in automatic flow mode with the 'Automatic transaction management' option enabled, until the page is refreshed.