### PR TITLE
V8.0 - Fix #14469: prevent ingest error when filename has special chars

### DIFF
--- a/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/rest/IngestExternalController.java
+++ b/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/rest/IngestExternalController.java
@@ -37,7 +37,6 @@
 package fr.gouv.vitamui.ingest.external.server.rest;
 
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
-import fr.gouv.vitamui.common.security.SafeFileChecker;
 import fr.gouv.vitamui.common.security.SanityChecker;
 import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.ParameterChecker;
@@ -143,19 +142,11 @@ public class IngestExternalController {
     public ResponseEntity<Void> streamingUpload(
         InputStream inputStream,
         @RequestHeader(value = CommonConstants.X_ACTION) final String action,
-        @RequestHeader(value = CommonConstants.X_CONTEXT_ID) final String contextId,
-        @RequestHeader(value = CommonConstants.X_ORIGINAL_FILENAME_HEADER) final String originalFileName
+        @RequestHeader(value = CommonConstants.X_CONTEXT_ID) final String contextId
     ) throws InvalidParseOperationException, PreconditionFailedException {
-        ParameterChecker.checkParameter(
-            "The action and the context ID are mandatory parameters: ",
-            action,
-            contextId,
-            originalFileName
-        );
-        SanityChecker.checkSecureParameter(action, contextId, originalFileName);
-        SanityChecker.isValidFileName(originalFileName);
-        SafeFileChecker.checkSafeFilePath(originalFileName);
-        LOGGER.debug("[Internal] upload file v2: {}", originalFileName);
-        return ingestExternalService.streamingUpload(inputStream, originalFileName, contextId, action);
+        ParameterChecker.checkParameter("The action and the context ID are mandatory parameters: ", action, contextId);
+        SanityChecker.checkSecureParameter(action, contextId);
+        LOGGER.debug("[Internal] upload file v2");
+        return ingestExternalService.streamingUpload(inputStream, contextId, action);
     }
 }

--- a/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/service/IngestExternalService.java
+++ b/api/api-ingest/ingest-external/src/main/java/fr/gouv/vitamui/ingest/external/server/service/IngestExternalService.java
@@ -115,15 +115,9 @@ public class IngestExternalService extends AbstractResourceClientService<Logbook
         return ingestInternalRestClient;
     }
 
-    public ResponseEntity<Void> streamingUpload(
-        InputStream inputStream,
-        final String originalFileName,
-        final String contextId,
-        final String action
-    ) {
+    public ResponseEntity<Void> streamingUpload(InputStream inputStream, final String contextId, final String action) {
         return ingestStreamingInternalRestClient.streamingUpload(
             getInternalHttpContext(),
-            originalFileName,
             inputStream,
             contextId,
             action

--- a/api/api-ingest/ingest-internal-client/src/main/java/fr/gouv/vitamui/ingest/internal/client/IngestStreamingInternalRestClient.java
+++ b/api/api-ingest/ingest-internal-client/src/main/java/fr/gouv/vitamui/ingest/internal/client/IngestStreamingInternalRestClient.java
@@ -92,7 +92,6 @@ public class IngestStreamingInternalRestClient
 
     public ResponseEntity<Void> streamingUpload(
         final InternalHttpContext context,
-        String originalFileName,
         InputStream inputStream,
         final String contextId,
         final String action
@@ -104,7 +103,6 @@ public class IngestStreamingInternalRestClient
         headersList.addAll(buildHeaders(context));
         headersList.add(CommonConstants.X_CONTEXT_ID, contextId);
         headersList.add(CommonConstants.X_ACTION, action);
-        headersList.add(CommonConstants.X_ORIGINAL_FILENAME_HEADER, originalFileName);
 
         HttpHeaders headersParams = new HttpHeaders();
         headersParams.setContentType(MediaType.APPLICATION_OCTET_STREAM);

--- a/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/rest/IngestInternalController.java
+++ b/api/api-ingest/ingest-internal/src/main/java/fr/gouv/vitamui/ingest/internal/server/rest/IngestInternalController.java
@@ -29,7 +29,6 @@ package fr.gouv.vitamui.ingest.internal.server.rest;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.ingest.external.api.exception.IngestExternalException;
-import fr.gouv.vitamui.common.security.SafeFileChecker;
 import fr.gouv.vitamui.common.security.SanityChecker;
 import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.ParameterChecker;
@@ -151,19 +150,11 @@ public class IngestInternalController {
     public ResponseEntity<Void> streamingUpload(
         InputStream inputStream,
         @RequestHeader(value = CommonConstants.X_ACTION) final String action,
-        @RequestHeader(value = CommonConstants.X_CONTEXT_ID) final String contextId,
-        @RequestHeader(value = CommonConstants.X_ORIGINAL_FILENAME_HEADER) final String originalFileName
+        @RequestHeader(value = CommonConstants.X_CONTEXT_ID) final String contextId
     ) throws IngestExternalException, PreconditionFailedException, InvalidParseOperationException {
-        ParameterChecker.checkParameter(
-            "The action and the context ID are mandatory parameters: ",
-            action,
-            contextId,
-            originalFileName
-        );
-        SanityChecker.isValidFileName(originalFileName);
-        SafeFileChecker.checkSafeFilePath(originalFileName);
-        SanityChecker.checkSecureParameter(action, contextId, originalFileName);
-        LOGGER.debug("[Internal] upload file v2: {}", originalFileName);
+        ParameterChecker.checkParameter("The action and the context ID are mandatory parameters: ", action, contextId);
+        SanityChecker.checkSecureParameter(action, contextId);
+        LOGGER.debug("[Internal] upload file v2");
         final String operationId = ingestInternalService.streamingUpload(inputStream, contextId, action);
         if (operationId != null) {
             return ResponseEntity.ok().header(CommonConstants.X_OPERATION_ID_HEADER, operationId).build();


### PR DESCRIPTION
## Description

Le nom de fichier du SIP est transmis de couche en couche... pour rien (si ce n'est des logs).
Or, le nom est "validé" et ne permet pas les caractères spéciaux (genre `é`).
Cette transmission de couche en couche et validation n'existe plus en 8.1 (suite à la suppression des internal/external).
Cette MR supprime la "validation" et la transmission du nom de fichier.

## Type de changement

* Correction

## Tests

*Indiquer comment le code à été testé (manuel, environnement, TU, etc)*

* manuel
* environnement
* TU

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)