### PR TITLE
Fix #14778: fix user update + fix centerCodes (array) + refacto

### DIFF
--- a/ui/ui-frontend/projects/identity/src/app/user/user-create/user-create.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/user/user-create/user-create.component.ts
@@ -216,7 +216,13 @@ export class UserCreateComponent implements OnInit, OnDestroy {
     } else if (this.connectedUserInfo.type === 'LIST') {
       this.groups = this.connectedUserInfo.profilGroup.map((group) => {
         const profilGroup = this.groups.find((g) => g.id === group.id);
-        return Object({ id: group.id, name: group.name, description: group.description, selected: false, profiles: profilGroup?.profiles });
+        return Object({
+          id: group.id,
+          name: group.name,
+          description: group.description,
+          selected: false,
+          profiles: profilGroup?.profiles,
+        });
       });
       this.groups.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
     }
@@ -241,7 +247,10 @@ export class UserCreateComponent implements OnInit, OnDestroy {
     this.userInfoService.create({ id: null, language: this.customer.language }).subscribe(
       (response: UserInfo) => {
         this.form.get('userInfoId').setValue(response.id);
-        this.userService.create(this.form.getRawValue()).subscribe(
+        const formData = this.form.getRawValue();
+        // centerCodes is used for auto-provisioning (Xelians) and should be an array
+        const centerCodes = formData.centerCodes?.split(',')?.map((v: string) => v.trim());
+        this.userService.create({ ...formData, centerCodes }).subscribe(
           () => this.dialogRef.close(true),
           (error) => {
             this.creating = false;

--- a/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-information-tab/user-information-tab.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-information-tab/user-information-tab.component.ts
@@ -150,7 +150,7 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
 
   ngOnInit() {
     this.form.get('mobile').valueChanges.subscribe(() => {
-      this.updateOtpState(this.form, this.adminUserProfile, this.customer);
+      this.updateOtpState(this.form);
     });
     this.form.get('otp').valueChanges.subscribe(() => {
       this.initMobileValidators(this.form);
@@ -161,12 +161,16 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
         debounceTime(UPDATE_DEBOUNCE_TIME),
         map(() => diff(this.form.getRawValue(), this.previousValue)),
         filter((formData) => !isEmpty(formData)),
-        map((formData) => extend({ id: this.user.id }, formData)),
+        map((formData) => {
+          // centerCodes is used for auto-provisioning (Xelians) and should be an array
+          const centerCodes = formData.centerCodes?.split(',')?.map((v: string) => v.trim());
+          return { ...formData, id: this.user.id, centerCodes };
+        }),
         switchMap((formData) => this.userService.patch(formData).pipe(catchError(() => of(null)))),
       )
       .subscribe((user: User) => {
         if (user) {
-          this.resetForm(this.form, user, this.customer, this.adminUserProfile, this.readOnly);
+          this.resetForm(user);
         }
       });
 
@@ -178,15 +182,15 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
         map((formData) => extend({ id: this.userInfo.id }, formData)),
         switchMap((formData) => this.userInfoService.patch(formData, this.user).pipe(catchError(() => of(null)))),
       )
-      .subscribe((userInfo: UserInfo) => this.resetUserInfoForm(this.form, userInfo));
+      .subscribe((userInfo: UserInfo) => this.resetUserInfoForm(userInfo));
 
     this.countryService.getAvailableCountries().subscribe((values: CountryOption[]) => {
       this.countries = values.map((country) => ({ key: country.code, label: country.name }));
     });
   }
 
-  private updateOtpState(form: FormGroup, adminUserProfile: AdminUserProfile, customer: Customer): void {
-    if (this.canModifyOtp(adminUserProfile, customer)) {
+  private updateOtpState(form: FormGroup): void {
+    if (this.canModifyOtp()) {
       if (form.get('mobile') && (!form.get('mobile').value || form.get('mobile').value === '')) {
         this.showTooltip = true;
         form.get('otp').disable({ emitEvent: false });
@@ -197,8 +201,8 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
     }
   }
 
-  private canModifyOtp(adminUserProfile: AdminUserProfile, customer: Customer) {
-    return adminUserProfile || !adminUserProfile.multifactorAllowed || (customer && customer.otp !== OtpState.OPTIONAL);
+  private canModifyOtp() {
+    return this.adminUserProfile || !this.adminUserProfile.multifactorAllowed || (this.customer && this.customer.otp !== OtpState.OPTIONAL);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -209,26 +213,26 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
       changes.hasOwnProperty('adminUserProfile')
     ) {
       if (this.user && this.customer && this.adminUserProfile) {
-        this.resetForm(this.form, this.user, this.customer, this.adminUserProfile, this.readOnly);
+        this.resetForm(this.user);
       }
     }
     if (changes.hasOwnProperty('userInfo') && this.userInfo) {
-      this.resetUserInfoForm(this.userInfoForm, this.userInfo);
+      this.resetUserInfoForm(this.userInfo);
     }
   }
 
-  private resetForm(form: FormGroup, user: User, customer: Customer, adminUserProfile: AdminUserProfile, readOnly: boolean) {
-    form.reset(user, { emitEvent: false });
-    this.previousValue = this.form.value;
-    this.initFormValidators(form, user);
-    this.initFormActivationState(form, customer, adminUserProfile, readOnly);
-    form.updateValueAndValidity({ emitEvent: false });
+  private resetForm(user: User) {
+    this.form.reset(user, { emitEvent: false });
+    this.previousValue = this.form.getRawValue();
+    this.initFormValidators(this.form, user);
+    this.initFormActivationState(this.form);
+    this.form.updateValueAndValidity({ emitEvent: false });
   }
-  private resetUserInfoForm(userInfoForm: FormGroup, userInfo: UserInfo) {
+  private resetUserInfoForm(userInfo: UserInfo) {
     if (userInfo) {
-      userInfoForm.reset(userInfo, { emitEvent: false });
-      this.previousUserInfoValue = this.userInfoForm.value;
-      userInfoForm.updateValueAndValidity({ emitEvent: false });
+      this.userInfoForm.reset(userInfo, { emitEvent: false });
+      this.previousUserInfoValue = this.userInfoForm.getRawValue();
+      this.userInfoForm.updateValueAndValidity({ emitEvent: false });
     }
   }
 
@@ -245,11 +249,11 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
     form.get('mobile').setValidators(mobileValidators);
   }
 
-  private initFormActivationState(form: FormGroup, customer: Customer, adminUserProfile: AdminUserProfile, readOnly: boolean) {
+  private initFormActivationState(form: FormGroup) {
     // get customer email domains
     this.customerEmailDomains = [];
-    customer.emailDomains.forEach((domain) => this.customerEmailDomains.push(domain.replace('*.', '')));
-    if (readOnly || !adminUserProfile.standardAttrsAllowed) {
+    this.customer.emailDomains.forEach((domain) => this.customerEmailDomains.push(domain.replace('*.', '')));
+    if (this.readOnly || !this.adminUserProfile.standardAttrsAllowed) {
       form.disable({ emitEvent: false });
 
       return;
@@ -259,10 +263,10 @@ export class UserInfoTabComponent implements OnChanges, OnInit {
 
     form.get('identifier').disable({ emitEvent: false });
     form.get('level').disable({ emitEvent: false });
-    if (!adminUserProfile.genericAllowed) {
+    if (!this.adminUserProfile.genericAllowed) {
       form.get('type').disable({ emitEvent: false });
     }
 
-    this.updateOtpState(form, adminUserProfile, customer);
+    this.updateOtpState(form);
   }
 }


### PR DESCRIPTION
## Description

La modification d'un utilisateur était systématiquement en erreur car le `diff`, et donc le patch, renvoyait systématiquement l'`identifier` et le `level` qui sont des champs disabled.

Aussi, centerCodes était mal géré car l'API attends une liste de string alors qu'Angular gérait une string.

## Type de changement

* Correction
* Refactorisation de code

## Tests

* manuel

## Checklist

*Sélectionner les éléments de la checklist*

* [ ] Mon code suit le style de code de ce projet.
* [ ] J'ai commenté mon code, en particulier dans les classes et les méthodes difficile à comprendre.
* [ ] J'ai fait les changements correspondant dans la documentation RAML.
* [ ] J'ai fait les changements correspondant dans la documentation Métier.
* [ ] J'ai fait les changements correspondant dans la documentation Technique.
* [ ] J'ai rajouté les tests unitaires vérifiant mes fonctionnalités.
* [ ] J'ai rajouté les tests de non régression vérifiant mes fonctionnalités.
* [ ] Les tests unitaires nouveaux et existants passent avec succès localement.
* [ ] Toutes les dépendances ont été mergées en priorité

## Contributeur

* VAS (Vitam Accessible en Service)