### PR TITLE
Bugs #14552: fix link to report download for securisation audit

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-download.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-download.service.ts
@@ -115,7 +115,7 @@ export class LogbookDownloadService extends SearchService<IEvent> {
         if (eventType === 'EXPORT_PROBATIVE_VALUE' || eventType === 'RECTIFICATION_AUDIT') {
           return DOWNLOAD_TYPE_REPORT;
         }
-        if (eventType === 'EVIDENCE_AUDIT' || eventType === 'PROCESS_AUDIT') {
+        if (eventType === 'EVIDENCE_AUDIT' || eventType === 'PROCESS_AUDIT' || eventType === 'LINKED_CHECK_SECURISATION') {
           return DOWNLOAD_TYPE_BATCH_REPORT;
         }
       // eslint-disable-next-line no-fallthrough


### PR DESCRIPTION
Correction du lien vers le téléchargement du rapport. Le cas n'était pas géré et on tombait donc par défaut sur le téléchargement d'un rapport de type "report" au lieu de "batchreport".