### PR TITLE
CP V8.1 - Bug #14948: Fixed editing errors in archive unit metadata with repeatable entries.

### DIFF
--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/exception/ArchiveUnitUpdateException.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/exception/ArchiveUnitUpdateException.java
@@ -41,4 +41,8 @@ public class ArchiveUnitUpdateException extends RuntimeException {
     public ArchiveUnitUpdateException(String message) {
         super(message);
     }
+
+    public ArchiveUnitUpdateException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ArchiveUnitServiceImpl.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ArchiveUnitServiceImpl.java
@@ -85,7 +85,10 @@ public class ArchiveUnitServiceImpl implements ArchiveUnitService {
     public OperationIdDto update(String transactionId, JsonPatchDto jsonPatchDto) {
         final UpdateMultiQuery updateMultiQuery = jsonPatchDtoToUpdateMultiQueryConverter.convert(jsonPatchDto);
         if (updateMultiQuery == null) {
-            throw new ArchiveUnitUpdateException("Fail to convert json patch payload to dsl query");
+            log.error("Failed to convert JSON patch to DSL query for archive unit: {}", jsonPatchDto.getId());
+            throw new ArchiveUnitUpdateException(
+                "Failed to convert JSON patch payload to DSL query. The patch may contain invalid field paths or operations."
+            );
         }
 
         final Set<UpdateMultiQuery> updateMultiQueries = Set.of(updateMultiQuery);
@@ -119,8 +122,8 @@ public class ArchiveUnitServiceImpl implements ArchiveUnitService {
             log.info("Operation started: {}", operationIdDto);
             return operationIdDto;
         } catch (VitamClientException | InvalidParseOperationException e) {
-            log.error("{}", e);
-            throw new ArchiveUnitUpdateException(e);
+            log.error("Failed to update archive units for transaction: {}", transactionId, e);
+            throw new ArchiveUnitUpdateException("Failed to update archive units", e);
         }
     }
 }

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/converter/JsonPatchToSetActionConverter.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/converter/JsonPatchToSetActionConverter.java
@@ -34,6 +34,7 @@ import fr.gouv.vitam.common.database.builder.request.exception.InvalidCreateOper
 import fr.gouv.vitamui.commons.api.dtos.JsonPatch;
 import fr.gouv.vitamui.commons.api.dtos.PatchCommand;
 import fr.gouv.vitamui.commons.api.exception.DslQueryCreateException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
@@ -56,13 +57,20 @@ public class JsonPatchToSetActionConverter implements Converter<JsonPatch, SetAc
         final Map<String, JsonNode> map = source
             .stream()
             .filter(patchCommand -> List.of(ADD, REPLACE).contains(patchCommand.getOp()))
-            .collect(Collectors.toMap(PatchCommand::getPath, PatchCommand::getValue));
+            .filter(patchCommand -> StringUtils.isNotBlank(patchCommand.getPath()))
+            .filter(patchCommand -> patchCommand.getValue() != null)
+            .collect(
+                Collectors.toMap(PatchCommand::getPath, PatchCommand::getValue, (existing, replacement) -> {
+                    log.warn("Duplicate path found in JSON patch: {}. Using replacement value.", existing);
+                    return replacement;
+                })
+            );
         if (!map.isEmpty()) {
             try {
                 return UpdateActionHelper.set(map);
             } catch (InvalidCreateOperationException e) {
-                log.error("{}", e);
-                throw new DslQueryCreateException(e);
+                log.error("Failed to create set action for paths: {}", map.keySet(), e);
+                throw new DslQueryCreateException("Invalid field paths for set operation: " + e.getMessage());
             }
         }
         return null;

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/converter/JsonPatchToUnsetActionConverter.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/converter/JsonPatchToUnsetActionConverter.java
@@ -34,6 +34,7 @@ import fr.gouv.vitamui.commons.api.dtos.JsonPatch;
 import fr.gouv.vitamui.commons.api.dtos.PatchCommand;
 import fr.gouv.vitamui.commons.api.dtos.PatchOperation;
 import fr.gouv.vitamui.commons.api.exception.DslQueryCreateException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
@@ -46,18 +47,20 @@ public class JsonPatchToUnsetActionConverter implements Converter<JsonPatch, Uns
 
     @Override
     public UnsetAction convert(JsonPatch source) {
-        try {
-            final String[] paths = source
-                .stream()
-                .filter(patchCommand -> patchCommand.getOp() == PatchOperation.REMOVE)
-                .map(PatchCommand::getPath)
-                .toArray(String[]::new);
-            if (paths.length > 0) {
+        final String[] paths = source
+            .stream()
+            .filter(patchCommand -> patchCommand.getOp() == PatchOperation.REMOVE)
+            .map(PatchCommand::getPath)
+            .filter(StringUtils::isNotBlank)
+            .toArray(String[]::new);
+
+        if (paths.length > 0) {
+            try {
                 return UpdateActionHelper.unset(paths);
+            } catch (InvalidCreateOperationException e) {
+                log.error("Failed to create unset action for paths: {}", paths, e);
+                throw new DslQueryCreateException("Invalid field paths for unset operation: " + e.getMessage());
             }
-        } catch (InvalidCreateOperationException e) {
-            log.error("{}", e);
-            throw new DslQueryCreateException(e);
         }
         return null;
     }


### PR DESCRIPTION
## Description

> Cherry-Picked from #2938 

* Fix NullPointerException in JsonPatchToSetActionConverter when processing null/empty paths
* Add null path validation in JsonPatchToUnsetActionConverter for REMOVE operations
* Improve error handling and logging in ArchiveUnitServiceImpl
* Add constructor to ArchiveUnitUpdateException for better error context

The issue affected all metadata editing operations (tags, collectors map fields, custom fields) that use multi-selector inputs. The root cause was Collectors.toMap() throwing NullPointerException when JSON patch operations contained null or empty paths.

## Type de changement

* Correction

## Contributeur

* Programme Vitam