### PR TITLE
Bugs #14835: ontology id is not part of the form

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-information-tab/ontology-information-tab.component.ts
@@ -142,7 +142,7 @@ export class OntologyInformationTabComponent {
 
   prepareSubmit(): Observable<Ontology> {
     const payload = {
-      id: this.previousValue().id,
+      id: this._inputOntology.id,
       identifier: this.previousValue().identifier,
       ...this.form.value,
     };


### PR DESCRIPTION
## Description

Correction du bug **bloquant** 14835. Lors de la modification d'une ontologie, le composant envoie `undefined` à la place de l'identifiant de l'ontologie lors du PATCH, car le code considère à tort que le champ `id` fait partie du formulaire.

## Type de changement

* Correction
