### PR TITLE
Bugs #14836: stop event propagation so that the confirmation can open

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-group/schema-list/schema-list.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-group/schema-list/schema-list.component.html
@@ -59,7 +59,7 @@
         <button
           *ngIf="canDelete(data.item)"
           class="btn btn-circle primary"
-          (click)="delete(data)"
+          (click)="$event.stopPropagation(); delete(data)"
           (mouseover)="previewDelete(data.item)"
           (mouseout)="hidePreviewDelete()"
         >


### PR DESCRIPTION
## Description

Arrêt de la propagation du clic pour que la popup ait le temps de s'afficher. Dans le cas contraire, le clic est propagé à la ligne du tableau et permet de charger le détail de l'élément de schéma.

## Type de changement

* Correction
