### PR TITLE
CP V7.1 - Bug #14420 [Collect & App Search] Saved filters are displayed as keys instead of being translated. 

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -776,7 +776,9 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
           this.addCriteria(
             c,
             value,
-            value.value,
+            c === ALL_ARCHIVE_UNIT_TYPES
+              ? this.translateService.instant('COLLECT.SEARCH_CRITERIA_FILTER.FIELDS.UNIT_TYPE.' + value.id)
+              : value.value,
             criteria.keyTranslated,
             criteria.operator,
             SearchCriteriaTypeEnum.FIELDS,

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -918,7 +918,9 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
             this.nbQueryCriteria,
             c,
             value,
-            value.value,
+            c === ALL_ARCHIVE_UNIT_TYPES
+              ? this.translateService.instant('COLLECT.SEARCH_CRITERIA_FILTER.FIELDS.UNIT_TYPE.' + value.id)
+              : value.value,
             criteria.keyTranslated,
             criteria.operator,
             SearchCriteriaTypeEnum.FIELDS,


### PR DESCRIPTION
CP V7.1 - Bug #14420 [Collect & App Search] Saved filters are displayed as keys instead of being translated. 