### PR TITLE
Bug #14669 - [PASTIS] The "Allow metadata" toggle is not saved when creating/updating a PUA.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/user-actions/create-notice/create-notice.component.html
+++ b/ui/ui-frontend/projects/pastis/src/app/user-actions/create-notice/create-notice.component.html
@@ -51,7 +51,7 @@
   <div *ngIf="modePUA" class="row">
     <div class="col-10 form-control">
       <div class="d-flex justify-content-between align-items-center py-1 px-2 mb-2">
-        <vitamui-common-slide-toggle [formControl]="additionalProperties">
+        <vitamui-common-slide-toggle formControlName="additionalProperties">
           {{ 'PROFILE.POP_UP_CREATION_NOTICE.AUTORISER_PRESENCE_METADONNEES' | translate }}
         </vitamui-common-slide-toggle>
         <div>


### PR DESCRIPTION
Specific fix for 7.1