### PR TITLE
Bugs #14972: remove sort button on id

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/securisation/securisation-list/securisation-list.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/securisation/securisation-list/securisation-list.component.html
@@ -3,12 +3,6 @@
     <div class="col-1"><i class="vitamui-icon vitamui-icon-operation"></i></div>
     <div class="col-2 d-flex align-items-center justify-content-between">
       {{ 'SECURE.HOME.ARRAY.IDENTIFIER' | translate }}
-      <vitamui-order-by-button
-        orderByKey="#id"
-        [(orderBy)]="orderBy"
-        [(direction)]="direction"
-        (orderChange)="emitOrderChange()"
-      ></vitamui-order-by-button>
     </div>
     <div class="col-3 d-flex align-items-center justify-content-between">
       {{ 'SECURE.HOME.ARRAY.CATEGORY' | translate }}


### PR DESCRIPTION
Le bouton de tri sur l'id ne fonctionne pas, mais cela n'a de toute façon aucun sens de trier sur l'id d'opération. On enlève le bouton de tri.