### PR TITLE
Bug #15032 : Confirmation popup unexpected opening

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/click-outside/click-outside.directive.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/click-outside/click-outside.directive.ts
@@ -59,7 +59,8 @@ export class ClickOutsideDirective {
       target.closest('.cdk-overlay-container') ||
       target.closest('.mat-datepicker-content') ||
       target.closest('.mat-select-panel') ||
-      target.closest('.mat-dialog-container')
+      target.closest('.mat-dialog-container') ||
+      target.closest('.mat-mdc-tab-body-content')
     ) {
       return; // Ignore the click if it’s a MatMenu, MatDatepicker, etc.
     }


### PR DESCRIPTION
## Description

Sur Collecte (et Archive-Search), en mode Modification, lors d'un clic sur la barre de scroll (et par extension sur toute la zone autour du contenu de l'onglet), si des modifications sont présentes, la popin de confirmation s'ouvre, comportement qui n'est pas attendu.