### PR TITLE
bug #14918 : Rules update

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/add-management-rules/add-management-rules.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/add-management-rules/add-management-rules.component.ts
@@ -309,6 +309,9 @@ export class AddManagementRulesComponent implements OnDestroy, OnInit {
   onDelete() {
     const dialogToOpen = this.confirmDeleteAddRuleDialog;
     const dialogRef = this.dialog.open(dialogToOpen);
+    this.managementRulesSharedDataService.emitIsRuleDuplicated(
+      !!(this.ruleDetailsForm.get('rule').errors && this.ruleDetailsForm.get('rule').errors.uniqueRuleId),
+    );
 
     this.showConfirmDeleteAddRuleSuscription = dialogRef
       .afterClosed()

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/archive-unit-rules.component.spec.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/archive-unit-rules.component.spec.ts
@@ -188,6 +188,8 @@ describe('ArchiveUnitRulesComponent', () => {
     getRuleActions: () => of(ruleActions),
     emitManagementRules: () => of({}),
     emitRuleActions: () => of({}),
+    emitIsRuleDuplicated: () => of({}),
+    getIsRuleDuplicated: () => of(false),
   };
 
   const updateUnitManagementRuleServiceMock = {

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/archive-unit-rules.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/archive-unit-rules.component.ts
@@ -38,7 +38,7 @@ import { animate, AUTO_STYLE, state, style, transition, trigger } from '@angular
 import { Component, Input, OnDestroy } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { ManagementRulesSharedDataService } from '../../../../../core/management-rules-shared-data.service';
-import { ActionsRules, ManagementRules, RuleActionsEnum, RuleCategoryAction } from '../../../../models/ruleAction.interface';
+import { ActionsRules, ManagementRules, RuleAction, RuleActionsEnum, RuleCategoryAction } from '../../../../models/ruleAction.interface';
 import { Rule } from 'vitamui-library';
 
 @Component({
@@ -72,6 +72,7 @@ export class ArchiveUnitRulesComponent implements OnDestroy {
 
   managementRulesSubscription: Subscription;
   ruleActionsSubscription: Subscription;
+  isRuleDuplicatedSubscription: Subscription;
 
   collapsed = false;
   updateRuleCollapsed = false;
@@ -82,12 +83,14 @@ export class ArchiveUnitRulesComponent implements OnDestroy {
   unlockCategoryInheritanceCollapsed = false;
   blockRuleInheritanceCollapsed = false;
   unlockRuleInheritanceCollapsed = false;
+  isRuleDuplicated = false;
 
   constructor(private managementRulesSharedDataService: ManagementRulesSharedDataService) {}
 
   ngOnDestroy() {
     this.ruleActionsSubscription?.unsubscribe();
     this.managementRulesSubscription?.unsubscribe();
+    this.isRuleDuplicatedSubscription?.unsubscribe();
   }
 
   confirmStep(id: number) {
@@ -150,6 +153,10 @@ export class ArchiveUnitRulesComponent implements OnDestroy {
       this.managementRules = data;
     });
 
+    this.isRuleDuplicatedSubscription = this.managementRulesSharedDataService.getIsRuleDuplicated().subscribe((isDuplicated) => {
+      this.isRuleDuplicated = isDuplicated;
+    });
+
     if (this.managementRules.findIndex((managementRule) => managementRule.category === this.ruleCategory) !== -1) {
       if (actionType === RuleActionsEnum.BLOCK_RULE_INHERITANCE) {
         this.ruleCategoryDuaActions = this.managementRules.find(
@@ -180,7 +187,7 @@ export class ArchiveUnitRulesComponent implements OnDestroy {
           this.ruleCategoryDuaActions.rules?.filter((rule) => rule.rule !== ruleId).length === 0
         ) {
           this.ruleCategoryDuaActions = {
-            rules: [],
+            rules: this.isRuleDuplicated ? this.ruleCategoryDuaActions.rules : [],
             finalAction: this.ruleCategoryDuaActions.finalAction,
             preventRulesIdToAdd: this.ruleCategoryDuaActions.preventRulesIdToAdd,
           };
@@ -193,11 +200,18 @@ export class ArchiveUnitRulesComponent implements OnDestroy {
             finalAction: this.ruleCategoryDuaActions.finalAction,
           };
         } else {
+          let ruleActions: RuleAction[];
+          if (actionType === RuleActionsEnum.UPDATE_RULES) {
+            ruleActions = this.ruleCategoryDuaActions.rules.filter((rule) => rule.oldRule !== ruleId);
+          } else {
+            if (this.isRuleDuplicated) {
+              ruleActions = this.ruleCategoryDuaActions.rules;
+            } else {
+              ruleActions = this.ruleCategoryDuaActions.rules.filter((rule) => rule.rule !== ruleId);
+            }
+          }
           this.ruleCategoryDuaActions = {
-            rules:
-              actionType === RuleActionsEnum.UPDATE_RULES
-                ? this.ruleCategoryDuaActions.rules.filter((rule) => rule.oldRule !== ruleId)
-                : this.ruleCategoryDuaActions.rules.filter((rule) => rule.rule !== ruleId),
+            rules: ruleActions,
             finalAction: this.ruleCategoryDuaActions.finalAction,
           };
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/core/management-rules-shared-data.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/core/management-rules-shared-data.service.ts
@@ -53,6 +53,7 @@ export class ManagementRulesSharedDataService {
 
   private managementRules = new BehaviorSubject<ManagementRules[]>([]);
   private hasExactCount = new BehaviorSubject<boolean>(false);
+  private isRuleDuplicated = new BehaviorSubject<boolean>(false);
 
   selectedItem = this.selectedItems.asObservable();
   allCriteriaSearchListToSave = this.criteriaSearchListToSave.asObservable();
@@ -135,5 +136,13 @@ export class ManagementRulesSharedDataService {
 
   getHasExactCount(): Observable<boolean> {
     return this.hasExactCount.asObservable();
+  }
+
+  emitIsRuleDuplicated(isRuleDuplicated: boolean) {
+    this.isRuleDuplicated.next(isRuleDuplicated);
+  }
+
+  getIsRuleDuplicated(): Observable<boolean> {
+    return this.isRuleDuplicated.asObservable();
   }
 }


### PR DESCRIPTION
## Description

Lors de la mise à jour des règles, sélectionner deux fois la même règle puis annuler la seconde ne rend pas effective la sauvegarde. Le fait d'annuler la seconde règle dans ce cas de figure annule également la première et par conséquent n'enregistre pas la règle.

Pour corriger, ajout d'une variable afin de vérifier si une règle en erreur est remontée
