### PR TITLE
CP 8.1 -  Bug #15035 [Referentials] - 500 error when exporting an empty list in the "Management Rules" and "Agent Services" applications.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/agency/agency.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency.component.html
@@ -28,7 +28,7 @@
           <button mat-menu-item [disabled]="!hasImportRole" (click)="openAgencyImportDialog()">
             {{ 'AGENCY.HOME.ACTION_IMPORT' | translate }}
           </button>
-          <button mat-menu-item [disabled]="!hasExportRole" (click)="exportAgencies()">
+          <button mat-menu-item [disabled]="!agencyList?.dataSource?.length || !hasExportRole" (click)="exportAgencies()">
             {{ 'AGENCY.HOME.ACTION_EXPORT' | translate }}
           </button>
         </vitamui-common-menu-button>
@@ -36,7 +36,7 @@
     </div>
 
     <div class="vitamui-content">
-      <app-agency-list (agencyClick)="showAgency($event)" [search]="search"></app-agency-list>
+      <app-agency-list #agencyList (agencyClick)="showAgency($event)" [search]="search"></app-agency-list>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule.component.html
@@ -23,7 +23,7 @@
           <button mat-menu-item [disabled]="(checkImportRole | async) !== true" (click)="openRuleImportDialog()">
             {{ 'RULES_APP.HOME.IMPORT' | translate }}
           </button>
-          <button mat-menu-item [disabled]="(checkExportRole | async) !== true" (click)="exportRules()">
+          <button mat-menu-item [disabled]="!ruleList?.dataSource?.length || (checkExportRole | async) !== true" (click)="exportRules()">
             {{ 'RULES_APP.HOME.EXPORT' | translate }}
           </button>
         </vitamui-common-menu-button>
@@ -31,7 +31,7 @@
     </div>
 
     <div class="vitamui-content">
-      <app-rule-list (ruleClick)="showRule($event)" [search]="search"></app-rule-list>
+      <app-rule-list #ruleList (ruleClick)="showRule($event)" [search]="search"></app-rule-list>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>


### PR DESCRIPTION
CP 8.1 -  Bug #15035 [Referentials] - 500 error when exporting an empty list in the "Management Rules" and "Agent Services" applications.

> Cherry-Picked from #3025