### PR TITLE
CP V8.1 Bug #14832 [Collection] The confirmation pop-up for updating submissions is not displayed when exiting the side panel without saving.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/project-preview/project-preview.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/project-preview/project-preview.component.ts
@@ -362,7 +362,7 @@ export class ProjectPreviewComponent implements OnInit, AfterViewInit, OnDestroy
       .subscribe((result) => {
         if (result) {
           this.selectedValue = 'NO';
-          this.onConfirm();
+          this.launchUpdate();
         } else {
           this.onCancel();
         }


### PR DESCRIPTION
[Collecte] La pop-up de confirmation de mise à jour des versements n’est pas affichée lors de la sortie sans enregistrement du panneau latéral de modification d’un projet de versement automatique.