### PR TITLE
Bug #14851 [Collect] The "Edit" and "Cancel" buttons remain active after validating a transaction in automatic flow.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
@@ -36,12 +36,14 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, interval, of, takeWhile } from 'rxjs';
 import { Direction, InfiniteScrollTable, StartupService, Transaction, TransactionStatus } from 'vitamui-library';
 import { TransactionsService } from '../transactions.service';
 import { ArchiveCollectService } from '../../archive-search-collect/archive-collect.service';
+import { ProjectsService } from '../../projects/projects.service';
+import { catchError, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-transaction-list',
@@ -59,14 +61,16 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
   hasSendTransactionRole = false;
   hasCloseTransactionRole = false;
   hasDownloadTransactionRole = false;
+  isAutomaticIngest = false;
   disabledSendTransactions = new Set<string>();
 
   constructor(
     private snackBar: MatSnackBar,
     private transactionService: TransactionsService,
-    private archiveUnitCollectService: ArchiveCollectService,
     private archiveCollectService: ArchiveCollectService,
     private translateService: TranslateService,
+    private projectService: ProjectsService,
+    private route: ActivatedRoute,
     private router: Router,
     private startupService: StartupService,
   ) {
@@ -77,6 +81,12 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
     this.tenantIdentifier = this.startupService.getTenantIdentifier();
     this.checkTransactionsPermissions();
     super.search(null);
+    this.route.params.subscribe((params) => {
+      const projectId = params['projectId'];
+      this.projectService.getProjectById(projectId).subscribe((project) => {
+        this.isAutomaticIngest = project?.automaticIngest;
+      });
+    });
   }
 
   onScroll() {
@@ -110,9 +120,24 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
     this.transactionService.validateTransaction(transaction.id).subscribe(
       () => {
         transaction.status = TransactionStatus.READY;
-        this.archiveUnitCollectService.getProjectById(transaction.projectId).subscribe((project) => {
-          if (project.automaticIngest) this.disabledSendTransactions.add(transaction.id);
-        });
+        if (this.isAutomaticIngest) {
+          this.disabledSendTransactions.add(transaction.id);
+          // Lancer un polling pour suivre le statut
+          interval(5000)
+            .pipe(
+              switchMap(() => this.transactionService.getTransactionById(transaction.id).pipe(catchError(() => of(null)))),
+              takeWhile(
+                (updatedTransaction: Transaction | null) =>
+                  updatedTransaction != null && updatedTransaction.status !== TransactionStatus.SENDING,
+                true,
+              ),
+            )
+            .subscribe((updatedTransaction: Transaction | null) => {
+              if (updatedTransaction) {
+                transaction.status = updatedTransaction.status;
+              }
+            });
+        }
         const message = this.translateService.instant('COLLECT.VALIDATE_TRANSACTION_VALIDATED');
         this.snackBar.open(message, null, {
           duration: 10000,
@@ -171,35 +196,37 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
   }
 
   transactionIsEditable(transaction: Transaction): boolean {
-    return (
-      [TransactionStatus.READY, TransactionStatus.VALIDATED, TransactionStatus.ACK_KO, TransactionStatus.KO].indexOf(transaction.status) !==
-      -1
+    if (this.isAutomaticIngest && [TransactionStatus.READY, TransactionStatus.VALIDATED].includes(transaction.status)) {
+      return false;
+    }
+
+    return [TransactionStatus.READY, TransactionStatus.VALIDATED, TransactionStatus.ACK_KO, TransactionStatus.KO].includes(
+      transaction.status,
     );
   }
 
   transactionIsAbortable(transaction: Transaction): boolean {
-    return (
-      [
-        TransactionStatus.OPEN,
-        TransactionStatus.READY,
-        TransactionStatus.VALIDATED,
-        TransactionStatus.ACK_KO,
-        TransactionStatus.KO,
-      ].indexOf(transaction.status) !== -1
-    );
+    if (this.isAutomaticIngest && [TransactionStatus.READY, TransactionStatus.VALIDATED].includes(transaction.status)) {
+      return false;
+    }
+    return [
+      TransactionStatus.OPEN,
+      TransactionStatus.READY,
+      TransactionStatus.VALIDATED,
+      TransactionStatus.ACK_KO,
+      TransactionStatus.KO,
+    ].includes(transaction.status);
   }
 
   transactionIsDownloadable(transaction: Transaction): boolean {
-    return (
-      [
-        TransactionStatus.READY,
-        TransactionStatus.VALIDATED,
-        TransactionStatus.SENDING,
-        TransactionStatus.SENT,
-        TransactionStatus.ACK_KO,
-        TransactionStatus.KO,
-      ].indexOf(transaction.status) !== -1
-    );
+    return [
+      TransactionStatus.READY,
+      TransactionStatus.VALIDATED,
+      TransactionStatus.SENDING,
+      TransactionStatus.SENT,
+      TransactionStatus.ACK_KO,
+      TransactionStatus.KO,
+    ].includes(transaction.status);
   }
 
   transactionIsDownloadDisabled(transaction: Transaction): boolean {


### PR DESCRIPTION
Lorsque le projet est en flux automatique et que l’option de gestion automatique des transactions est activée, je mets en place un contrôle régulier du statut de la transaction ( tous les 5 seconds ) jusqu’à ce qu’elle passe au statut SENDING.
Cela me permet de mettre à jour son statut de manière visible sans recharger la page, et ainsi de bloquer l’édition et l’annulation dans ce cas précis.