### PR TITLE
bug #14923 : Ingest contract creation - identifier mandatory

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
@@ -234,14 +234,18 @@ export class IngestContractCreateComponent implements OnInit, OnDestroy {
   }
 
   firstStepInvalid(): boolean {
-    return (
+    const invalid =
       this.form.get('name').invalid ||
       this.form.get('name').pending ||
       this.form.get('description').invalid ||
       this.form.get('description').pending ||
       this.form.get('status').invalid ||
-      this.form.get('status').pending
-    );
+      this.form.get('status').pending;
+    if (this.isSlaveMode) {
+      return invalid || this.form.get('identifier').invalid || this.form.get('identifier').pending;
+    } else {
+      return invalid;
+    }
   }
 
   thirdStepInvalid(): boolean {


### PR DESCRIPTION
## Description

A l'étape 1 de la création d'un contrat d'entrée, on peut passer à l'étape suivante sans renseigner l'identifiant, alors qu'il est obligatoire

EDIT : Rajout d'une condition de vérification du tenant, le champ `Identifiant` ne s'affichant que pour le tenant 1
