### PR TITLE
Bugs #14906: missing placeholders and translations

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-authorizations-tab/access-contract-authorizations-update/access-contract-authorizations-update.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-authorizations-tab/access-contract-authorizations-update/access-contract-authorizations-update.component.html
@@ -42,6 +42,7 @@
             formControlName="ruleCategoryToFilter"
             [options]="ruleTypesOptions"
             [placeholder]="'ACCESS_CONTRACT.CREATE_DIALOG.AUTHORISATION_PERIMETER.SELECT_RULES' | translate"
+            [searchBarPlaceHolder]="'ACCESS_CONTRACT.CREATE_DIALOG.AUTHORISATION_PERIMETER.SELECT_RULES' | translate"
             [required]="true"
             required
           >
@@ -74,6 +75,7 @@
               formControlName="ruleCategoryToFilterForTheOtherOriginatingAgencies"
               [options]="ruleTypesOptions"
               [placeholder]="'ACCESS_CONTRACT.CREATE_DIALOG.AUTHORISATION_PERIMETER.SELECT_RULES' | translate"
+              [searchBarPlaceHolder]="'ACCESS_CONTRACT.CREATE_DIALOG.AUTHORISATION_PERIMETER.SELECT_RULES' | translate"
               [required]="true"
               required
             >
@@ -101,6 +103,7 @@
               formControlName="ruleCategoryToFilter"
               [options]="ruleTypesOptions"
               [placeholder]="'ACCESS_CONTRACT.CREATE_DIALOG.AUTHORISATION_PERIMETER.SELECT_RULES' | translate"
+              [searchBarPlaceHolder]="'ACCESS_CONTRACT.CREATE_DIALOG.AUTHORISATION_PERIMETER.SELECT_RULES' | translate"
               [required]="true"
               required
             >

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
@@ -5083,7 +5083,8 @@
       "ALL_POSITIONS_TOOLTIP": "Choice of the positions to which one wishes to give access in consultation",
       "NAME_ALREADY_EXISTS": "Name already in use",
       "IDENTIFIER_ALREADY_EXISTS": "Identifier already in use",
-      "SELECT_AGENCY_SEARCH": "Type producer service ID or name"
+      "SELECT_AGENCY_SEARCH": "Type producer service ID or name",
+      "SELECT_PRODUCERS": "Select producer services"
     },
     "UPDATE_NODE_DIALOG": {
       "TITLE": "Change of consultation positions",

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
@@ -5083,7 +5083,8 @@
       "ALL_POSITIONS_TOOLTIP": "Choix des positions auxquelles on souhaite donner accès en consultation",
       "NAME_ALREADY_EXISTS": "Nom déjà utilisé",
       "IDENTIFIER_ALREADY_EXISTS": "Identifiant déjà utilisé",
-      "SELECT_AGENCY_SEARCH": "Taper l'ID ou le nom de service producteur"
+      "SELECT_AGENCY_SEARCH": "Taper l'ID ou le nom de service producteur",
+      "SELECT_PRODUCERS": "Sélectionner les services producteurs"
     },
     "UPDATE_NODE_DIALOG": {
       "TITLE": "Modification des positions de consultation",


### PR DESCRIPTION
Placeholders manquants (searchBarPlaceHolder), permet d'éviter d'afficher "undefined".
Traductions manquantes.

Doit également être backporté jusqu'en 8.0