### PR TITLE
Bug #15056 && #14490 - [Collect] Empty attachment position label for non-tree unit in non-connected project. And fix(filing-holding-scheme): internal and external attachment handling.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/filing-holding-scheme/filing-holding-scheme.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/filing-holding-scheme/filing-holding-scheme.component.ts
@@ -206,24 +206,36 @@ export class FilingHoldingSchemeComponent implements OnInit, OnDestroy {
     if (isEmpty(this.fullNodes) || isEmpty(this.attachmentUnits)) {
       return;
     }
-    this.attachmentNodes = [];
-    for (const unit of this.attachmentUnits) {
-      const key = unit['#management'].UpdateOperation.ArchiveUnitIdentifierKey?.MetadataName;
-      const value = key
-        ? unit['#management'].UpdateOperation.ArchiveUnitIdentifierKey?.MetadataValue
-        : unit['#management'].UpdateOperation.SystemId;
-      const treeNode = FilingHoldingSchemeHandler.foundNode(this.fullNodes, value, key);
+
+    this.attachmentNodes = this.attachmentUnits.map((unit: Unit) => {
+      const { UpdateOperation } = unit['#management'];
+      const key = UpdateOperation.ArchiveUnitIdentifierKey?.MetadataName || 'id';
+      const value = UpdateOperation.ArchiveUnitIdentifierKey?.MetadataValue || UpdateOperation.SystemId;
+      const inCollectAttachment: FilingHoldingSchemeNode = FilingHoldingSchemeHandler.foundNode(this.fullNodes, value, key);
       const node = FilingHoldingSchemeHandler.convertUnitToNode(unit);
-      if (key) {
-        node.unitType = UnitType.WITH_KEY_VALUE;
-      } else {
-        node.vitamId = treeNode?.id;
-        node.title = treeNode?.title;
-        node.unitType = treeNode?.unitType;
-        node.hasObject = treeNode?.hasObject;
+      const isDefaultKey = key === 'id';
+
+      if (isDefaultKey && inCollectAttachment) {
+        const { title, unitType, hasObject } = inCollectAttachment;
+        return {
+          // internalAttachment
+          ...node,
+          title,
+          unitType,
+          hasObject,
+        };
       }
-      this.attachmentNodes.push(node);
-    }
+
+      return {
+        // externalAttachment
+        ...node,
+        title: `${this.translateService.instant('COLLECT.FILING_SCHEMA.KEY_VALUE_NODE')}: (${key}: ${value})`,
+        vitamId: isDefaultKey ? value : undefined,
+        unitType: isDefaultKey ? unit['#unitType'] : UnitType.WITH_KEY_VALUE,
+        disableLabelClickCallback: true,
+        disabled: true,
+      };
+    });
   }
 
   loadFilingHoldingSchemeTree() {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-tree-node/vitamui-tree-node.component.ts
@@ -74,7 +74,7 @@ export class VitamuiTreeNodeComponent implements AfterContentChecked {
   }
 
   onLabelClick(event: MouseEvent) {
-    if (this.isVirtualNode()) return;
+    if (this.isVirtualNode() || this.node.disableLabelClickCallback) return;
     this.labelClick.emit();
     if (!this.labelIsLinkedToCheckbox) {
       event.stopPropagation();

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/nodes/node.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/nodes/node.interface.ts
@@ -64,6 +64,7 @@ export interface FilingHoldingSchemeNode extends Id {
   canLoadMoreChildren?: boolean;
   paginatedMatchingChildrenLoaded?: number;
   canLoadMoreMatchingChildren?: boolean;
+  disableLabelClickCallback?: boolean;
 
   waitingChildren?: FilingHoldingSchemeNode[];
   realDirectNodePage?: number;


### PR DESCRIPTION
Dans l’application Collecte, pour un projet manuel non connecté à un SAE (donc avec saisie libre), ou pour un projet automatique non connecté avec rattachement fixe, lorsque je renseigne le GUID d’une unité qui n’est pas de type arbre dans l’étape de position de rattachement,
l’intitulé de la position de rattachement affiché dans le panneau de gauche est vide.