### PR TITLE
Story #14559: [CC] Ensure Ansible 12 (2.19) compatibility

### DIFF
--- a/deployment/scripts/mongod/v8.1/0-00_security.populate_certificates.js.j2
+++ b/deployment/scripts/mongod/v8.1/0-00_security.populate_certificates.js.j2
@@ -25,15 +25,15 @@ dbSecurity.certificates.insertOne({
     {% endif %}
 {%- endmacro %}
 
-{{ process('{{ pki_dir }}/server/hosts/%host%/cas-server.pem', 'cas_context', 'hosts_cas_server') }}
+{{ process(pki_dir + '/server/hosts/%host%/cas-server.pem', 'cas_context', 'hosts_cas_server') }}
 
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-portal.pem', 'ui_portal_context', 'hosts_ui_portal') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-identity.pem', 'ui_identity_context', 'hosts_ui_identity') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-identity-admin.pem', 'ui_admin_identity_context', 'hosts_ui_identity_admin') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-referential.pem', 'ui_referential_context', 'hosts_ui_referential') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-archive-search.pem', 'ui_archive_search_context', 'hosts_ui_archive_search') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-ingest.pem', 'ui_ingest_context', 'hosts_ui_ingest') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-pastis.pem', 'ui_pastis_context', 'hosts_ui_pastis') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-collect.pem', 'ui_collect_context', 'hosts_ui_collect') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-portal.pem', 'ui_portal_context', 'hosts_ui_portal') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-identity.pem', 'ui_identity_context', 'hosts_ui_identity') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-identity-admin.pem', 'ui_admin_identity_context', 'hosts_ui_identity_admin') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-referential.pem', 'ui_referential_context', 'hosts_ui_referential') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-archive-search.pem', 'ui_archive_search_context', 'hosts_ui_archive_search') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-ingest.pem', 'ui_ingest_context', 'hosts_ui_ingest') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-pastis.pem', 'ui_pastis_context', 'hosts_ui_pastis') }}
+{{ process(pki_dir + '/server/hosts/%host%/ui-collect.pem', 'ui_collect_context', 'hosts_ui_collect') }}
 
 print("END v8.1.0-00_security.populate_certificates.js");


### PR DESCRIPTION
Les scripts de base de données ne fonctionnaient pas avec Ansible 2.19 (aka 12).