### PR TITLE
Bug #15121 - [Access Contracts] Display issue: producer services selector.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -222,6 +222,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
   @ViewChild('scrollViewport') private cdkVirtualScrollViewport: CdkVirtualScrollViewport;
   @ViewChildren(MatOption) optionKeys: QueryList<MatOption>;
   @ViewChild('matSelect') matSelect: MatSelect;
+  @ViewChild(CdkVirtualScrollViewport) viewport: CdkVirtualScrollViewport;
 
   @HostListener('document:keydown', ['$event'])
   handleKeyboardEvent(event: KeyboardEvent) {
@@ -293,6 +294,11 @@ export class SelectComponent extends AbstractFormInputDirective implements After
   }
 
   protected openedChange(opened: boolean): void {
+    // Attend que overlay du select soit rendu
+    setTimeout(() => {
+      this.viewport.checkViewportSize();
+    });
+
     if (opened && this.enableSearch) {
       this.searchBar.onFocus();
     }


### PR DESCRIPTION
Le problème est :
quand tu fermes le sélecteur, l’overlay détruit le contenu.
à la réouverture, le cdk-virtual-scroll-viewport peut garder son renderedRange vide si le dataSource n’est pas réinitialisé.