### PR TITLE
Bug #15118 - [Collect] - Referential fields (producer, contributor, archives) appear empty in edit mode despite a saved value.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.html
@@ -4,6 +4,7 @@
     (closed)="onSelectClosed()"
     (openedChange)="openedChange($event)"
     [multiple]="multiple"
+    [compareWith]="compareOptions"
     [formControl]="control"
     panelClass="vitamui-select-panel"
     #matSelect

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -389,6 +389,19 @@ export class SelectComponent extends AbstractFormInputDirective implements After
     }
 
     this.updateMatSelectTriggerContent();
+    this.normalizeSelection();
+  }
+
+  protected compareOptions(o1: { key: string } | null, o2: { key: string } | null): boolean {
+    return !!o1 && !!o2 ? o1.key === o2.key : o1 === o2;
+  }
+
+  private normalizeSelection() {
+    if (this.multiple && Array.isArray(this.control.value)) {
+      const set = new Set(this.control.value);
+      const normalized = this.allOptions.map((o) => o.key).filter((k) => set.has(k));
+      this.control.setValue(normalized, { emitEvent: false });
+    }
   }
 
   private overrideControlMethods() {
@@ -439,6 +452,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
       this.clearAllSelectedOptions();
     }
     this.resizeContainerHeightInSelectedItemsView();
+    this.normalizeSelection();
   }
 
   private resizeContainerHeightInSearchView(): void {


### PR DESCRIPTION
[Collecte]- Les champs référentiels (producteur, versant, archives) apparaissent vides en mode édition malgré une valeur enregistrée