### PR TITLE
Story #15087: upgrade ngx-toaster to avoid malicious version

### DIFF
--- a/ui/ui-frontend/package-lock.json
+++ b/ui/ui-frontend/package-lock.json
@@ -40,7 +40,7 @@
         "ngx-color-picker": "^17.0.0",
         "ngx-filesize": "^3.0.5",
         "ngx-quicklink": "0.4.7",
-        "ngx-toastr": "^19.0.0",
+        "ngx-toastr": "^19.1.0",
         "ngx-translate-multi-http-loader": "^19.0.2",
         "ngx-ui-loader": "^13.0.0",
         "rxjs": "^7.8.1",
@@ -13325,9 +13325,9 @@
       }
     },
     "node_modules/ngx-toastr": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.0.0.tgz",
-      "integrity": "sha512-6pTnktwwWD+kx342wuMOWB4+bkyX9221pAgGz3SHOJH0/MI9erLucS8PeeJDFwbUYyh75nQ6AzVtolgHxi52dQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.1.0.tgz",
+      "integrity": "sha512-Qa7Kg7QzGKNtp1v04hu3poPKKx8BGBD/Onkhm6CdH5F0vSMdq+BdR/f8DTpZnGFksW891tAFufpiWb9UZX+3vg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/ui/ui-frontend/package.json
+++ b/ui/ui-frontend/package.json
@@ -117,7 +117,7 @@
     "ngx-color-picker": "^17.0.0",
     "ngx-filesize": "^3.0.5",
     "ngx-quicklink": "0.4.7",
-    "ngx-toastr": "^19.0.0",
+    "ngx-toastr": "^19.1.0",
     "ngx-translate-multi-http-loader": "^19.0.2",
     "ngx-ui-loader": "^13.0.0",
     "rxjs": "^7.8.1",


### PR DESCRIPTION
Checkmarx indique que la version 1.19.0 de ngx-toastr est "malicious". Mise à jour du composant.

Backports en 8.1 et 8.0 à venir.