### PR TITLE
bug #14279 - hidden lateral panel

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/resize-sidebar/resize-sidebar.directive.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/resize-sidebar/resize-sidebar.directive.ts
@@ -74,7 +74,7 @@ export class ResizeSidebarDirective implements OnInit {
     if (this.status === 1) {
       const space = Number(mouse.x) ? mouse.x : 0;
       if (this.orientation === 'left') {
-        this.width = space;
+        this.width = space >= 5 ? space : 5;
         this.elementRef.nativeElement.style.width = this.width + 'px';
       } else {
         const { left } = this.elementRef.nativeElement.getBoundingClientRect();


### PR DESCRIPTION
## Description

Sur Archive-Search et Collecte, le panneau latéral devenait inaccessible si entièrement décalé vers la gauche. Ajout d'une marge pour la rendre visible