### PR TITLE
Bug #14995: untranslated keys after object deletion

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
@@ -3532,7 +3532,19 @@
     "PRESERVATION_PREPARATION_INSERTION_AU_METADATA": "Preparation of the insertion of archival units",
     "STP_PRESERVATION_INSERTION_AU_METADATA.STARTED": "Start of the process of inserting metadata",
     "STP_PRESERVATION_INSERTION_AU_METADATA": "Process of inserting metadata",
-    "PRESERVATION_INSERTION_AU_METADATA": "Indexation of archival units metadata"
+    "PRESERVATION_INSERTION_AU_METADATA": "Indexation of archival units metadata",
+    "DELETE_GOT_VERSIONS": "Deletion of object group versions",
+    "STP_DELETE_GOT_VERSIONS_PREPARATION.STARTED": "Beginning of the preparation process for deleting object group versions",
+    "STP_DELETE_GOT_VERSIONS_PREPARATION": "Preparation process for deleting object group versions",
+    "DELETE_GOT_VERSIONS_PREPARATION": "Preparing to delete object group versions",
+    "STP_DELETE_GOT_VERSIONS_ACTION.STARTED": "Beginning of process for deleting object group versions",
+    "STP_DELETE_GOT_VERSIONS_ACTION": "Process for deleting versions of object groups",
+    "STP_DELETE_GOT_VERSIONS_ACCESSION_REGISTER_UPDATE.STARTED": "Beginning of the fund register process",
+    "STP_DELETE_GOT_VERSIONS_ACCESSION_REGISTER_UPDATE": "Supply process for the Register of Funds",
+    "DELETE_GOT_VERSIONS_ACCESSION_REGISTER_UPDATE": "Supply for the Register of Funds",
+    "STP_DELETE_GOT_VERSIONS_FINALIZATION.STARTED": "Beginning of the finalization process for deleting object group versions",
+    "STP_DELETE_GOT_VERSIONS_FINALIZATION": "Finalization process for deleting object group versions",
+    "DELETE_GOT_VERSIONS_FINALIZATION": "Finalization of deleting object group versions"
   },
   "HTTP_INTERCEPTOR": {
     "HTTP_STATUS_CODE_FORBIDDEN": "You do not have the necessary rights to perform this operation.",

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
@@ -3532,7 +3532,19 @@
     "PRESERVATION_PREPARATION_INSERTION_AU_METADATA": "Préparation de l'insertion des unités archivistiques",
     "STP_PRESERVATION_INSERTION_AU_METADATA.STARTED": "Début du processus de l'insertion des métadonnées",
     "STP_PRESERVATION_INSERTION_AU_METADATA": "Processus de l'insertion des métadonnées",
-    "PRESERVATION_INSERTION_AU_METADATA": "Indexation des métadonnées des unités archivistiques"
+    "PRESERVATION_INSERTION_AU_METADATA": "Indexation des métadonnées des unités archivistiques",
+    "DELETE_GOT_VERSIONS": "Suppression des versions des groupes d'objets",
+    "STP_DELETE_GOT_VERSIONS_PREPARATION.STARTED": "Début du processus de préparation de la suppression des versions des groupes d'objets",
+    "STP_DELETE_GOT_VERSIONS_PREPARATION": "Processus de préparation de la suppression des versions des groupes d'objets",
+    "DELETE_GOT_VERSIONS_PREPARATION": "Préparation de la suppression des versions des groupes d'objets",
+    "STP_DELETE_GOT_VERSIONS_ACTION.STARTED": "Début du processus de suppression des versions des groupes d'objets",
+    "STP_DELETE_GOT_VERSIONS_ACTION": "Processus de suppression des versions des groupes d'objets",
+    "STP_DELETE_GOT_VERSIONS_ACCESSION_REGISTER_UPDATE.STARTED": "Début du processus de l'alimentation du Registre des Fonds",
+    "STP_DELETE_GOT_VERSIONS_ACCESSION_REGISTER_UPDATE": "Processus de l'alimentation du Registre des Fonds",
+    "DELETE_GOT_VERSIONS_ACCESSION_REGISTER_UPDATE": "Alimentation du Registre des Fonds",
+    "STP_DELETE_GOT_VERSIONS_FINALIZATION.STARTED": "Début du processus de finalisation de la suppression des versions des groupes d'objets",
+    "STP_DELETE_GOT_VERSIONS_FINALIZATION": "Processus de finalisation de la suppression des versions des groupes d'objets",
+    "DELETE_GOT_VERSIONS_FINALIZATION": "Processus de finalisation de la suppression des versions des groupes d'objets"
   },
   "HTTP_INTERCEPTOR": {
     "HTTP_STATUS_CODE_FORBIDDEN": "Vous n'avez pas les droits nécessaires pour effectuer cette opération.",


### PR DESCRIPTION
## Description

Aprés suppression de versions sur des GOTS certaines clé liés à l'opération ne sont pas traduite
