### PR TITLE
Bugs #14839: display creation and modification date for external schema elements

### DIFF
--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/schema/SchemaModelToSchemaElementDtoConverter.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/schema/SchemaModelToSchemaElementDtoConverter.java
@@ -63,7 +63,9 @@ public class SchemaModelToSchemaElementDtoConverter extends StdConverter<SchemaR
             .setCategory(schemaModel.getCategory())
             .setApiPath(Optional.ofNullable(schemaModel.getApiPath()).orElse(schemaModel.getPath()))
             .setDataType(convertFromIndexationType(schemaModel.getType()))
-            .setCustomSearchTypes(schemaModel.getCustomSearchTypes());
+            .setCustomSearchTypes(schemaModel.getCustomSearchTypes())
+            .setCreationDate(schemaModel.getCreationDate())
+            .setLastUpdate(schemaModel.getLastUpdate());
 
         return schemaElementDto;
     }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/schema/SchemaService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/schema/SchemaService.java
@@ -80,7 +80,6 @@ public class SchemaService extends AbstractService {
     private final ImportSchemaConverter converter;
     private final ApplicationsApi applicationsApi;
     private final AdminExternalClient adminExternalClient;
-    private final SecurityService securityService;
 
     public SchemaService(
         final AdminExternalClient adminExternalClient,
@@ -90,7 +89,6 @@ public class SchemaService extends AbstractService {
         ApplicationsApi applicationsApi
     ) {
         super(securityService);
-        this.securityService = securityService;
         this.adminExternalClient = adminExternalClient;
         this.importSchemaCommonService = importSchemaCommonService;
         this.converter = converter;

--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/schema-information-tab/schema-information-tab.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/schema-information-tab/schema-information-tab.component.html
@@ -81,13 +81,14 @@
     ></vitamui-select>
 
     <vitamui-input
+      *ngIf="!isExternal"
       formControlName="SedaVersions"
       [placeholder]="'ONTOLOGY.SCHEMA.TAB.INFORMATION.SEDA_VERSIONS' | translate"
     ></vitamui-input>
 
     <vitamui-input
       *ngIf="isExternal"
-      [value]="form.get('CreationDate').value | dateTime: 'dd/MM/yyyy'"
+      formControlName="CreationDate"
       [placeholder]="'ONTOLOGY.SCHEMA.TAB.INFORMATION.CREATION_DATE' | translate"
       [disabled]="true"
     >
@@ -95,7 +96,7 @@
 
     <vitamui-input
       *ngIf="isExternal"
-      [value]="form.get('LastUpdate').value | dateTime: 'dd/MM/yyyy'"
+      formControlName="LastUpdate"
       [placeholder]="'ONTOLOGY.SCHEMA.TAB.INFORMATION.MODIFICATION_DATE' | translate"
       [disabled]="true"
     >


### PR DESCRIPTION
Affichage de CreationDate et LastUpdate pour les schémas externes. On en profite pour n'afficher SedaVersions que pour les schémas internes.

Dépend d'une modification de l'api schéma de Vitam Core (qui ne renvoie pas les champs CreationDate et LastUpdate).