### PR TITLE
Bug #14921 - [Collect && SEARCH] - Display issue with selection in multi-criteria filters.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -244,6 +244,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
   }
 
   ngAfterViewChecked(): void {
+    this.updateCheckboxes();
     this.updateSelectAll();
   }
 


### PR DESCRIPTION
Dans la recherche multicritères, je coche quelques options, je clique ensuite sur "Consulter ma sélection" alors :
Les options n’apparaissent pas comme étant cochées.