### PR TITLE
Bugs #14188: vitamui-library-filing-plan does not work correctly when its previous value is not available anymore

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/filing-plan/filing-plan.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/filing-plan/filing-plan.component.ts
@@ -99,6 +99,12 @@ export class FilingPlanComponent extends AbstractFormInputDirective implements O
   setNodes(nodes: Node[]) {
     this.nestedDataSource.data = nodes;
     this.nestedTreeControl.dataNodes = nodes;
+    // Ensure that the selectedNodes are included in the nodes (needed when a value is not in the datasource anymore)
+    const nodeIds = nodes.map((node) => node.vitamId);
+    this.selectedNodes = {
+      included: this.selectedNodes.included.filter((id) => nodeIds.includes(id)),
+      excluded: this.selectedNodes.excluded.filter((id) => nodeIds.includes(id)),
+    };
     this.initCheckedNodes(this.selectedNodes, nodes);
   }
 


### PR DESCRIPTION
Si la valeur existante n'existe plus dans la liste des valeurs possibles, elle se retrouve dans la valeur du contrôle sans pouvoir être supprimée, et tout changement vient en plus de la valeur incorrecte (en mode SOLO !).

Le changement vérifie que la valeur du champ est bien une valeur possible, en faisant l'intersection des arrays.