### PR TITLE
Bug #14992: trigger form validation on load

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-information-tab/rule-information-tab.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-information-tab/rule-information-tab.component.ts
@@ -170,5 +170,6 @@ export class RuleInformationTabComponent implements OnInit {
 
   resetForm(rule: Rule) {
     this.form.reset(rule, { emitEvent: false });
+    this.form.markAllAsTouched({ emitEvent: false });
   }
 }


### PR DESCRIPTION
Nous devons afficher les erreurs au chargement du formulaire (car des règles invalides ont pu être importées).