### PR TITLE
Bug #14852 - [Collect] The help text in the metadata search field is truncated.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select-with-tree/select-with-tree.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select-with-tree/select-with-tree.component.html
@@ -50,6 +50,7 @@
           (searchChanged)="onSearch($event)"
           name="element-search"
           [placeholder]="searchBarPlaceHolder"
+          [title]="searchBarPlaceHolder"
           searchButtonColor="primary"
         ></vitamui-common-search-bar>
       </div>


### PR DESCRIPTION
[BUG Collect] Le texte d’aide à la saisie est tronqué dans le champ de recherche des métadonnées.