### PR TITLE
Bug #14974: prevent empty filter after clearing input

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-multi-inputs/vitamui-multi-inputs.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-multi-inputs/vitamui-multi-inputs.component.ts
@@ -68,6 +68,12 @@ export class VitamuiMultiInputsComponent extends EditableFieldComponent implemen
     super(elementRef);
   }
 
+  // Prevents validating an empty value in the multi-inputs
+  override get canConfirm(): boolean {
+    const value = this.control.value?.toString()?.trim();
+    return super.canConfirm && !!value;
+  }
+
   enterEditMode() {
     super.enterEditMode();
     setTimeout(() => this.input.nativeElement.focus(), 0);


### PR DESCRIPTION
Dans le module “Registre de fonds”, le bouton “Valider” des filtres de recherche avancée reste activé après suppression du contenu saisi. Cela provoque l’ajout d’un filtre vide.