### PR TITLE
Bug #15175: prevent 500 on other criteria date filter

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/simple-criteria-search/simple-criteria-search.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/simple-criteria-search/simple-criteria-search.component.html
@@ -147,6 +147,7 @@
               <vitamui-datepicker
                 [label]="getCriteriaName(otherCriteria)"
                 [formControlName]="otherCriteria.Path"
+                outputType="Date"
                 format="yyyy-MM-dd"
                 class="w-100"
               ></vitamui-datepicker>


### PR DESCRIPTION
Dans l'application collect, la recherche effectuée avec des date ajoutées dans la section Autres critères retourne une erreur 500