### PR TITLE
bug #14862 : Position criteria removed when adding new criteria

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -90,6 +90,7 @@ import {
   VALID_COMPUTED_INHERITED_RULES_FACET,
   VitamuiRoles,
   WAITING_RECALCULATE,
+  NODES,
 } from 'vitamui-library';
 import { ArchiveSharedDataService } from '../../core/archive-shared-data.service';
 import { ManagementRulesSharedDataService } from '../../core/management-rules-shared-data.service';
@@ -248,7 +249,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
         if (!node.checked) {
           node.count = null;
           if (node.id === ORPHANS_NODE_ID) {
-            this.removeCriteria(ORPHANS_NODE_ID, { id: node.id, value: node.id }, false);
+            this.removeCriteria(ORPHANS_NODE_ID, { id: 'position', value: ORPHANS_NODE_ID }, true);
           } else if (node.isVirtual) {
             this.removeCriteria(
               'VIRTUAL',
@@ -260,21 +261,21 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
               false,
             );
           } else {
-            this.removeCriteria('NODE', { id: node.id, value: node.id }, false);
+            this.removeCriteria('NODE', { id: NODES, value: node.id }, true);
           }
           return;
         }
         if (node.id === ORPHANS_NODE_ID) {
           this.addCriteria(
             ORPHANS_NODE_ID,
-            { id: ORPHANS_NODE_ID, value: ORPHANS_NODE_ID },
+            { id: 'position', value: ORPHANS_NODE_ID },
             node.title,
             true,
             CriteriaOperator.MISSING,
             SearchCriteriaTypeEnum.FIELDS,
             false,
             CriteriaDataType.STRING,
-            false,
+            true,
           );
         } else {
           if (node.isVirtual) {
@@ -297,14 +298,14 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
           } else {
             this.addCriteria(
               'NODE',
-              { id: node.id, value: node.id },
+              { id: NODES, value: node.id },
               node.title,
               true,
               CriteriaOperator.EQ,
               SearchCriteriaTypeEnum.NODES,
               false,
               CriteriaDataType.STRING,
-              false,
+              true,
             );
           }
         }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/common-services/archive-search-helper.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/common-services/archive-search-helper.service.ts
@@ -205,6 +205,18 @@ export class ArchiveSearchHelperService {
             action: 'ADD',
           });
         }
+        if (emit === true && [SearchCriteriaTypeEnum.FIELDS, SearchCriteriaTypeEnum.NODES].includes(category)) {
+          this.archiveExchangeDataService.addSimpleSearchCriteriaSubject({
+            keyElt,
+            valueElt,
+            labelElt,
+            keyTranslated,
+            operator,
+            category,
+            valueTranslated,
+            dataType,
+          });
+        }
       }
     }
   }
@@ -320,7 +332,7 @@ export class ArchiveSearchHelperService {
           }
           this.archiveExchangeDataService.emitSearchCriteriaChange(searchCriterias);
           nbQueryCriteria--;
-          if ((emit === true && key === 'NODE') || key === ORPHANS_NODE_ID) {
+          if (emit === true && [ORPHANS_NODE_ID, 'NODE'].includes(key)) {
             this.archiveExchangeDataService.emitNodeTarget(valueElt.value);
           }
 
@@ -363,7 +375,10 @@ export class ArchiveSearchHelperService {
               action: 'REMOVE',
             });
           }
-          if (emit === true && val.category === SearchCriteriaTypeEnum.FIELDS && val.key === ALL_ARCHIVE_UNIT_TYPES) {
+          if (
+            emit === true &&
+            [SearchCriteriaTypeEnum.FIELDS, SearchCriteriaTypeEnum.NODES, ALL_ARCHIVE_UNIT_TYPES].includes(val.category)
+          ) {
             this.archiveExchangeDataService.sendRemoveFromChildSearchCriteriaAction({
               keyElt,
               valueElt,

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
@@ -36,9 +36,6 @@
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CriteriaSearchCriteria, CriteriaValue, QueryParamsService, SearchCriteriaTypeEnum, SearchCriteriaValue } from 'vitamui-library';
-import { TranslateService } from '@ngx-translate/core';
-import { DatePipe } from '@angular/common';
-
 @Component({
   selector: 'app-criteria-search',
   templateUrl: './criteria-search.component.html',
@@ -46,11 +43,7 @@ import { DatePipe } from '@angular/common';
   standalone: false,
 })
 export class CriteriaSearchComponent {
-  constructor(
-    private queryParamsService: QueryParamsService,
-    private translateService: TranslateService,
-    private datePipe: DatePipe,
-  ) {}
+  constructor(private queryParamsService: QueryParamsService) {}
 
   @Input()
   criteriaKey: string;

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
@@ -36,6 +36,8 @@
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CriteriaSearchCriteria, CriteriaValue, QueryParamsService, SearchCriteriaTypeEnum, SearchCriteriaValue } from 'vitamui-library';
+import { TranslateService } from '@ngx-translate/core';
+import { DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-criteria-search',
@@ -44,7 +46,11 @@ import { CriteriaSearchCriteria, CriteriaValue, QueryParamsService, SearchCriter
   standalone: false,
 })
 export class CriteriaSearchComponent {
-  constructor(private queryParamsService: QueryParamsService) {}
+  constructor(
+    private queryParamsService: QueryParamsService,
+    private translateService: TranslateService,
+    private datePipe: DatePipe,
+  ) {}
 
   @Input()
   criteriaKey: string;

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -83,6 +83,7 @@ import {
   UnitType,
   VALID_COMPUTED_INHERITED_RULES_FACET,
   WAITING_RECALCULATE,
+  NODES,
 } from 'vitamui-library';
 import { ArchiveCollectService } from './archive-collect.service';
 import { SearchCriteriaSaverComponent } from './archive-search-criteria/components/search-criteria-saver/search-criteria-saver.component';
@@ -224,7 +225,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
         if (node && node.id && !node.checked) {
           node.count = null;
           if (node.id === ORPHANS_NODE_ID) {
-            this.removeCriteria(ORPHANS_NODE_ID, { id: node.id, value: node.id }, false);
+            this.removeCriteria(ORPHANS_NODE_ID, { id: 'position', value: ORPHANS_NODE_ID }, true);
           } else if (node.isVirtual) {
             this.removeCriteria(
               'VIRTUAL',
@@ -236,7 +237,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
               false,
             );
           } else {
-            this.removeCriteria('NODE', { id: node.id, value: node.id }, false);
+            this.removeCriteria('NODE', { id: NODES, value: node.id }, true);
           }
           return;
         }
@@ -246,14 +247,14 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
             this.searchCriteriaKeys,
             this.nbQueryCriteria,
             ORPHANS_NODE_ID,
-            { id: ORPHANS_NODE_ID, value: ORPHANS_NODE_ID },
+            { id: 'position', value: ORPHANS_NODE_ID },
             node.title,
             true,
             CriteriaOperator.MISSING,
             SearchCriteriaTypeEnum.FIELDS,
             false,
             CriteriaDataType.STRING,
-            false,
+            true,
           );
         } else if (node.isVirtual) {
           this.addCriteria(

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/services/archive-search-helper.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/services/archive-search-helper.service.ts
@@ -57,7 +57,7 @@ const ERRORS = 'ERRORS';
 const WAITING_RECALCULATE = 'WAITING_RECALCULATE';
 const ORIGIN_WAITING_RECALCULATE = 'ORIGIN_WAITING_RECALCULATE';
 
-const fieldKeys = [ALL_ARCHIVE_UNIT_TYPES, ERRORS];
+const fieldKeys = [ALL_ARCHIVE_UNIT_TYPES, ERRORS, SearchCriteriaTypeEnum.FIELDS, SearchCriteriaTypeEnum.NODES];
 
 @Injectable({
   providedIn: 'root',
@@ -211,6 +211,18 @@ export class ArchiveSearchHelperService {
         action: 'ADD',
       });
     }
+    if (emit === true && [SearchCriteriaTypeEnum.FIELDS, SearchCriteriaTypeEnum.NODES].includes(category)) {
+      this.archiveExchangeDataService.addSimpleSearchCriteriaSubject({
+        keyElt,
+        valueElt,
+        labelElt,
+        keyTranslated,
+        operator,
+        category,
+        valueTranslated,
+        dataType,
+      });
+    }
   }
 
   prepareUAIdList(
@@ -324,7 +336,7 @@ export class ArchiveSearchHelperService {
           }
           this.archiveExchangeDataService.emitSearchCriteriaChange(searchCriterias);
           nbQueryCriteria--;
-          if (emit === true && (key === 'NODE' || key === ORPHANS_NODE_ID)) {
+          if (emit === true && [ORPHANS_NODE_ID, 'NODE'].includes(key)) {
             this.archiveExchangeDataService.emitNodeTarget(valueElt.value);
           }
 
@@ -367,7 +379,7 @@ export class ArchiveSearchHelperService {
               action: 'REMOVE',
             });
           }
-          if (emit === true && searchCriteria.category === SearchCriteriaTypeEnum.FIELDS && fieldKeys.includes(searchCriteria.key)) {
+          if (emit === true && fieldKeys.includes(searchCriteria.category)) {
             this.archiveExchangeDataService.sendRemoveFromChildSearchCriteriaAction({
               keyElt,
               valueElt,

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/criteria/search-criteria-configs.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/criteria/search-criteria-configs.ts
@@ -133,6 +133,14 @@ const searchCriteriaConfigs: { [key: string]: Partial<SearchCriteriaAddAction> }
     keyElt: 'RULE_IDENTIFIER_REUSE_RULE',
     keyTranslated: true,
   },
+  position: {
+    keyElt: 'ORPHANS_NODE',
+    keyTranslated: true,
+  },
+  NODES: {
+    keyElt: 'NODE',
+    keyTranslated: true,
+  },
 };
 searchCriteriaConfigs.Title = searchCriteriaConfigs.title;
 searchCriteriaConfigs.Description = searchCriteriaConfigs.description;


### PR DESCRIPTION
## Description

Les critères de recherches concernant les positions de rattachement étaient supprimés dès lors que l'on rajoutait un critères hors position (ex: titre). Cela est dû au fait que les critères de recherche portant sur les positions n'étaient pas reportés sur l'url.
Il a fallu mettre en place le même mécanisme de sauvegarde pour les critères de recherche portant sur les positions de rattachement.