### PR TITLE
Story #14559 : Clean code - Avoid table overflow

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/sass/_table.scss
+++ b/ui/ui-frontend/projects/vitamui-library/src/sass/_table.scss
@@ -103,6 +103,7 @@ tr {
   th {
     position: relative;
     height: 60px;
+    overflow-wrap: anywhere;
   }
 }
 


### PR DESCRIPTION
## Description

Afin d'éviter le débordement d'un tableau en cas d'un long libellé, ajout de la propriété `overflow-wrap: anywhere` afin que les libellés ne fassent pas déborder les tableaux
