### PR TITLE
Bug #15293 [Collect] A transfer project to another SAE displays the local SAE's trees.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
@@ -385,7 +385,7 @@
         <div class="main-content">
           <div class="form-group">
             <vitamui-library-filing-plan
-              *ngIf="units && connectedToArchivingSystem"
+              *ngIf="units && connectedToArchivingSystem && connectedToLocalEasWithCurrentTenant"
               [dataSource]="units"
               [formControl]="linkParentIdControl"
               [mode]="FilingPlanMode.SOLO"
@@ -393,7 +393,7 @@
             </vitamui-library-filing-plan>
             <vitamui-input
               class="w-100"
-              *ngIf="!connectedToArchivingSystem"
+              *ngIf="!connectedToLocalEasWithCurrentTenant"
               [required]="connectedToArchivingSystem"
               [placeholder]="'COLLECT.ARCHIVAL_UNIT_IDENTIFIER' | translate"
               formControlName="unitUp"
@@ -478,7 +478,7 @@
                             <span class="required-marker">*</span>
                           }
                         </label>
-                        @if (connectedToArchivingSystem) {
+                        @if (connectedToArchivingSystem && connectedToLocalEasWithCurrentTenant) {
                           <vitamui-library-filing-plan formControlName="unitUp" [dataSource]="units" [mode]="FilingPlanMode.SOLO">
                           </vitamui-library-filing-plan>
                         } @else {

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.spec.ts
@@ -60,6 +60,7 @@ import {
 import { CollectZippedUploadFile } from '../../shared/collect-upload/collect-upload-file';
 import { CollectUploadService } from '../../shared/collect-upload/collect-upload.service';
 import { ProjectsService } from '../projects.service';
+import { TenantSelectionService } from 'vitamui-library';
 import { TransactionsService } from '../transactions.service';
 import { CreateProjectComponent } from './create-project.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
@@ -122,11 +123,16 @@ describe('CreateProjectComponent', () => {
     lastUpdate: new Date(),
   };
 
+  let tenantSelectionServiceMock: any;
   let projectsServiceMock: SpyObj<ProjectsService>;
   let transactionServiceMock: SpyObj<TransactionsService>;
   let uploadServiceMock: SpyObj<CollectUploadService>;
 
   beforeEach(async () => {
+    tenantSelectionServiceMock = {
+      getSelectedTenant: jasmine.createSpy('getSelectedTenant').and.returnValue({ identifier: 'tenant1' }),
+    };
+
     projectsServiceMock = jasmine.createSpyObj<ProjectsService>('ProjectsService', {
       create: of(defaultProject),
       updateProjectDescription: of(defaultProject),
@@ -157,6 +163,7 @@ describe('CreateProjectComponent', () => {
         { provide: MatDialog, useValue: matDialogSpy },
         { provide: WINDOW_LOCATION, useValue: window.location },
         { provide: ProjectsService, useValue: projectsServiceMock },
+        { provide: TenantSelectionService, useValue: tenantSelectionServiceMock },
         { provide: TransactionsService, useValue: transactionServiceMock },
         { provide: CollectUploadService, useValue: uploadServiceMock },
         provideHttpClient(withInterceptorsFromDi()),

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
@@ -533,6 +533,13 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
     return this.projectForm.get('connectedToArchivingSystem')?.value === true;
   }
 
+  get connectedToLocalEasWithCurrentTenant(): boolean {
+    const currentTenantId = this.tenantSelectionService.getSelectedTenant().identifier;
+    const defaultKey = `${LOCAL_ARCHIVING_SYSTEM_ID}${TENANT_SEPARATOR}${currentTenantId}`;
+    const archivingSystemValue = this.projectForm.get('archivingSystem')?.value;
+    return archivingSystemValue === defaultKey;
+  }
+
   private mapToOptions<T extends { identifier: string; name: string }>(items: T[]): { label: string; key: string }[] {
     return items.map((item) => ({
       label: `${item.identifier} - ${item.name}`,


### PR DESCRIPTION
lors de la création d'un projet connecté aux référentiels d'un autre tenant ou autre SAE, les arbres et plans affichés sont ceux du SAE local. Il devrait y avoir un champ de saisie libre