### PR TITLE
CP V8.1 - Bug #15295: Adding logrotate for Mongo-VitamUI logs.

### DIFF
--- a/deployment/environments/group_vars/all/mongodb_vars.yml
+++ b/deployment/environments/group_vars/all/mongodb_vars.yml
@@ -10,6 +10,9 @@ mongodb:
     mongod_port: 27017
     check_consul: 10 # in seconds
     drop_info_log: false # Drop mongo (I)nformational log, for Verbosity Level of 0
+    # logs configuration
+    logrotate: enabled # or disabled
+    history_days: 30 # How many days to store logs if logrotate is set to 'enabled'
     versioning:
         enable: true # Enable or not the versioning of the scripts.
     included_scripts: # List of regexs allowing to determine which scripts will be included and applied on database.

--- a/deployment/roles/mongo/tasks/main.yml
+++ b/deployment/roles/mongo/tasks/main.yml
@@ -74,7 +74,20 @@
   notify: mongo - restart service
   tags: update_mongodb_configuration
 
-# TODO: Add logrotate
+- name: Enable logrotate for vitamui-mongod
+  template:
+    src: logrotate.j2
+    dest: /etc/logrotate.d/vitamui-mongod
+    owner: root
+    group: root
+    mode: 0644
+  when: mongodb.logrotate | default('enabled') | lower == 'enabled'
+
+- name: Disable logrotate for vitamui-mongod
+  file:
+    path: /etc/logrotate.d/vitamui-mongod
+    state: absent
+  when: mongodb.logrotate | default('enabled') | lower == 'disabled'
 
 #### Consul configuration ####
 

--- a/deployment/roles/mongo/templates/logrotate.j2
+++ b/deployment/roles/mongo/templates/logrotate.j2
@@ -1,0 +1,15 @@
+{{ ansible_managed | comment }}
+
+{{ mongo_folder_log }}/mongod.log {
+        daily
+        rotate {{ mongodb.history_days | default(30) }}
+        copytruncate
+        dateext
+        dateformat -%Y-%m-%d
+        dateyesterday
+        extension .log
+        compress
+        delaycompress
+        notifempty
+        missingok
+}

--- a/deployment/roles/mongo/templates/mongod.conf.j2
+++ b/deployment/roles/mongo/templates/mongod.conf.j2
@@ -8,8 +8,12 @@
 {% if install_mode != 'container' %}
 systemLog:
   destination: file
+  syslogFacility: local0
+  verbosity: {{ mongodb.verbosity | default(0) }}
+  traceAllExceptions: {{ mongodb.trace_all_exceptions | default('false') }}
   logAppend: true
-  path: {{ vitamui_defaults.folder.root_path | default('/vitamui') }}/log/mongod/mongod.log
+  logRotate: reopen
+  path: {{ mongo_folder_log }}/mongod.log
 {% endif %}
 
 # Where and how to store data.

--- a/deployment/roles/mongo/vars/main.yml
+++ b/deployment/roles/mongo/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 
-mongo_tmp_path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/tmp/mongod"
-mongo_config_path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/conf/mongod"
-mongo_db_path: "{{ vitamui_defaults.folder.root_path | default('/vitamui') }}/data/mongod/db"
+mongo_tmp_path: "{{ vitamui_defaults.folder.root_path }}/tmp/mongod"
+mongo_config_path: "{{ vitamui_defaults.folder.root_path }}/conf/mongod"
+mongo_db_path: "{{ vitamui_defaults.folder.root_path }}/data/mongod/db"
+mongo_folder_log: '{{ vitamui_defaults.folder.root_path }}/log/mongod'


### PR DESCRIPTION
## Description

Add missing logrotate for /vitamui/log/mongod/mongod.log.

> Cherry-Picked from #3235 

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* VAS (Vitam Accessible en Service)