### PR TITLE
bugs #15192 fix(collect): transaction actions state after validation

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -83,11 +83,7 @@
             >
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
-            <button
-              mat-menu-item
-              (click)="sendTransaction()"
-              [disabled]="!hasSendTransactionRole || transaction?.status !== TransactionStatus.VALIDATED || isAutomaticIngest"
-            >
+            <button mat-menu-item (click)="sendTransaction()" [disabled]="!canSend(transaction)">
               {{ 'COLLECT.INGEST_ACTION' | translate }}
             </button>
           </vitamui-menu-button>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -1249,7 +1249,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   }
 
   canSend(transaction: Transaction): boolean {
-    const allowedStatus = [TransactionStatus.READY, TransactionStatus.VALIDATED];
+    const allowedStatus = [TransactionStatus.VALIDATED];
     const isAllowedStatus = allowedStatus.includes(transaction.status);
 
     return this.hasSendTransactionRole && !this.isAutomaticIngest && isAllowedStatus;

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -39,7 +39,7 @@ import { AfterViewInit, Component, OnDestroy, OnInit, TemplateRef, ViewChild } f
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, merge, Observable, Subject, Subscription, zip } from 'rxjs';
+import { BehaviorSubject, finalize, merge, Observable, Subject, Subscription, zip } from 'rxjs';
 import { debounceTime, filter, map, mergeMap, share, take, tap } from 'rxjs/operators';
 import { isEmpty } from 'underscore';
 import {
@@ -92,6 +92,7 @@ import { ArchiveSearchHelperService } from './archive-search-criteria/services/a
 import { ArchiveSharedDataService } from '../core/archive-shared-data.service';
 import { UpdateUnitsMetadataComponent } from './update-units-metadata/update-units-metadata.component';
 import { AddUnitsComponent } from './add-units/add-units.component';
+import { TransactionsService } from '../transactions/transactions.service';
 
 const PAGE_SIZE = 10;
 const ELIMINATION_TECHNICAL_ID = 'ELIMINATION_TECHNICAL_ID';
@@ -218,6 +219,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     private searchCriteriaService: SearchCriteriaService,
     private ruleService: RuleService,
     private snackBarService: SnackBarService,
+    private transactionService: TransactionsService,
   ) {
     super(route, globalEventService);
 
@@ -1229,15 +1231,28 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   }
 
   validateTransaction() {
-    this.archiveUnitCollectService.validateTransaction(this.transaction.id).subscribe((transaction: Transaction) => {
-      this.isNotOpen$.next(transaction.status !== TransactionStatus.OPEN);
-      this.isNotReady$.next(transaction.status !== TransactionStatus.READY);
-      this.transaction = transaction;
-      this.snackBarService.open({
-        message: 'COLLECT.VALIDATE_TRANSACTION_VALIDATED',
-        duration: 10_000,
+    this.transactionService
+      .validate(this.transaction, { isAutomaticIngest: this.isAutomaticIngest })
+      .pipe(
+        finalize(() => {
+          this.snackBarService.open({
+            message: 'COLLECT.VALIDATE_TRANSACTION_VALIDATED',
+            duration: 10_000,
+          });
+        }),
+      )
+      .subscribe((transaction: Transaction) => {
+        this.isNotOpen$.next(transaction.status !== TransactionStatus.OPEN);
+        this.isNotReady$.next(transaction.status !== TransactionStatus.READY);
+        this.transaction = transaction;
       });
-    });
+  }
+
+  canSend(transaction: Transaction): boolean {
+    const allowedStatus = [TransactionStatus.READY, TransactionStatus.VALIDATED];
+    const isAllowedStatus = allowedStatus.includes(transaction.status);
+
+    return this.hasSendTransactionRole && !this.isAutomaticIngest && isAllowedStatus;
   }
 
   sendTransaction() {

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/polling.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/polling.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { Observable, switchMap, takeWhile, throwError, timer } from 'rxjs';
+import { catchError, takeUntil } from 'rxjs/operators';
+
+export interface PollingOptions<T> {
+  until: (item: T) => boolean;
+  period: number; // milliseconds between polls
+  maxRetries: number; // number of retry attempts
+}
+
+export const pollUntil = <T>(action: Observable<T>, options: PollingOptions<T>): Observable<T> => {
+  const { until, period, maxRetries } = options;
+
+  return timer(0, period).pipe(
+    switchMap(() => action),
+    // Continue until "until(item)" returns true
+    takeWhile((result) => !until(result), true),
+    // Stop after maxRetries * period (timeout)
+    takeUntil(timer(period * maxRetries)),
+    catchError((err) => throwError(() => new Error(`Polling failed: ${err}`))),
+  );
+};

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.html
@@ -91,15 +91,7 @@
                   >
                     {{ 'COLLECT.VALIDATE_ACTION' | translate }}
                   </button>
-                  <button
-                    mat-menu-item
-                    [disabled]="
-                      !(transactionIsReady(transaction) || transactionIsValidated(transaction)) ||
-                      !hasSendTransactionRole ||
-                      disabledSendTransactions.has(transaction.id)
-                    "
-                    (click)="sendTransaction(transaction)"
-                  >
+                  <button mat-menu-item [disabled]="!canSend(transaction)" (click)="sendTransaction(transaction)">
                     {{ 'COLLECT.INGEST_ACTION' | translate }}
                   </button>
                   <button

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.spec.ts
@@ -93,6 +93,7 @@ describe('TransactionListComponent', () => {
       abortTransaction: of({}),
       editTransaction: of({}),
       validateTransaction: of({}),
+      validate: of({}),
       search: of([transaction]),
     },
   );
@@ -175,7 +176,7 @@ describe('TransactionListComponent', () => {
   it('should validate Transaction', () => {
     const transactionService = TestBed.inject(TransactionsService);
     component.validateTransaction(transaction);
-    expect(transactionService.validateTransaction).toHaveBeenCalled();
+    expect(transactionService.validate).toHaveBeenCalled();
   });
 
   it('should abort Transaction', () => {

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
@@ -133,7 +133,7 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
   }
 
   canSend(transaction: Transaction): boolean {
-    const allowedStatus = [TransactionStatus.READY, TransactionStatus.VALIDATED];
+    const allowedStatus = [TransactionStatus.VALIDATED];
     const isAllowedStatus = allowedStatus.includes(transaction.status);
 
     return this.hasSendTransactionRole && !this.isAutomaticIngest && isAllowedStatus;

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
@@ -36,12 +36,11 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, interval, of, takeWhile } from 'rxjs';
+import { BehaviorSubject, finalize } from 'rxjs';
 import { Direction, InfiniteScrollTable, SnackBarService, StartupService, Transaction, TransactionStatus } from 'vitamui-library';
 import { TransactionsService } from '../transactions.service';
 import { ArchiveCollectService } from '../../archive-search-collect/archive-collect.service';
 import { ProjectsService } from '../../projects/projects.service';
-import { catchError, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-transaction-list',
@@ -60,7 +59,6 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
   hasCloseTransactionRole = false;
   hasDownloadTransactionRole = false;
   isAutomaticIngest = false;
-  disabledSendTransactions = new Set<string>();
 
   constructor(
     private transactionService: TransactionsService,
@@ -114,36 +112,31 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
   }
 
   validateTransaction(transaction: Transaction) {
-    this.transactionService.validateTransaction(transaction.id).subscribe(
-      () => {
-        transaction.status = TransactionStatus.READY;
-        if (this.isAutomaticIngest) {
-          this.disabledSendTransactions.add(transaction.id);
-          // Lancer un polling pour suivre le statut
-          interval(5000)
-            .pipe(
-              switchMap(() => this.transactionService.getTransactionById(transaction.id).pipe(catchError(() => of(null)))),
-              takeWhile(
-                (updatedTransaction: Transaction | null) =>
-                  updatedTransaction != null && updatedTransaction.status !== TransactionStatus.SENDING,
-                true,
-              ),
-            )
-            .subscribe((updatedTransaction: Transaction | null) => {
-              if (updatedTransaction) {
-                transaction.status = updatedTransaction.status;
-              }
-            });
-        }
-        this.snackBarService.open({
-          message: 'COLLECT.VALIDATE_TRANSACTION_VALIDATED',
-          duration: 10_000,
-        });
-      },
-      () => {
-        transaction.status = TransactionStatus.KO;
-      },
-    );
+    this.transactionService
+      .validate(transaction, { isAutomaticIngest: this.isAutomaticIngest })
+      .pipe(
+        finalize(() => {
+          this.snackBarService.open({
+            message: 'COLLECT.VALIDATE_TRANSACTION_VALIDATED',
+            duration: 10_000,
+          });
+        }),
+      )
+      .subscribe({
+        next: (next) => {
+          transaction.status = next.status;
+        },
+        error: () => {
+          transaction.status = TransactionStatus.KO;
+        },
+      });
+  }
+
+  canSend(transaction: Transaction): boolean {
+    const allowedStatus = [TransactionStatus.READY, TransactionStatus.VALIDATED];
+    const isAllowedStatus = allowedStatus.includes(transaction.status);
+
+    return this.hasSendTransactionRole && !this.isAutomaticIngest && isAllowedStatus;
   }
 
   abortTransaction(transaction: Transaction) {
@@ -182,14 +175,6 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
 
   transactionIsOpen(transaction: Transaction): boolean {
     return TransactionStatus.OPEN === transaction.status;
-  }
-
-  transactionIsReady(transaction: Transaction): boolean {
-    return TransactionStatus.READY === transaction.status;
-  }
-
-  transactionIsValidated(transaction: Transaction): boolean {
-    return TransactionStatus.VALIDATED === transaction.status;
   }
 
   transactionIsEditable(transaction: Transaction): boolean {

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transactions.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transactions.service.ts
@@ -35,8 +35,8 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { BehaviorSubject, Observable, switchMap } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { saveAs } from 'file-saver-es';
 import {
   DEFAULT_PAGE_SIZE,
@@ -47,9 +47,11 @@ import {
   SearchService,
   SnackBarService,
   Transaction,
+  TransactionStatus,
 } from 'vitamui-library';
 import { ProjectsApiService } from '../core/api/project-api.service';
 import { TransactionApiService } from '../core/api/transaction-api.service';
+import { pollUntil } from './polling';
 
 @Injectable({
   providedIn: 'root',
@@ -84,6 +86,25 @@ export class TransactionsService extends SearchService<Transaction> {
 
   public getTransactionById(transactionById: string) {
     return this.transactionApiService.getTransactionById(transactionById);
+  }
+
+  public validate(transaction: Transaction, context = { isAutomaticIngest: false }): Observable<Transaction> {
+    return this.validateTransaction(transaction.id).pipe(
+      switchMap(() => {
+        const status$ = this.getTransactionById(transaction.id).pipe(map((next) => next.status));
+        const isValidated = (status: TransactionStatus) => {
+          return status === TransactionStatus.VALIDATED;
+        };
+        const isNotSending = (status: TransactionStatus) => {
+          return status !== TransactionStatus.SENDING;
+        };
+        const isFinalState = context.isAutomaticIngest ? isNotSending : isValidated;
+        const pollingOptions = { period: 3000, maxRetries: 30, until: isFinalState };
+
+        return pollUntil(status$, pollingOptions);
+      }),
+      map((status) => ({ ...transaction, status: status })),
+    );
   }
 
   validateTransaction(id: string) {


### PR DESCRIPTION
Corrige les problèmes suivants:

* Scrutation complète du status de transaction post validation.
* Retrait du status READY des status attendus pour envoyer vers le SAE.

**Pourquoi en deux commits ?**
Car le ticket initial (15081) semble demander READY et VALIDATED  pour activer l'action de versement.
Celà n'est pas cohérent car dans le cas d'une validation longue pour cause de trop de units la transaction passe à READY tant que le SIP n'est pas généré pour terminer sur VALIDATED.
A moins que la génération du SIP et le versement soient décorrélés, il ne devrait pas être possible de soumettre au SEA tant que le SIP n'est pas construit.
