### PR TITLE
bugs #13604 fix(pastis): hide error popup when AUP creation fails

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/archival-profile-unit-api.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/archival-profile-unit-api.service.ts
@@ -71,7 +71,10 @@ export class ArchivalProfileUnitApiService extends PaginatedHttpClient<ArchivalP
     return super.patch(partialAgency, headers);
   }
 
-  create(archivalUnitProfile: ArchivalProfileUnit, headers?: HttpHeaders): Observable<ArchivalProfileUnit> {
+  create(
+    archivalUnitProfile: ArchivalProfileUnit,
+    headers = new HttpHeaders({ [SKIP_ERROR_NOTIFICATION]: 1 }),
+  ): Observable<ArchivalProfileUnit> {
     return this.http.post<ArchivalProfileUnit>(this.apiUrl, archivalUnitProfile, { headers });
   }
 

--- a/ui/ui-frontend/projects/pastis/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/pastis/src/assets/i18n/en.json
@@ -463,7 +463,7 @@
     "ASK_SUBROGATION": "The user {{ user }} requests a temporary access to your rights",
     "ACCEPT_SUBROGATION": "Accept",
     "DECLINE_SUBROGATION": "Decline",
-    "ERROR_WITH_LOGBOOK_OPERATION_ID": "See in logbook operation: ({content})",
+    "ERROR_WITH_LOGBOOK_OPERATION_ID": "See in logbook operation: ({{content}})",
     "ERROR_WITH_LOGBOOK_OPERATION_ID_BUTTON": "Go to logbook operation"
   },
   "ERROR_DIALOG": {

--- a/ui/ui-frontend/projects/pastis/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/pastis/src/assets/i18n/fr.json
@@ -463,7 +463,7 @@
     "ASK_SUBROGATION": "L'utilisateur {{ user }} demande un accès temporaire à vos droits",
     "ACCEPT_SUBROGATION": "Accepter",
     "DECLINE_SUBROGATION": "Refuser",
-    "ERROR_WITH_LOGBOOK_OPERATION_ID": "Voir dans le journal des opérations : ({content})",
+    "ERROR_WITH_LOGBOOK_OPERATION_ID": "Voir dans le journal des opérations : ({{content}})",
     "ERROR_WITH_LOGBOOK_OPERATION_ID_BUTTON": "Aller au journal des opérations"
   },
   "ERROR_DIALOG": {


### PR DESCRIPTION
Corrige les problèmes suivants:

* Perte du contenu de l'erreur suite à la mise à jour globale des snackbars.
* N’affiche plus la popup d'erreur 500 quand la création de PUA échoue.