### PR TITLE
CP V8.1 - Bug #15340: Resolving VitamUI services on ip_service when co-located with Consul servers.

### DIFF
--- a/deployment/roles/vitamui/templates/api-gateway/application.yml.j2
+++ b/deployment/roles/vitamui/templates/api-gateway/application.yml.j2
@@ -38,6 +38,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search/application.yml.j2
@@ -7,6 +7,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -6,6 +6,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
 

--- a/deployment/roles/vitamui/templates/collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect/application.yml.j2
@@ -7,6 +7,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/iam/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam/application.yml.j2
@@ -7,6 +7,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest/application.yml.j2
@@ -7,6 +7,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/pastis/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis/application.yml.j2
@@ -21,6 +21,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential/application.yml.j2
@@ -7,6 +7,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}

--- a/deployment/roles/vitamui/templates/security/application.yml.j2
+++ b/deployment/roles/vitamui/templates/security/application.yml.j2
@@ -7,6 +7,7 @@ spring:
       discovery:
         serviceName: vitamui-{{ vitamui_struct.vitamui_component }}
         preferIpAddress: true
+        ipAddress: ${server.address}
         healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
         tags: {{ consul_tags }}
         instanceId: {{ vitamui_struct.vitamui_component }}-${server.port}-${spring.cloud.client.hostname}


### PR DESCRIPTION
## Description

> Cherry-Picked from #3251

Lors du cumul des conditions de déploiement suivantes:
* 2 réseaux distincts (ip_service != ip_admin).
* Déploiement d'un cluster consul sur la zone VitamUI.
* Colocalisation de services VitamUI sur les mêmes instances que celles du cluster consul.

Alors, la résolution DNS de ces services va se faire sur l'ip_admin au lieu de l'ip_service.

Ainsi, la correction proposée force l'enregistrement du service auprès de consul pour s'appuyer sur l'ip du server.address de spring.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam