### PR TITLE
bugs #15192 fix(collect): check transaction existence

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -1249,6 +1249,8 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   }
 
   canSend(transaction: Transaction): boolean {
+    if (!transaction) return false;
+
     const allowedStatus = [TransactionStatus.VALIDATED];
     const isAllowedStatus = allowedStatus.includes(transaction.status);
 


### PR DESCRIPTION
Corrige la méthode canSend du composant archives de collect.

La transaction n'existe pas au moment de l'initialisation du composant.

