### PR TITLE
Bug #15278 : Filters for virtual positions

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.spec.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.spec.ts
@@ -396,7 +396,7 @@ describe('ArchiveSearchComponent', () => {
       const virtualNode1: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someRealParentId',
         realParentTitle: 'someRealParentTitle',
         isVirtual: true,
@@ -406,7 +406,7 @@ describe('ArchiveSearchComponent', () => {
       const virtualNode2: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someOtherRealParentId',
         realParentTitle: 'someOtherRealParentTitle',
         isVirtual: true,
@@ -422,7 +422,7 @@ describe('ArchiveSearchComponent', () => {
       const virtualCriteria = component.searchCriterias.get('VIRTUAL');
       expect(virtualCriteria?.values?.length).toEqual(2);
 
-      const virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'virtualPath');
+      const virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'VIRTUAL');
 
       expect(virtualValues.map((o) => o.value.virtualNodeRealParentId)).toEqual(
         arrayWithExactContents(['someRealParentId', 'someOtherRealParentId']),
@@ -441,7 +441,7 @@ describe('ArchiveSearchComponent', () => {
       let virtualNode1: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someRealParentId',
         realParentTitle: 'someRealParentTitle',
         isVirtual: true,
@@ -451,7 +451,7 @@ describe('ArchiveSearchComponent', () => {
       let virtualNode2: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someOtherRealParentId',
         realParentTitle: 'someOtherRealParentTitle',
         isVirtual: true,
@@ -467,7 +467,7 @@ describe('ArchiveSearchComponent', () => {
       let virtualCriteria = component.searchCriterias.get('VIRTUAL');
       expect(virtualCriteria?.values?.length).toEqual(2);
 
-      let virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'virtualPath');
+      let virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'VIRTUAL');
 
       virtualNode1.checked = false;
       archiveSharedDataService.emitNode(virtualNode1);

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -254,11 +254,12 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
             this.removeCriteria(
               'VIRTUAL',
               {
-                id: node.virtualPath,
-                value: '/' + node.virtualPath,
+                id: 'VIRTUAL',
+                value: `/${node.virtualPath}`,
                 virtualNodeRealParentId: node.realParentId,
+                virtualNodeRealParentTitle: node.realParentTitle,
               },
-              false,
+              true,
             );
           } else {
             this.removeCriteria('NODE', { id: NODES, value: node.id }, true);
@@ -282,18 +283,18 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
             this.addCriteria(
               'VIRTUAL',
               {
-                id: node.virtualPath,
-                value: '/' + node.virtualPath,
+                id: 'VIRTUAL',
+                value: `/${node.virtualPath}`,
                 virtualNodeRealParentId: node.realParentId,
                 virtualNodeRealParentTitle: node.realParentTitle,
               },
-              node.title,
+              `/${node.virtualPath}`,
               true,
               CriteriaOperator.EQ,
               SearchCriteriaTypeEnum.FIELDS,
               false,
               CriteriaDataType.STRING,
-              false,
+              true,
             );
           } else {
             this.addCriteria(

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
@@ -61,7 +61,11 @@ export class CriteriaSearchComponent {
     const builder = this.queryParamsService.builder();
     criteriaValues.forEach((criteriaValue) => {
       //fixme manage navigation
-      builder.removeQueryParam(criteriaValue.id, criteriaValue.value);
+      let value =
+        criteriaValue.id === 'VIRTUAL'
+          ? criteriaValue.value + '/' + criteriaValue.virtualNodeRealParentId + '/' + criteriaValue.virtualNodeRealParentTitle
+          : criteriaValue.value;
+      builder.removeQueryParam(criteriaValue.id, value);
       this.criteriaRemoveEvent.emit({ keyElt: this.criteriaKey, valueElt: criteriaValue });
     });
     builder.navigate();

--- a/ui/ui-frontend/projects/archive-search/src/app/core/archive-shared-data.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/core/archive-shared-data.service.ts
@@ -221,7 +221,20 @@ export class ArchiveSharedDataService {
   addSimpleSearchCriteriaSubjects(searchCriteriaList: SearchCriteriaAddAction[]) {
     const builder = this.queryParamsService.builder();
     searchCriteriaList.forEach((searchCriteria) => {
-      builder.addQueryParam(searchCriteria.valueElt.id, searchCriteria.valueElt.value);
+      if (searchCriteria.valueElt.id === 'VIRTUAL') {
+        const paramsLength = searchCriteria.valueElt.value.split('/').length;
+        if (
+          searchCriteria.valueElt.value.split('/')[paramsLength] === undefined &&
+          searchCriteria.valueElt.value.split('/')[paramsLength + 1] === undefined
+        ) {
+          builder.addQueryParam(
+            searchCriteria.valueElt.id,
+            `${searchCriteria.valueElt.value}/${searchCriteria.valueElt.virtualNodeRealParentId}/${searchCriteria.valueElt.virtualNodeRealParentTitle}`,
+          );
+        }
+      } else {
+        builder.addQueryParam(searchCriteria.valueElt.id, searchCriteria.valueElt.value);
+      }
       this.simpleSearchCriteriaAddSubject.next(searchCriteria);
     });
     builder.navigate();
@@ -285,7 +298,11 @@ export class ArchiveSharedDataService {
 
   sendRemoveFromChildSearchCriteriaAction(searchCriteriaAction: SearchCriteriaRemoveAction) {
     const builder = this.queryParamsService.builder();
-    builder.removeQueryParam(searchCriteriaAction.valueElt.id, searchCriteriaAction.valueElt.value);
+    let valueToRemove =
+      searchCriteriaAction.valueElt.id !== 'VIRTUAL'
+        ? searchCriteriaAction.valueElt.value
+        : `${searchCriteriaAction.valueElt.value}/${searchCriteriaAction.valueElt.virtualNodeRealParentId}/${searchCriteriaAction.valueElt.virtualNodeRealParentTitle}`;
+    builder.removeQueryParam(searchCriteriaAction.valueElt.id, valueToRemove);
     this.searchCriteriaRemoveFromChildSubject.next(searchCriteriaAction);
     builder.navigate();
   }

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.spec.ts
@@ -327,7 +327,7 @@ describe('ArchiveSearchCollectComponent', () => {
       const virtualNode1: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someRealParentId',
         realParentTitle: 'someRealParentTitle',
         isVirtual: true,
@@ -337,7 +337,7 @@ describe('ArchiveSearchCollectComponent', () => {
       const virtualNode2: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someOtherRealParentId',
         realParentTitle: 'someOtherRealParentTitle',
         isVirtual: true,
@@ -353,7 +353,7 @@ describe('ArchiveSearchCollectComponent', () => {
       const virtualCriteria = component.searchCriterias.get('VIRTUAL');
       expect(virtualCriteria?.values?.length).toEqual(2);
 
-      const virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'virtualPath');
+      const virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'VIRTUAL');
       expect(virtualValues.map((o) => o.value.virtualNodeRealParentId)).toEqual(
         arrayWithExactContents(['someRealParentId', 'someOtherRealParentId']),
       );
@@ -371,7 +371,7 @@ describe('ArchiveSearchCollectComponent', () => {
       let virtualNode1: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someRealParentId',
         realParentTitle: 'someRealParentTitle',
         isVirtual: true,
@@ -381,7 +381,7 @@ describe('ArchiveSearchCollectComponent', () => {
       let virtualNode2: NodeData = {
         checked: true,
         virtualPath: 'virtualPath',
-        id: 'virtualPath',
+        id: 'VIRTUAL',
         realParentId: 'someOtherRealParentId',
         realParentTitle: 'someOtherRealParentTitle',
         isVirtual: true,
@@ -397,7 +397,7 @@ describe('ArchiveSearchCollectComponent', () => {
       let virtualCriteria = component.searchCriterias.get('VIRTUAL');
       expect(virtualCriteria?.values?.length).toEqual(2);
 
-      let virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'virtualPath');
+      let virtualValues = virtualCriteria.values.filter((value) => value?.value?.id === 'VIRTUAL');
 
       virtualNode1.checked = false;
       archiveSharedDataService.emitNode(virtualNode1);

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -233,11 +233,12 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
             this.removeCriteria(
               'VIRTUAL',
               {
-                id: node.virtualPath,
-                value: '/' + node.virtualPath,
+                id: 'VIRTUAL',
+                value: `/${node.virtualPath}`,
                 virtualNodeRealParentId: node.realParentId,
+                virtualNodeRealParentTitle: node.realParentTitle,
               },
-              false,
+              true,
             );
           } else {
             this.removeCriteria('NODE', { id: NODES, value: node.id }, true);
@@ -263,18 +264,18 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
           this.addCriteria(
             'VIRTUAL',
             {
-              id: node.virtualPath,
-              value: '/' + node.virtualPath,
+              id: 'VIRTUAL',
+              value: `/${node.virtualPath}`,
               virtualNodeRealParentId: node.realParentId,
               virtualNodeRealParentTitle: node.realParentTitle,
             },
-            node.title,
+            `/${node.virtualPath}`,
             true,
             CriteriaOperator.EQ,
             SearchCriteriaTypeEnum.FIELDS,
             false,
             CriteriaDataType.STRING,
-            false,
+            true,
           );
         } else {
           this.archiveHelperService.addCriteria(

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/criteria-search/criteria-search.component.ts
@@ -62,7 +62,11 @@ export class CriteriaSearchComponent {
   private removeCriteriaList(criteriaValues: CriteriaValue[]) {
     const builder = this.queryParamsService.builder();
     criteriaValues.forEach((criteriaValue) => {
-      builder.removeQueryParam(criteriaValue.id, criteriaValue.value);
+      let value =
+        criteriaValue.id === 'VIRTUAL'
+          ? criteriaValue.value + '/' + criteriaValue.virtualNodeRealParentId + '/' + criteriaValue.virtualNodeRealParentTitle
+          : criteriaValue.value;
+      builder.removeQueryParam(criteriaValue.id, value);
       this.criteriaRemoveEvent.emit({ keyElt: this.criteriaKey, valueElt: criteriaValue });
     });
     builder.navigate();

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/archive-shared-data.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/archive-shared-data.service.ts
@@ -216,7 +216,20 @@ export class ArchiveSharedDataService {
   addSimpleSearchCriteriaSubjects(searchCriteriaList: SearchCriteriaAddAction[]) {
     const builder = this.queryParamsService.builder();
     searchCriteriaList.forEach((searchCriteria) => {
-      builder.addQueryParam(searchCriteria.valueElt.id, searchCriteria.valueElt.value);
+      if (searchCriteria.valueElt.id === 'VIRTUAL') {
+        const paramsLength = searchCriteria.valueElt.value.split('/').length;
+        if (
+          searchCriteria.valueElt.value.split('/')[paramsLength] === undefined &&
+          searchCriteria.valueElt.value.split('/')[paramsLength + 1] === undefined
+        ) {
+          builder.addQueryParam(
+            searchCriteria.valueElt.id,
+            `${searchCriteria.valueElt.value}/${searchCriteria.valueElt.virtualNodeRealParentId}/${searchCriteria.valueElt.virtualNodeRealParentTitle}`,
+          );
+        }
+      } else {
+        builder.addQueryParam(searchCriteria.valueElt.id, searchCriteria.valueElt.value);
+      }
       this.simpleSearchCriteriaAddSubject.next(searchCriteria);
     });
     builder.navigate();
@@ -252,7 +265,11 @@ export class ArchiveSharedDataService {
 
   sendRemoveFromChildSearchCriteriaAction(searchCriteriaAction: SearchCriteriaRemoveAction) {
     const builder = this.queryParamsService.builder();
-    builder.removeQueryParam(searchCriteriaAction.valueElt.id, searchCriteriaAction.valueElt.value);
+    let valueToRemove =
+      searchCriteriaAction.valueElt.id !== 'VIRTUAL'
+        ? searchCriteriaAction.valueElt.value
+        : `${searchCriteriaAction.valueElt.value}/${searchCriteriaAction.valueElt.virtualNodeRealParentId}/${searchCriteriaAction.valueElt.virtualNodeRealParentTitle}`;
+    builder.removeQueryParam(searchCriteriaAction.valueElt.id, valueToRemove);
     this.searchCriteriaRemoveFromChildSubject.next(searchCriteriaAction);
     builder.navigate();
   }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/criteria/search-criteria-configs.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/criteria/search-criteria-configs.ts
@@ -139,6 +139,10 @@ const searchCriteriaConfigs: { [key: string]: Partial<SearchCriteriaAddAction> }
     keyElt: 'ORPHANS_NODE',
     keyTranslated: true,
   },
+  VIRTUAL: {
+    keyElt: 'VIRTUAL',
+    keyTranslated: true,
+  },
   NODES: {
     keyElt: 'NODE',
     keyTranslated: true,

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/criteria/search-criteria.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/criteria/search-criteria.service.ts
@@ -158,9 +158,28 @@ export class SearchCriteriaService {
         const beginDate = this.getBeginDate(fragment, key);
         const endDate = this.getEndDate(fragment, key);
         const dataType = this.getDataType(key);
+        const titleForVirtual =
+          key === 'VIRTUAL'
+            ? this.setParamForVirtualPositions(fragment, fragment.split('/').length - 1)
+              ? this.setParamForVirtualPositions(fragment, fragment.split('/').length - 1)
+              : null
+            : null;
+        const idForVirtual =
+          key === 'VIRTUAL'
+            ? this.setParamForVirtualPositions(fragment, fragment.split('/').length - 2)
+              ? this.setParamForVirtualPositions(fragment, fragment.split('/').length - 2)
+              : null
+            : null;
 
         const defaultCriteriaConfig: Partial<SearchCriteriaAddAction> = {
-          valueElt: { id: key, value: formattedValue, beginInterval: beginDate, endInterval: endDate },
+          valueElt: {
+            id: key,
+            value: key === 'VIRTUAL' ? this.setValueForVirtualPositions(fragment) : formattedValue,
+            beginInterval: beginDate,
+            endInterval: endDate,
+            virtualNodeRealParentTitle: key === 'VIRTUAL' ? titleForVirtual : null,
+            virtualNodeRealParentId: key === 'VIRTUAL' ? idForVirtual : null,
+          },
           labelElt: formattedValue,
           keyTranslated: true,
           operator: operator,
@@ -179,6 +198,19 @@ export class SearchCriteriaService {
         } as SearchCriteriaAddAction;
       }),
     );
+  }
+
+  private setValueForVirtualPositions(fragment: string) {
+    const fragments = fragment.split('/');
+    let acc = '';
+    for (let i = 1; i < fragments.length - 2; i++) {
+      acc += '/' + fragments[i];
+    }
+    return acc;
+  }
+
+  private setParamForVirtualPositions(fragment: string, pos: number) {
+    return fragment.split('/')[pos];
   }
 
   private getCategory(key: string) {


### PR DESCRIPTION
## Description

Adaptation des filtres de recherche sur Archive-Search et Collecte pour les positions virtuelles.
Etant donné que les positions virtuelles comportent plus de données que les autres positions, j'ai enregistré le nom de la position, l'id et le nom du parent afin de gérer les doublons
