### PR TITLE
Bug #15305 [JDO] – The operation displays only two events after clicking the “Refresh” button.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-operation-detail/logbook-operation-detail.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-operation-detail/logbook-operation-detail.component.ts
@@ -96,11 +96,6 @@ export class LogbookOperationDetailComponent implements OnInit, OnChanges, OnDes
 
   ngOnInit() {
     this.externalParameterService.getUserExternalParameters().subscribe((parameters) => this.setAccessContractId(parameters));
-    this.subscriptions.add(
-      this.logbookDownloadService.logbookOperationsReloaded.subscribe((logbookOperations) =>
-        this.setLogbookOperationIfIfHasBeenReloaded(logbookOperations),
-      ),
-    );
     this.refreshLogbookOperation();
   }
 
@@ -110,15 +105,6 @@ export class LogbookOperationDetailComponent implements OnInit, OnChanges, OnDes
 
   ngOnChanges() {
     this.refreshLogbookOperation();
-  }
-
-  private setLogbookOperationIfIfHasBeenReloaded(logbookOperations: IEvent[]) {
-    const logbookOperationUpdated = logbookOperations.find((e) => e.id === this.eventId);
-    if (logbookOperationUpdated) {
-      this.event = logbookOperationUpdated;
-      this.updateDownloadButton();
-      this.updateReportFilename();
-    }
   }
 
   private setAccessContractId(userExternalParameters: Map<string, string>) {
@@ -187,7 +173,9 @@ export class LogbookOperationDetailComponent implements OnInit, OnChanges, OnDes
     }
     this.setAccessContractLogbookIdentifier();
     this.logbookService.getOperationById(this.eventId, this.tenantIdentifier, this.accessContractLogbookIdentifier).subscribe((event) => {
-      this.logbookDownloadService.logbookOperationsReloaded.next([event]);
+      // Assign directly instead of emitting through the Subject
+      // This prevents the detail panel from receiving truncated operations from the list
+      this.setEvent(event);
     });
   }
 
@@ -196,6 +184,12 @@ export class LogbookOperationDetailComponent implements OnInit, OnChanges, OnDes
       return false;
     }
     return this.event.typeProc === LogbookOperationTypeProc.INGEST_TEST && this.ingestIsFinish();
+  }
+
+  private setEvent(event: IEvent): void {
+    this.event = event;
+    this.updateDownloadButton();
+    this.updateReportFilename();
   }
 
   private ingestIsFinish(): boolean {


### PR DESCRIPTION
Après rafraîchissement, seules deux events s’affichent, même si on reclique sur la même opération, l’ensemble des events associés à l’opération doit être réaffiché après un rafraîchissement, sans nécessiter de fermeture du panneau latéral.