### PR TITLE
Bug #15304 [Funds Register] – Incorrect display of the "Operation Date" field.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-interval-date-picker/vitamui-interval-date-picker.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/vitamui-interval-date-picker/vitamui-interval-date-picker.component.html
@@ -5,7 +5,7 @@
         <span>{{ label }} :</span>
       </div>
 
-      <div class="col-2">
+      <div class="col-3">
         <vitamui-datepicker
           [label]="'LOGBOOK_OPERATION_PAGE.OPERATION_DATE' | translate"
           formControlName="dateMin"
@@ -25,7 +25,7 @@
         </span>
       </div>
 
-      <div class="col-2" *ngIf="showDateMax">
+      <div class="col-3" *ngIf="showDateMax">
         <vitamui-datepicker
           [label]="'LOGBOOK_OPERATION_PAGE.OPERATION_DATE' | translate"
           formControlName="dateMax"


### PR DESCRIPTION
FIx le problème : le texte "Date d’opération" se superpose à l’icône du calendrier.