### PR TITLE
Bug #13933 [Pastis] - Missing EXT suffix in the Metadata Side Panel.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/file.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/file.service.ts
@@ -167,6 +167,12 @@ export class FileService implements OnDestroy {
 
       const nodeName = node.name === 'xml:id' ? 'id' : node.name;
       node.sedaData = parent?.sedaData ? this.sedaService.findSedaNode(nodeName, parent.sedaData) : this.sedaService.findSedaNode(nodeName);
+
+      // Copy external flag from sedaData to fileNode
+      if (node.sedaData && node.sedaData.external !== undefined) {
+        node.external = node.sedaData.external;
+      }
+
       this.linkFileNodeToSedaData(node, node.children);
     });
   }


### PR DESCRIPTION
Lors de l'import d'un profil documentaire de type RNg dans l'application "Profils Documentaires", le suffixe des métadonnées externes ajoutées manuellement n'est pas affiché dans le panneau latéral des métadonnées.