### PR TITLE
CP V8.1 - Bug #13933 [Pastis] - Missing EXT suffix in the Metadata Side Panel.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/core/services/file.service.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/core/services/file.service.ts
@@ -167,6 +167,12 @@ export class FileService implements OnDestroy {
 
       const nodeName = node.name === 'xml:id' ? 'id' : node.name;
       node.sedaData = parent?.sedaData ? this.sedaService.findSedaNode(nodeName, parent.sedaData) : this.sedaService.findSedaNode(nodeName);
+
+      // Copy external flag from sedaData to fileNode
+      if (node.sedaData && node.sedaData.external !== undefined) {
+        node.external = node.sedaData.external;
+      }
+
       this.linkFileNodeToSedaData(node, node.children);
     });
   }


### PR DESCRIPTION
CP V8.1 - Bug #13933 [Pastis] - Missing EXT suffix in the Metadata Side Panel.

> Cherry-Picked from #3278
