### PR TITLE
Bug #15350 [Collect] - Field incorrectly marked as mandatory in the transfer project creation process.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
@@ -394,7 +394,6 @@
             <vitamui-input
               class="w-100"
               *ngIf="!connectedToLocalEasWithCurrentTenant"
-              [required]="connectedToArchivingSystem"
               [placeholder]="'COLLECT.ARCHIVAL_UNIT_IDENTIFIER' | translate"
               formControlName="unitUp"
             >


### PR DESCRIPTION
Lorsque je créé un projet de versement manuel connecté à un SAE distant, alors à l'étape 6 du parcours j'ai un champ de saisie libre "identifiant de l'unité archivistique". Ce champs n'est pas obligatoire mais le front le présente avec un astérisque et un cadre rouge indiqué "champs obligatoire".