### PR TITLE
CP V8.1 - Bug #15175 : Fix search with dates from other criterias

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/simple-criteria-search/simple-criteria-search.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/simple-criteria-search/simple-criteria-search.component.html
@@ -158,6 +158,7 @@
                 [label]="getCriteriaName(otherCriteria)"
                 [formControlName]="otherCriteria.Path"
                 class="w-100"
+                [withTimeZone]="['StartDate', 'EndDate'].includes(otherCriteria.Path)"
               ></vitamui-common-multiple-options-datepicker>
             } @else {
               <!--FIXME: what do we do with OBJECT type?-->

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/simple-criteria-search/simple-criteria-search.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/simple-criteria-search/simple-criteria-search.component.html
@@ -146,6 +146,7 @@
                 outputType="Date"
                 format="yyyy-MM-dd"
                 class="w-100"
+                [withTimeZone]="['StartDate', 'EndDate'].includes(otherCriteria.Path)"
               ></vitamui-common-multiple-options-datepicker>
             } @else {
               <!--FIXME: what do we do with OBJECT type?-->


### PR DESCRIPTION
## Description

Suite à ma correction sur #3292, nouvelle correction pour les dates de début et de fin, main provenant des autres critères (`StartDate` et `EndDate` ont le même nom que ce soit dans les autres critères et les critères de dates classiques)
