### PR TITLE
Bug #15485: add missing translation for operation events after reclassification

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
@@ -566,6 +566,7 @@
   },
   "EVENT_TYPE_LABEL": {
     "RECLASSIFICATION_PREPARATION_CHECK_HOLD_RULES": "Checking the blocking of reclassification of archival units by hold rules.",
+    "RECLASSIFICATION_PREPARATION_CHECK_HOLD_RULES.OK": "Success of checking the blocking of reclassification of archival units by hold rules.",
     "EXPORT_CHECK_RESOURCE_AVAILABILITY": "Checking the availability of binary objects on the storage offer",
     "EXPORT_CHECK_RESOURCE_AVAILABILITY.OK": "Success of checking the availability of binary objects on the storage offer",
     "CHECK_ATTACHEMENT": "Verification of the attachment between existing and new objects, groups of objects and archival units",
@@ -580,6 +581,7 @@
     "STP_COMPUTE_INHERITED_RULES.STARTED": "Process for calculating the applicable management rules",
     "STP_COMPUTE_INHERITED_RULES": "Process for calculating the applicable management rules",
     "COMPUTE_INHERITED_RULES_ACTION": "Calculation of applicable management rules",
+    "COMPUTE_INHERITED_RULES_ACTION.OK": "Success of the calculation of applicable management rules",
     "STP_COMPUTE_INHERITED_RULES_FINALIZATION.STARTED": "Process for finalizing the calculation of the applicable management rules",
     "STP_COMPUTE_INHERITED_RULES_FINALIZATION": "Finalization of the calculation of the applicable management rules",
     "CHECK_OBJECT_SIZE": "File size check",

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
@@ -566,6 +566,7 @@
   },
   "EVENT_TYPE_LABEL": {
     "RECLASSIFICATION_PREPARATION_CHECK_HOLD_RULES": "Contrôle du blocage de reclassification des unités archivistiques par des règles de gel.",
+    "RECLASSIFICATION_PREPARATION_CHECK_HOLD_RULES.OK": "Succès du contrôle du blocage de reclassification des unités archivistiques par des règles de gel.",
     "EXPORT_CHECK_RESOURCE_AVAILABILITY": "Vérification de la disponibilité des objets binaires sur l'offre de stockage",
     "EXPORT_CHECK_RESOURCE_AVAILABILITY.OK": "Succès de la vérification de la disponibilité des objets binaires sur l'offre de stockage",
     "CHECK_ATTACHEMENT": "Vérification du rattachement entre objets, groupes d'objets et unités archivistiques existantes et les nouveaux.",
@@ -580,6 +581,7 @@
     "STP_COMPUTE_INHERITED_RULES.STARTED": "Début du processus de calcul des règles de gestion applicables",
     "STP_COMPUTE_INHERITED_RULES": "Processus de calcul des règles de gestion applicables",
     "COMPUTE_INHERITED_RULES_ACTION": "Calcul des règles de gestion applicables",
+    "COMPUTE_INHERITED_RULES_ACTION.OK": "Succès du calcul des règles de gestion applicables",
     "STP_COMPUTE_INHERITED_RULES_FINALIZATION.STARTED": "Début du processus de finalisation du calcul des règles de gestion applicables",
     "STP_COMPUTE_INHERITED_RULES_FINALIZATION": "Processus de finalisation du calcul des règles de gestion applicables",
     "CHECK_OBJECT_SIZE": "Vérification de la taille des fichiers",


### PR DESCRIPTION
Clé non traduite dans le journal des opérations apres reclassement et calcul de l'héritage