### PR TITLE
Bug #15498 [Pastis] Pressing Enter triggers a step rollback and generates “MISSING TITLE AT INDEX 2”.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/user-actions/save-profile-popup/save-profile-popup.component.html
+++ b/ui/ui-frontend/projects/pastis/src/app/user-actions/save-profile-popup/save-profile-popup.component.html
@@ -9,7 +9,7 @@
   ]"
 ></vitamui-dialog-header>
 
-<form [formGroup]="noticeForm">
+<form [formGroup]="noticeForm" (keydown.enter)="$event.preventDefault()">
   <vitamui-stepper #stepper [(selectedIndex)]="stepIndex">
     <cdk-step>
       <mat-dialog-content>


### PR DESCRIPTION
à l’étape d’enregistrement dans le SAE, lorsque l’on remplit Intitulé et que l’on appuie sur Entrée, on revient à l’étape précédente.
Si l’on continue pour faire l’enregistrement, on obtient l’erreur “MISSING TITLE AT INDEX 2".