### PR TITLE
Story #15307: Clean code - create profile: deduplicate http requests & hide selects until options are available

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/dip-request-create/dip-request-create.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/dip-request-create/dip-request-create.component.ts
@@ -34,11 +34,11 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Component, Inject, OnDestroy, OnInit, resource, ResourceRef } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, ResourceRef } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
-import { finalize, firstValueFrom, Subscription } from 'rxjs';
+import { finalize, Subscription } from 'rxjs';
 import * as uuid from 'uuid';
 import {
   AgencyService,
@@ -55,6 +55,7 @@ import {
 import { ArchiveService } from '../../../archive.service';
 import { ExportDIPRequestDto, QualifierVersion } from '../../../models/dip.interface';
 import { distinctUntilChanged, map } from 'rxjs/operators';
+import { rxResource } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-dip-request-create',
@@ -86,20 +87,18 @@ export class DipRequestCreateComponent implements OnInit, OnDestroy {
     },
     private snackBarService: SnackBarService,
   ) {
-    this.agencyOptionsResource = resource<VitamuiSelectOptions, void>({
+    this.agencyOptionsResource = rxResource<VitamuiSelectOptions, void>({
       loader: () =>
-        firstValueFrom(
-          this.agencyService.getAll().pipe(
-            map(
-              (agencies) =>
-                ({
-                  options: agencies.map((agency) => ({
-                    key: agency.identifier,
-                    label: `${agency.identifier} - ${agency.name}`,
-                  })),
-                  customSorting: (a, b) => a.key.localeCompare(b.key),
-                }) satisfies VitamuiSelectOptions,
-            ),
+        this.agencyService.getAll().pipe(
+          map(
+            (agencies) =>
+              ({
+                options: agencies.map((agency) => ({
+                  key: agency.identifier,
+                  label: `${agency.identifier} - ${agency.name}`,
+                })),
+                customSorting: (a, b) => a.key.localeCompare(b.key),
+              }) satisfies VitamuiSelectOptions,
           ),
         ),
     });

--- a/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.html
@@ -1,59 +1,62 @@
-<div class="d-flex align-items-center">
-  <div class="gap-2 align-items-stretch">
-    <vitamui-select
-      [options]="applications"
-      [formControl]="appSelect"
-      [placeholder]="'GROUP.PROFILE.MODAL.APP' | translate"
-    ></vitamui-select>
-    <ng-container *ngIf="!tenantIdentifier">
-      <vitamui-select
-        [options]="filteredTenants"
-        [formControl]="tenantSelect"
-        #tenantInput
-        [placeholder]="'GROUP.PROFILE.MODAL.SAFE' | translate"
-      ></vitamui-select>
-    </ng-container>
-    <vitamui-select
-      [options]="filteredProfiles"
-      [formControl]="profileSelect"
-      [placeholder]="'GROUP.PROFILE.MODAL.PROFILE' | translate"
-      #profileInput
-    ></vitamui-select>
+@if (loading) {
+  <div class="vitamui-min-content">
+    <mat-spinner class="vitamui-spinner medium"></mat-spinner>
   </div>
+} @else {
+  <div class="d-flex align-items-center">
+    <div class="gap-2 align-items-stretch">
+      <vitamui-select
+        [options]="applications"
+        [formControl]="appSelect"
+        [placeholder]="'GROUP.PROFILE.MODAL.APP' | translate"
+      ></vitamui-select>
+      <ng-container *ngIf="!tenantIdentifier">
+        <vitamui-select
+          [options]="filteredTenants"
+          [formControl]="tenantSelect"
+          #tenantInput
+          [placeholder]="'GROUP.PROFILE.MODAL.SAFE' | translate"
+        ></vitamui-select>
+      </ng-container>
+      <vitamui-select
+        [options]="filteredProfiles"
+        [formControl]="profileSelect"
+        [placeholder]="'GROUP.PROFILE.MODAL.PROFILE' | translate"
+        #profileInput
+      ></vitamui-select>
+    </div>
 
-  <div>
-    <div class="d-flex flex-column align-items-center justify-content-center">
-      <button type="button" class="btn primary" (click)="add()" [disabled]="!canAddProfile" #addButton>
-        {{ 'COMMON.ADD' | translate }}
-      </button>
-      <button type="button" class="btn link" (click)="resetTree()">
-        <i class="material-icons">replay</i>
-      </button>
+    <div>
+      <div class="d-flex flex-column align-items-center justify-content-center">
+        <button type="button" class="btn primary" (click)="add()" [disabled]="!canAddProfile" #addButton>
+          {{ 'COMMON.ADD' | translate }}
+        </button>
+        <button type="button" class="btn link" (click)="resetTree()">
+          <i class="material-icons">replay</i>
+        </button>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="vitamui-table mt-2 unscrollable">
-  <div class="vitamui-table-head">
-    <div class="col-3">{{ 'GROUP.PROFILE.MODAL.APP' | translate }}</div>
-    <div *ngIf="!tenantIdentifier" class="col-3">{{ 'GROUP.PROFILE.MODAL.SAFE' | translate }}</div>
-    <div class="col-5">{{ 'GROUP.PROFILE.MODAL.PROFILE' | translate }}</div>
-  </div>
-  <div *ngIf="!loading" class="vitamui-table-body">
-    <div class="vitamui-table-rows" *ngFor="let id of profileIds; let index = index">
-      <div class="vitamui-row d-flex align-items-center">
-        <div class="col-3" vitamuiCommonEllipsis>{{ getApplicationFromId(id)?.name }}</div>
-        <div *ngIf="!tenantIdentifier" class="col-3" vitamuiCommonEllipsis>{{ getProfileFromId(id)?.tenantName }}</div>
-        <div class="col-5" vitamuiCommonEllipsis>{{ getProfileFromId(id)?.name }}</div>
-        <div class="d-flex justify-content-end" [ngClass]="{ 'col-1': !tenantIdentifier, 'col-4': tenantIdentifier }">
-          <button class="btn link" (click)="remove(index)">
-            <i class="material-icons">clear</i>
-          </button>
+  <div class="vitamui-table mt-2 unscrollable">
+    <div class="vitamui-table-head">
+      <div class="col-3">{{ 'GROUP.PROFILE.MODAL.APP' | translate }}</div>
+      <div *ngIf="!tenantIdentifier" class="col-3">{{ 'GROUP.PROFILE.MODAL.SAFE' | translate }}</div>
+      <div class="col-5">{{ 'GROUP.PROFILE.MODAL.PROFILE' | translate }}</div>
+    </div>
+    <div *ngIf="!loading" class="vitamui-table-body">
+      <div class="vitamui-table-rows" *ngFor="let id of profileIds; let index = index">
+        <div class="vitamui-row d-flex align-items-center">
+          <div class="col-3" vitamuiCommonEllipsis>{{ getApplicationFromId(id)?.name }}</div>
+          <div *ngIf="!tenantIdentifier" class="col-3" vitamuiCommonEllipsis>{{ getProfileFromId(id)?.tenantName }}</div>
+          <div class="col-5" vitamuiCommonEllipsis>{{ getProfileFromId(id)?.name }}</div>
+          <div class="d-flex justify-content-end" [ngClass]="{ 'col-1': !tenantIdentifier, 'col-4': tenantIdentifier }">
+            <button class="btn link" (click)="remove(index)">
+              <i class="material-icons">clear</i>
+            </button>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div *ngIf="loading" class="vitamui-min-content">
-  <mat-spinner class="vitamui-spinner medium"></mat-spinner>
-</div>
+}

--- a/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.spec.ts
+++ b/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.spec.ts
@@ -141,7 +141,7 @@ const expectedApp = {
 };
 
 @Component({
-  template: ` <app-profiles-form [(ngModel)]="profiles"></app-profiles-form> `,
+  template: ` <app-profiles-form [(ngModel)]="profiles" level=""></app-profiles-form> `,
   standalone: false,
 })
 class TesthostComponent {

--- a/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.ts
@@ -34,13 +34,14 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Component, ElementRef, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, forwardRef, Input, OnInit, SimpleChanges, ViewChild, OnChanges } from '@angular/core';
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
-import { switchMap, tap } from 'rxjs/operators';
+import { map, shareReplay } from 'rxjs/operators';
 import { Application, ApplicationApiService, Option, Profile, ProfileService, SelectComponent } from 'vitamui-library';
 
 import { HttpParams } from '@angular/common/http';
 import { OptionTree } from './option-tree.interface';
+import { zip } from 'rxjs';
 
 export const PROFILES_FORM_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -55,29 +56,17 @@ export const PROFILES_FORM_VALUE_ACCESSOR: any = {
   providers: [PROFILES_FORM_VALUE_ACCESSOR],
   standalone: false,
 })
-export class ProfilesFormComponent implements ControlValueAccessor, OnInit {
+export class ProfilesFormComponent implements ControlValueAccessor, OnInit, OnChanges {
   profiles: Profile[] = [];
   profileIds: string[] = [];
   applicationsDetails: Application[] = [];
 
   public loading = true;
 
-  @Input()
-  showLevel = false;
-
+  @Input() showLevel = false;
   @Input() tenantIdentifier: number;
-
   @Input() applicationNameExclude: string[];
-  @Input()
-  set level(level: string) {
-    this._level = level;
-    this.getProfiles();
-  }
-
-  get level(): string {
-    return this._level;
-  }
-  private _level: string;
+  @Input() level: string;
 
   appSelect = new FormControl(null, [Validators.required]);
   tenantSelect = new FormControl(null, [Validators.required]);
@@ -88,8 +77,13 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit {
   filteredProfiles: Option[] = [];
 
   @ViewChild('tenantInput', { static: false }) tenantInput: SelectComponent;
-  @ViewChild('profileInput', { static: true }) profileInput: SelectComponent;
-  @ViewChild('addButton', { static: true }) addButton: ElementRef;
+  @ViewChild('profileInput', { static: false }) profileInput: SelectComponent;
+  @ViewChild('addButton', { static: false }) addButton: ElementRef;
+
+  private applicationsDetails$ = this.appApiService.getAllByParams(new HttpParams().set('filterApp', 'false')).pipe(
+    map((applications) => applications.APPLICATION_CONFIGURATION),
+    shareReplay(1),
+  );
 
   constructor(
     private rngProfileService: ProfileService,
@@ -97,7 +91,8 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.getProfiles();
+    this.applicationsDetails$.subscribe((applicationsDetails) => (this.applicationsDetails = applicationsDetails));
+
     this.appSelect.valueChanges.subscribe(() => {
       this.filterTenants();
       if (this.filteredTenants.length === 1) {
@@ -105,7 +100,7 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit {
       } else {
         this.tenantSelect.setValue(null);
         if (!this.tenantIdentifier) {
-          setTimeout(() => this.tenantInput.focus(), 0);
+          setTimeout(() => this.tenantInput?.focus(), 0);
         }
       }
       this.toggleSelects();
@@ -121,26 +116,25 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit {
       if (this.filteredProfiles.length === 1) {
         setTimeout(() => this.addButton.nativeElement.focus(), 0);
       } else {
-        setTimeout(() => this.profileInput.focus(), 0);
+        setTimeout(() => this.profileInput?.focus(), 0);
       }
     });
   }
 
-  getProfiles() {
-    const params = new HttpParams().set('filterApp', 'false');
-    this.appApiService
-      .getAllByParams(params)
-      .pipe(
-        tap((applications) => (this.applicationsDetails = applications.APPLICATION_CONFIGURATION)),
-        switchMap(() => this.rngProfileService.list(this.level, this.tenantIdentifier, this.applicationNameExclude)),
-      )
-      .subscribe((profiles) => {
-        this.profiles = profiles;
-        this.profileIds = this.filterProfileIds(this.profileIds, this.profiles, this.applicationsDetails);
-        this.profileIds = this.profileIds.sort(byApplicationName(this.profiles, this.applicationsDetails));
-        this.updateApplicationTree();
-        this.loading = false;
-      });
+  ngOnChanges(_changes: SimpleChanges) {
+    this.getProfiles();
+  }
+
+  private getProfiles() {
+    const rngProfiles$ = this.rngProfileService.list(this.level, this.tenantIdentifier, this.applicationNameExclude);
+
+    zip(this.applicationsDetails$, rngProfiles$).subscribe(([applicationsDetails, profiles]) => {
+      this.profiles = profiles;
+      this.profileIds = this.filterProfileIds(this.profileIds, this.profiles, applicationsDetails);
+      this.profileIds = this.profileIds.sort(byApplicationName(this.profiles, applicationsDetails));
+      this.updateApplicationTree();
+      this.loading = false;
+    });
   }
 
   onChange = (_: any) => {};

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -48,7 +48,7 @@ import {
   Injector,
   Input,
   QueryList,
-  ResourceRef,
+  Resource,
   Signal,
   ViewChild,
   ViewChildren,
@@ -173,13 +173,13 @@ export class SelectComponent extends AbstractFormInputDirective implements After
   }
 
   private isResource(
-    optionsParam: VitamuiSelectOptions | any[] | ResourceRef<VitamuiSelectOptions | any[]>,
-  ): optionsParam is ResourceRef<VitamuiSelectOptions | any[]> {
-    return !!(optionsParam as ResourceRef<VitamuiSelectOptions | any[]>)?.isLoading;
+    optionsParam: VitamuiSelectOptions | any[] | Resource<VitamuiSelectOptions | any[]>,
+  ): optionsParam is Resource<VitamuiSelectOptions | any[]> {
+    return !!(optionsParam as Resource<VitamuiSelectOptions | any[]>)?.isLoading;
   }
 
   @Input({ required: true })
-  set options(optionsParam: VitamuiSelectOptions | any[] | ResourceRef<VitamuiSelectOptions | any[]>) {
+  set options(optionsParam: VitamuiSelectOptions | any[] | Resource<VitamuiSelectOptions | any[]>) {
     if (this.isResource(optionsParam)) {
       this.optionsResource = optionsParam;
     } else {
@@ -213,7 +213,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
     this.addEventListeners();
   }
 
-  private optionsResource: ResourceRef<VitamuiSelectOptions | any[]>;
+  private optionsResource: Resource<VitamuiSelectOptions | any[]>;
 
   @Input() selectAllLabel = this.translateService.instant('SELECT.SELECT_ALL');
   @Input() allSelectedLabel?: string;


### PR DESCRIPTION
Permet de corriger les tests e2e qui peuvent échouer si l'étape 2 avec les selects est affichée avant que la réponse à l'appel http récupérant les profils ne soit reçue.

Aussi, évite les doubles requêtes.