### PR TITLE
CP V8.0 - Story #15510: Delivering JRE instead of JDK for Pastis Standalone.

### DIFF
--- a/api/api-pastis/pastis-standalone/pom.xml
+++ b/api/api-pastis/pastis-standalone/pom.xml
@@ -235,7 +235,7 @@
                         <executions>
                             <!-- download openjdk -->
                             <execution>
-                                <id>download-jdk</id>
+                                <id>download-jre</id>
                                 <phase>initialize</phase>
                                 <goals>
                                     <goal>run</goal>
@@ -243,28 +243,27 @@
                                 <configuration>
                                     <target>
                                         <get
-                                                src="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_windows_hotspot_17.0.13_11.zip"
-                                                dest="${project.build.directory}/jdk17.zip"
-                                                verbose="false"
-                                                usetimestamp="true"/>
+                                            src="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17+10/OpenJDK17U-jre_x64_windows_hotspot_17.0.17_10.zip"
+                                            dest="${project.build.directory}/jre17.zip"
+                                            verbose="false"
+                                            usetimestamp="true"/>
                                     </target>
                                 </configuration>
                             </execution>
-
                             <!-- unzip jdk -->
                             <execution>
-                                <id>unzip-jdk</id>
+                                <id>unzip-jre</id>
                                 <phase>package</phase>
-                                <configuration>
-                                    <tasks>
-                                        <echo message="unzipping file"/>
-                                        <unzip src="${project.build.directory}/jdk17.zip"
-                                               dest="${project.build.directory}/jdk17/"/>
-                                    </tasks>
-                                </configuration>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
+                                <configuration>
+                                    <target>
+                                        <echo message="unzipping file"/>
+                                        <unzip src="${project.build.directory}/jre17.zip"
+                                               dest="${project.build.directory}/"/>
+                                    </target>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -290,9 +289,8 @@
                             <errTitle>Erreur</errTitle>
                             <jre>
                                 <minVersion>17</minVersion>
-                                <path>./jdk17/jdk-17.0.13+11</path>
+                                <path>./jdk-17.0.17+10-jre</path>
                                 <requires64Bit/>
-                                <requiresJdk/>
                             </jre>
                             <versionInfo>
                                 <fileVersion>1.0.0.0</fileVersion>

--- a/api/api-pastis/pastis-standalone/src/main/assembly/packaging-zip.xml
+++ b/api/api-pastis/pastis-standalone/src/main/assembly/packaging-zip.xml
@@ -12,7 +12,7 @@
             <outputDirectory>/</outputDirectory>
             <includes>
                 <include>*.exe</include>
-                <include>jdk17/jdk-17.0.13+11/**</include>
+                <include>jdk-17.0.17+10-jre/**</include>
             </includes>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
## Description

> Cherry-Picked from #3415 

## Type de changement

* Build

## Contributeur

* Programme Vitam