### PR TITLE
Story #15048: Upgrade Elasticsearch components from v8.18.0 to v9.2.2.

### DIFF
--- a/deployment/roles/filebeat/defaults/main.yml
+++ b/deployment/roles/filebeat/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-filebeat_version: "{{ filebeat.version | default('8.18.0') }}"
+filebeat_version: "{{ filebeat.version | default('9.2.2') }}"
 filebeat_package: "filebeat{{ '=' if ansible_os_family == 'Debian' else '-' }}{{ filebeat_version }}"
 
 filebeat:

--- a/deployment/roles/logstash/defaults/main.yml
+++ b/deployment/roles/logstash/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-# HOTFIX: Workaround for logstash package which is actually a "1:8.18.0-1" on Debian, and "8.18.0" for Redhat-family
-logstash_version: "{{ '1:' if ansible_os_family == 'Debian' else '' }}{{ logstash.version | default('8.18.0') }}{{ '-1' if ansible_os_family == 'Debian' else '' }}"
+# HOTFIX: Workaround for logstash package which is actually a "1:9.2.2-1" on Debian, and "9.2.2" for Redhat-family
+logstash_version: "{{ '1:' if ansible_os_family == 'Debian' else '' }}{{ logstash.version | default('9.2.2') }}{{ '-1' if ansible_os_family == 'Debian' else '' }}"
 logstash_package: "logstash{{ '=' if ansible_os_family == 'Debian' else '-' }}{{ logstash_version }}"
 
 logstash_user: "{{ logstash.user | default('logstash') }}"


### PR DESCRIPTION
## Description

Updating logstash and filebeat version from 8.18.0 to 9.2.2.

## Type de changement

* Ansiblerie
* COTS

## Contributeur

* Programme Vitam