### PR TITLE
CP V9.0 - Bug #15498 [Pastis] Pressing Enter triggers a step rollback and generates “MISSING TITLE AT INDEX 2”.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/user-actions/save-profile-popup/save-profile-popup.component.html
+++ b/ui/ui-frontend/projects/pastis/src/app/user-actions/save-profile-popup/save-profile-popup.component.html
@@ -9,7 +9,7 @@
   ]"
 ></vitamui-dialog-header>
 
-<form [formGroup]="noticeForm">
+<form [formGroup]="noticeForm" (keydown.enter)="$event.preventDefault()">
   <vitamui-stepper #stepper [(selectedIndex)]="stepIndex">
     <cdk-step>
       <mat-dialog-content>


### PR DESCRIPTION
see: https://github.com/ProgrammeVitam/vitam-ui/pull/3411