### PR TITLE
CP V9.0 - Bug #15571: Disabling zlib compression on mongod servers.

### DIFF
--- a/deployment/roles/mongo/templates/mongod.conf.j2
+++ b/deployment/roles/mongo/templates/mongod.conf.j2
@@ -38,6 +38,10 @@ net:
     pathPrefix: {{ mongo_tmp_path }}
     filePermissions: 0700
 
+  # Mitigate CVE-2025-14847 ("MongoBleed") by disabling zlib compressor
+  compression:
+    compressors: snappy,zstd
+
 # operationProfiling:
 replication:
   replSetName: shard{{ mongo_shard_id | default(0) }} # name of the replica set


### PR DESCRIPTION
## Description

Mitigate CVE-2025-14847 ("MongoBleed").

> Cherry-Picked from #3444 

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam