### PR TITLE
Bug #15519 : Wrong popup when updating rules on holding units

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
@@ -572,6 +572,39 @@
   </mat-dialog-actions>
 </ng-template>
 
+<ng-template #launchSelectionContainsHoldingUnitAlertMessageDialog>
+  <vitamui-dialog-header [subhead]="'ARCHIVE_SEARCH.RULES_ACTION.ACTION_ALERTE_TITLE' | translate"></vitamui-dialog-header>
+  <mat-dialog-content>
+    <div class="row red-text">
+      <div class="col-1">
+        <i class="material-icons icon-style">cancel</i>
+      </div>
+      <div class="col-11">
+        {{ 'RULES.ALERTE_MESSAGES.ACTION_ALERTE_TITLE' | translate }}
+      </div>
+    </div>
+    <br />
+    <div class="row">
+      <div class="col-1">
+        <span class="vertical-line"></span>
+      </div>
+      <div class="col-11">
+        <div class="text small bold">
+          {{ 'ARCHIVE_SEARCH.RULES_ACTION.ACTION_ALERTE_FIRST_MESSAGE' | translate }}
+        </div>
+        <div class="text small">
+          {{ 'RULES.ALERTE_MESSAGES.ACTION_ALERTE_FIRST_MESSAGE' | translate }}
+        </div>
+      </div>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button [matDialogClose]="true" class="btn primary btn-confirm-dialog">
+      {{ 'RULES.ALERTE_MESSAGES.BACK_TO_SELECTION' | translate }}
+    </button>
+  </mat-dialog-actions>
+</ng-template>
+
 <ng-template #confirmImportantAllowedBulkOperationsDialog>
   <mat-dialog-content>
     <div class="text large bold">

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -209,6 +209,8 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
   reclassificationAlerteMessageDialog: TemplateRef<ArchiveSearchComponent>;
   @ViewChild('launchComputeInheritedRuleAlerteMessageDialog', { static: true })
   launchComputeInheritedRuleAlerteMessageDialog: TemplateRef<ArchiveSearchComponent>;
+  @ViewChild('launchSelectionContainsHoldingUnitAlertMessageDialog', { static: true })
+  launchSelectionContainsHoldingUnitAlertMessageDialog: TemplateRef<ArchiveSearchComponent>;
   archiveSearchResultFacets: ArchiveSearchResultFacets = new ArchiveSearchResultFacets();
   @ViewChild('confirmImportantAllowedBulkOperationsDialog', { static: true })
   confirmImportantAllowedBulkOperationsDialog: TemplateRef<ArchiveSearchComponent>;
@@ -1339,7 +1341,7 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
           this.router,
           this.selectedItemCount,
           this.actionsWithThresholdReachedAlerteMessageDialogSubscription,
-          this.actionsWithThresholdReachedAlerteMessageDialog,
+          this.launchSelectionContainsHoldingUnitAlertMessageDialog,
           this.confirmSecondActionBigNumberOfResultsActionDialog,
         ),
       this.DEFAULT_UPDATE_MGT_RULES_THRESHOLD,

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/en.json
@@ -18,7 +18,9 @@
       }
     },
     "RULES_ACTION": {
-      "UPDATE_RULE": "Update rules"
+      "UPDATE_RULE": "Update rules",
+      "ACTION_ALERTE_TITLE": "The requested action is not possible for this selection",
+      "ACTION_ALERTE_FIRST_MESSAGE": "The requested action is not possible for this selection"
     },
     "PUA": {
       "UPDATE": "Update AUP"

--- a/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/i18n/fr.json
@@ -18,7 +18,9 @@
       }
     },
     "RULES_ACTION": {
-      "UPDATE_RULE": "Mettre à jour des règles"
+      "UPDATE_RULE": "Mettre à jour des règles",
+      "ACTION_ALERTE_TITLE": "L'action demandée n'est pas possible pour cette sélection",
+      "ACTION_ALERTE_FIRST_MESSAGE": "L'action demandée n'est pas possible pour cette sélection"
     },
     "PUA": {
       "UPDATE": "Mettre à jour les PUA"


### PR DESCRIPTION
## Description

La mauvaise popup s'affiche lorsque l'on met à jour des règles si la sélection contient des unités de type Arbre
