### PR TITLE
Bug #15625 - [Vitam-ui] – The "Select All" button of the Multi-Select component does not select all items and does not check the checkbox.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.html
@@ -92,11 +92,15 @@
           <cdk-virtual-scroll-viewport itemSize="48" #scrollViewport class="h-100" minBufferPx="240" maxBufferPx="480">
             <div class="vitamui-mat-select-options">
               <ng-container *ngIf="enableSelectAll && multiple">
-                <mat-option [id]="String(0)" (onSelectionChange)="toggleSelectAll($event)" [value]="SELECT_ALL_OPTIONS">
-                  <span class="text normal secondary bold">
+                <div class="mat-mdc-option" (click)="toggleSelectAll($event)">
+                  <mat-pseudo-checkbox
+                    [state]="isAllSelected() ? 'checked' : 'unchecked'"
+                    class="mat-mdc-option-pseudo-checkbox"
+                  ></mat-pseudo-checkbox>
+                  <span class="mat-mdc-option-text text normal secondary bold">
                     {{ selectAllLabel }}
                   </span>
-                </mat-option>
+                </div>
                 <mat-divider></mat-divider>
               </ng-container>
 

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -68,7 +68,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
-import { MatOption, MatOptionModule, MatOptionSelectionChange } from '@angular/material/core';
+import { MatOption, MatOptionModule, MatOptionSelectionChange, MatPseudoCheckboxModule } from '@angular/material/core';
 import { MatSelect, MatSelectModule } from '@angular/material/select';
 import { PipesModule } from '../../../app/modules/pipes/pipes.module';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -105,6 +105,7 @@ export interface VitamuiSelectOptions {
     MatInputModule,
     MatListModule,
     MatOptionModule,
+    MatPseudoCheckboxModule,
     MatSelectModule,
     PipesModule,
     ReactiveFormsModule,
@@ -363,13 +364,16 @@ export class SelectComponent extends AbstractFormInputDirective implements After
       this.searchBar?.reset();
     }
   }
+  protected toggleSelectAll(event: MouseEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
 
-  protected toggleSelectAll(event: MatOptionSelectionChange): void {
-    if (!event.isUserInput) {
-      return;
-    }
+    // Toggle: if all are selected, deselect all. Otherwise, select all.
+    this.selectAll(!this.isAllSelected());
+  }
 
-    this.selectAll(event.source.selected);
+  protected isAllSelected(): boolean {
+    return this.allOptions.length > 0 && this.getSelectedOptionsCount() === this.allOptions.length;
   }
 
   protected clearAllSelectedOptions(): void {


### PR DESCRIPTION
en étant l'élément "Sélectionner tout"  comme une `mat-option` standard, Angular Material ne pouvait sélectionner que les options visibles.

==> La solution consiste à ne plus utiliser `mat-option` pour l'élément "Sélectionner tout", mais plutôt un "div personnalisé"