### PR TITLE
CP V9.0 - Bug #14397 - [Ingest] – The inter-app link is missing when the user is associated with a profile group that does not allow access to the Search app.

### DIFF
--- a/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-information-tab/ingest-information-tab.component.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-information-tab/ingest-information-tab.component.ts
@@ -46,8 +46,8 @@ import {
 } from '../../../models/logbook-event.interface';
 
 import { ApplicationId, ApplicationService } from 'vitamui-library';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-ingest-information-tab',
@@ -118,8 +118,9 @@ export class IngestInformationTabComponent implements OnChanges {
   }
 
   getOpiUrl$(): Observable<string> {
-    return this.applicationService
-      .getUrl$({ appId: ApplicationId.ARCHIVE_SEARCH_APP })
-      .pipe(map((appUrl) => `${appUrl}?guidopi=${this.ingest.id}`));
+    return this.applicationService.getUrl$({ appId: ApplicationId.ARCHIVE_SEARCH_APP }).pipe(
+      map((appUrl) => `${appUrl}?guidopi=${this.ingest.id}`),
+      catchError(() => of('/')),
+    );
   }
 }


### PR DESCRIPTION
see: https://github.com/ProgrammeVitam/vitam-ui/pull/3500