### PR TITLE
CP V9.0 - Bug #15634: Allow nginx to disable ssl.

### DIFF
--- a/deployment/roles/reverse/defaults/main.yml
+++ b/deployment/roles/reverse/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 vitamui_reverse_external_protocol: https
+reverse_proxy_port: "{{ 443 if vitamui_reverse_external_protocol | lower == 'https' else 80 }}"
 reverse_connection_params: "acquire=5000 connectiontimeout=300 timeout=600 retry=5"
 
 assets_path: "{{ vitamui_defaults.folder.root_path }}/conf/assets"

--- a/deployment/roles/reverse/tasks/nginx/nginx.yml
+++ b/deployment/roles/reverse/tasks/nginx/nginx.yml
@@ -29,6 +29,7 @@
     - reverse.key
     - dhparam.pem
   notify: reload nginx
+  when: vitamui_reverse_external_protocol | lower == 'https'
 
 - name: Ensure nginx is started
   systemd:

--- a/deployment/roles/reverse/templates/apache/httpd_config
+++ b/deployment/roles/reverse/templates/apache/httpd_config
@@ -1,6 +1,6 @@
-<VirtualHost {{ ip_service }}:{{ reverse_proxy_port | default(443) }}>
+<VirtualHost {{ ip_service }}:{{ reverse_proxy_port }}>
 
-{% if vitamui_reverse_external_protocol | default('https') | lower == 'https' %}
+{% if vitamui_reverse_external_protocol | lower == 'https' %}
     SSLEngine on
     SSLCertificateFile /etc/{{ apache_service }}/certs/reverse.crt
     SSLCertificateKeyFile /etc/{{ apache_service }}/certs/reverse.key

--- a/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
@@ -1,8 +1,12 @@
 #jinja2: lstrip_blocks: True
 server {
 
-  listen {{ ip_service }}:443 ssl;
+{% if vitamui_reverse_external_protocol | lower == 'https' %}
+  listen {{ ip_service }}:{{ reverse_proxy_port }} ssl;
   include {{ nginx_ssl_dir }}/ssl.conf;
+{% else %}
+  listen {{ ip_service }}:{{ reverse_proxy_port }};
+{% endif %}
 
   server_name {{ vitamui_reverse_external_dns }};
 


### PR DESCRIPTION
## Description

Mise à jour du template de déploiement nginx pour permettre la désactivation du ssl et le choix du port associé.

> Cherry-Picked from #3476

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam