### PR TITLE
Bug #15626 - [Operations Management] – Fix: cancellation of an operation in a non-cancellable step.

### DIFF
--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/LogbookManagementOperationController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/LogbookManagementOperationController.java
@@ -90,7 +90,8 @@ public class LogbookManagementOperationController {
             request.getReason()
         );
         ProcessDetailDto processDetailDto = logbookManagementOperationService.cancelOperationProcessExecution(
-            operationId
+            operationId,
+            request.isStepCancellable()
         );
         if (processDetailDto != null) {
             operationResponseDto = processDetailDto.getOperations();

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/logbookmanagement/LogbookManagementOperationService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/logbookmanagement/LogbookManagementOperationService.java
@@ -109,11 +109,14 @@ public class LogbookManagementOperationService extends AbstractService {
         return operation;
     }
 
-    public ProcessDetailDto cancelOperationProcessExecution(VitamContext vitamContext, String operationId)
-        throws VitamClientException, JsonProcessingException {
+    public ProcessDetailDto cancelOperationProcessExecution(
+        VitamContext vitamContext,
+        String operationId,
+        boolean stepCancellable
+    ) throws VitamClientException, JsonProcessingException {
         ProcessDetailDto operation;
         LOGGER.info("Cancel the operation Id=  {}", operationId);
-        vitamOperationCommonService.cancelOperationProcessExecution(vitamContext, operationId);
+        vitamOperationCommonService.cancelOperationProcessExecution(vitamContext, operationId, stepCancellable);
         ProcessQuery processQuery = new ProcessQuery();
         processQuery.setId(operationId);
         operation = searchOperationsDetails(vitamContext, processQuery);
@@ -139,10 +142,10 @@ public class LogbookManagementOperationService extends AbstractService {
         }
     }
 
-    public ProcessDetailDto cancelOperationProcessExecution(String operationId) {
+    public ProcessDetailDto cancelOperationProcessExecution(String operationId, boolean stepCancellable) {
         VitamContext vitamContext = buildVitamContext();
         try {
-            return this.cancelOperationProcessExecution(vitamContext, operationId);
+            return this.cancelOperationProcessExecution(vitamContext, operationId, stepCancellable);
         } catch (VitamClientException | JsonProcessingException e) {
             throw new InternalServerException("Unable to cancel operation process execution", e);
         }

--- a/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/LogbookManagementOperationServiceTest.java
+++ b/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/LogbookManagementOperationServiceTest.java
@@ -144,12 +144,16 @@ public class LogbookManagementOperationServiceTest {
         String identifier = "identifier";
 
         when(
-            vitamOperationCommonService.cancelOperationProcessExecution(any(VitamContext.class), any(String.class))
+            vitamOperationCommonService.cancelOperationProcessExecution(
+                any(VitamContext.class),
+                any(String.class),
+                any(Boolean.class)
+            )
         ).thenThrow(new VitamClientException("Exception thrown by vitam"));
 
         //When //Then
         assertThatCode(
-            () -> logbookManagementOperationService.cancelOperationProcessExecution(vitamContext, identifier)
+            () -> logbookManagementOperationService.cancelOperationProcessExecution(vitamContext, identifier, false)
         ).isInstanceOf(VitamClientException.class);
     }
 

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/administration/VitamOperationCommonService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/administration/VitamOperationCommonService.java
@@ -70,8 +70,13 @@ public class VitamOperationCommonService {
         return adminExternalClient.updateOperationActionProcess(vitamContext, actionId, operationId);
     }
 
-    public RequestResponse<ItemStatus> cancelOperationProcessExecution(VitamContext vitamContext, String operationId)
-        throws VitamClientException, IllegalArgumentException {
-        return adminExternalClient.cancelOperationProcessExecution(vitamContext, operationId);
+    public RequestResponse<ItemStatus> cancelOperationProcessExecution(
+        VitamContext vitamContext,
+        String operationId,
+        boolean stepCancellable
+    ) throws VitamClientException, IllegalArgumentException {
+        return stepCancellable
+            ? adminExternalClient.cancelOperationProcessExecution(vitamContext, operationId)
+            : adminExternalClient.cancelOperationProcessExecution(vitamContext, operationId, true);
     }
 }


### PR DESCRIPTION
fix: annulation d'une opération dans une étape non annulable:

La pop-up d'erreur s'affiche correctement, mais l'opération passe en globalState = PAUSE au lieu COMPLETED  et stepStatus = FATAL au lieu KO, ce qui est incorrect (KO).