### PR TITLE
Bug #15674: Make hostname-verification parameter configurable.

### DIFF
--- a/deployment/roles/vitamui/defaults/main.yml
+++ b/deployment/roles/vitamui/defaults/main.yml
@@ -10,6 +10,7 @@ jvm_opts:
 start_timeout: "{{ vitamui_defaults.services.start_timeout | default(300) }}"
 at_boot: "{{ vitamui_defaults.services.at_boot | default(false) }}"
 secure: "{{ vitamui_defaults.services.secure | default(true) | bool }}"
+ssl_hostname_verification: "{{ vitamui_defaults.services.ssl_hostname_verification | default(true) }}"
 jvm_log: "{{ vitamui_defaults.services.jvm_log | default(false) | bool }}"
 accesslogs: "{{ vitamui_defaults.services.accesslogs | default('true') | lower }}"
 access_retention_days: "{{ vitamui_defaults.services.access_retention_days | default(365) }}"

--- a/deployment/roles/vitamui/templates/archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search/application.yml.j2
@@ -67,28 +67,27 @@ archive-search:
   security-client:
     server-host: {{ vitamui.security.host }}
     server-port: {{ vitamui.security.port_service }}
-{% if vitamui.security.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.security.secure | default(secure) | lower }}
+{% if vitamui.security.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
   iam-client:
     server-host: {{ vitamui.iam.host }}
     server-port: {{ vitamui.iam.port_service }}
-{% if vitamui.iam.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.iam.secure | default(secure) | lower }}
+{% if vitamui.iam.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       keystore:
         key-path: {{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.service_name | default(service_name) }}.jks
         key-password: {{ password_keystore_client }}
-        type: JKS
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 {% if opentracing.jaeger.enabled | default(false) | bool %}

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -73,7 +73,7 @@ iam-client:
     truststore:
       key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
       key-password: {{ truststores_vitamui }}
-    hostname-verification: true
+    hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 cas.authn.accept.users:

--- a/deployment/roles/vitamui/templates/collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect/application.yml.j2
@@ -76,19 +76,19 @@ collect:
   security-client:
     server-host: {{ vitamui.security.host }}
     server-port: {{ vitamui.security.port_service }}
-{% if vitamui.security.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.security.secure | default(secure) | lower }}
+{% if vitamui.security.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
   iam-client:
     server-host: {{ vitamui.iam.host }}
     server-port: {{ vitamui.iam.port_service }}
-{% if vitamui.iam.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.iam.secure | default(secure) | lower }}
+{% if vitamui.iam.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       keystore:
         key-path: {{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.service_name | default(service_name) }}.jks
@@ -97,7 +97,7 @@ collect:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 ontologies_file_path: {{ vitamui_folder_data }}/external_ontology_fields.json

--- a/deployment/roles/vitamui/templates/iam/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam/application.yml.j2
@@ -72,13 +72,13 @@ iam:
   security-client:
     server-host: {{ vitamui.security.host }}
     server-port: {{ vitamui.security.port_service }}
-{% if vitamui.security.secure | default(secure) | bool == true %}
+{% if vitamui.security.secure | default(secure) | bool %}
     secure: true
     ssl-configuration:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 list-enable-external-identifiers:
@@ -104,7 +104,7 @@ login:
 cas-client:
   server-host: {{ vitamui.cas_server.host }}
   server-port: {{ vitamui.cas_server.port_service }}
-{% if vitamui.cas_server.secure | default(secure) | bool == true %}
+{% if vitamui.cas_server.secure | default(secure) | bool %}
   secure: true
   ssl-configuration:
     keystore:
@@ -114,7 +114,7 @@ cas-client:
     truststore:
       key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
       key-password: {{ truststores_vitamui }}
-    hostname-verification: true
+    hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 cas.reset.password.url: {{ vitamui.cas_server.base_url | default('/cas') }}{{ vitamui.cas_server.reset_password_url | default('/extras/resetPassword?username={username}&firstname={firstname}&lastname={lastname}&language={language}&customerId={customerId}&ttl=1day') }}

--- a/deployment/roles/vitamui/templates/ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest/application.yml.j2
@@ -17,7 +17,7 @@ spring:
 server:
   address: {{ ip_service }}
   port: {{ vitamui_struct.port_service }}
-{% if vitamui_struct.secure | default(secure) | bool == true %}
+{% if vitamui_struct.secure | default(secure) | bool %}
   ssl:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
@@ -64,19 +64,19 @@ ingest:
   security-client:
     server-host: {{ vitamui.security.host }}
     server-port: {{ vitamui.security.port_service }}
-{% if vitamui.security.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.security.secure | default(secure) | lower }}
+{% if vitamui.security.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
   iam-client:
     server-host: {{ vitamui.iam.host }}
     server-port: {{ vitamui.iam.port_service }}
-{% if vitamui.iam.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.iam.secure | default(secure) | lower }}
+{% if vitamui.iam.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       keystore:
         key-path: {{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.service_name | default(service_name) }}.jks
@@ -85,7 +85,7 @@ ingest:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 {% if opentracing.jaeger.enabled | default(false) | bool %}

--- a/deployment/roles/vitamui/templates/pastis/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis/application.yml.j2
@@ -40,7 +40,7 @@ logging:
 server:
   address: {{ ip_service }}
   port: {{ vitamui_struct.port_service }}
-{% if vitamui_struct.secure | default(secure) | bool == true %}
+{% if vitamui_struct.secure | default(secure) | bool %}
   ssl:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
@@ -86,19 +86,19 @@ pastis:
   security-client:
     server-host: {{ vitamui.security.host }}
     server-port: {{ vitamui.security.port_service }}
-{% if vitamui.security.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.security.secure | default(secure) | lower }}
+{% if vitamui.security.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
   iam-client:
     server-host: {{ vitamui.iam.host }}
     server-port: {{ vitamui.iam.port_service }}
-{% if vitamui.iam.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.iam.secure | default(secure) | lower }}
+{% if vitamui.iam.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       keystore:
         key-path: {{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.service_name | default(service_name) }}.jks
@@ -107,7 +107,7 @@ pastis:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 {% if opentracing.jaeger.enabled | default(false) | bool %}

--- a/deployment/roles/vitamui/templates/referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential/application.yml.j2
@@ -72,19 +72,19 @@ referential:
   security-client:
     server-host: {{ vitamui.security.host }}
     server-port: {{ vitamui.security.port_service }}
-{% if vitamui.security.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.security.secure | default(secure) | lower }}
+{% if vitamui.security.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
   iam-client:
     server-host: {{ vitamui.iam.host }}
     server-port: {{ vitamui.iam.port_service }}
-{% if vitamui.iam.secure | default(secure) | bool == true %}
-    secure: {{ vitamui.iam.secure | default(secure) | lower }}
+{% if vitamui.iam.secure | default(secure) | bool %}
+    secure: true
     ssl-configuration:
       keystore:
         key-path: {{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.service_name | default(service_name) }}.jks
@@ -93,7 +93,7 @@ referential:
       truststore:
         key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
         key-password: {{ truststores_vitamui }}
-      hostname-verification: true
+      hostname-verification: {{ vitamui_struct.ssl_hostname_verification | default(ssl_hostname_verification) | bool | lower }}
 {% endif %}
 
 {% if external_archiving_systems is defined %}


### PR DESCRIPTION
## Description

Nouveau paramètre de configuration pour désactiver la vérification des hostnames associés aux certificats applicatifs.

La configuration applicable à tous les services se fait par la variable suivante : `vitamui_defaults.services.ssl_hostname_verification` (par défaut à true).

Il est aussi possible de configurer pour chaque service individuellement par la variable suivante : `vitamui.<service>.ssl_hostname_verification` (par défaut à la valeur de la variable précédente).

## Type de changement

* Ansiblerie
* Refactorisation de code

## Contributeur

* Programme Vitam
