### PR TITLE
CP V8.0 - Story #15211: Separate client certificates for UI components and server certificates for VitamUI components.

### DIFF
--- a/deployment/ansible-vitamui/vitamui_apps.yml
+++ b/deployment/ansible-vitamui/vitamui_apps.yml
@@ -55,6 +55,7 @@
     vitamui_struct: "{{ vitamui.cas_server }}"
     vitamui_certificate_type: "external"
     password_keystore: "{{ keystores_server_cas_server }}"
+    password_keystore_client: "{{ keystores_client_external_cas_server }}"
     password_truststore: "{{ truststores_client_external }}"
     consul_tags: "cas-server, cas, external"
   tags:

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -71,34 +71,43 @@ vitamui:
   identity:
     vitamui_component: ui-identity
     port_service: 8002
+    secure: false
   identity_admin:
     vitamui_component: ui-identity-admin
     port_service: 8401
     package_name: vitamui-ui-identity-rsc
+    secure: false
   referential:
     vitamui_component: ui-referential
     port_service: 8005
+    secure: false
   portal:
     vitamui_component: ui-portal
     port_service: 8003
     has_tenant_list: true
     has_lang_selection: true
     has_site_selection: false
+    secure: false
   ingest:
     vitamui_component: ui-ingest
     port_service: 8008
+    secure: false
   archive_search:
     vitamui_component: ui-archive-search
     port_service: 8009
+    secure: false
   collect:
     vitamui_component: ui-collect
     port_service: 8010
+    secure: false
   pastis:
     vitamui_component: ui-pastis
     port_service: 9015
+    secure: false
   design_system:
     vitamui_component: ui-design-system
     port_service: 9016
+    secure: false
 
   # Applications
   api_gateway:

--- a/deployment/pki/config/crt-config
+++ b/deployment/pki/config/crt-config
@@ -54,8 +54,8 @@ issuerAltName                   = issuer:copy
 subjectAltName                  = ${ENV::OPENSSL_SAN}
 basicConstraints                = critical,CA:FALSE
 keyUsage                        = digitalSignature, keyEncipherment
-nsCertType                      = server, client
-extendedKeyUsage                = serverAuth, clientAuth
+nsCertType                      = server
+extendedKeyUsage                = serverAuth
 
 [ extension_client ]
 nsComment                       = "Certificat Client SSL"

--- a/deployment/pki/scripts/generate_certs.sh
+++ b/deployment/pki/scripts/generate_certs.sh
@@ -39,16 +39,17 @@ function generateCerts {
     generateHostCertAndStorePassphrase   collect-external        hosts_vitamui_collect_external
     generateHostCertAndStorePassphrase   pastis-external         hosts_vitamui_pastis_external
 
+    pki_logger "Génération des certificats clients"
     #Zone UI
-    generateHostCertAndStorePassphrase   ui-portal               hosts_ui_portal
-    generateHostCertAndStorePassphrase   ui-identity             hosts_ui_identity
-    generateHostCertAndStorePassphrase   ui-identity-admin       hosts_ui_identity_admin
-    generateHostCertAndStorePassphrase   ui-referential          hosts_ui_referential
-    generateHostCertAndStorePassphrase   ui-ingest               hosts_ui_ingest
-    generateHostCertAndStorePassphrase   ui-archive-search       hosts_ui_archive_search
-    generateHostCertAndStorePassphrase   ui-collect              hosts_ui_collect
-    generateHostCertAndStorePassphrase   ui-pastis               hosts_ui_pastis
-    generateHostCertAndStorePassphrase   ui-design-system        hosts_ui_design_system
+    generateClientCertAndStorePassphrase ui-portal               client-external
+    generateClientCertAndStorePassphrase ui-identity             client-external
+    generateClientCertAndStorePassphrase ui-identity-admin       client-external
+    generateClientCertAndStorePassphrase ui-referential          client-external
+    generateClientCertAndStorePassphrase ui-ingest               client-external
+    generateClientCertAndStorePassphrase ui-archive-search       client-external
+    generateClientCertAndStorePassphrase ui-collect              client-external
+    generateClientCertAndStorePassphrase ui-pastis               client-external
+    generateClientCertAndStorePassphrase ui-design-system        client-external
 
     #Reverse
     generateHostCertAndStorePassphrase   reverse                 hosts_vitamui_reverseproxy

--- a/deployment/pki/scripts/generate_certs.sh
+++ b/deployment/pki/scripts/generate_certs.sh
@@ -40,6 +40,8 @@ function generateCerts {
     generateHostCertAndStorePassphrase   pastis-external         hosts_vitamui_pastis_external
 
     pki_logger "Génération des certificats clients"
+    generateClientCertAndStorePassphrase cas-server              client-external
+
     #Zone UI
     generateClientCertAndStorePassphrase ui-portal               client-external
     generateClientCertAndStorePassphrase ui-identity             client-external

--- a/deployment/pki/scripts/lib/certs.sh
+++ b/deployment/pki/scripts/lib/certs.sh
@@ -20,15 +20,14 @@ function getHostCertificatePath {
 
 # Génération du SubjectAlternate Name pour les certificats serveur.
 function getHostCertificateSan {
-    local HOSTNAME="${1}"
-    local SERVICE_HOSTNAME="${2}"
-    local SERVICE_DC_HOSTNAME="${3}"
-    local REVERSE_SAN="${4}"
+    local SERVICE_HOSTNAME="${1}"
+    local SERVICE_DC_HOSTNAME="${2}"
+    local REVERSE_SAN="${3}"
 
     if [ -n "${REVERSE_SAN}" ]; then
-        echo "DNS:${SERVICE_HOSTNAME},DNS:${HOSTNAME},DNS:${SERVICE_DC_HOSTNAME},DNS:${REVERSE_SAN}"
+        echo "DNS:${SERVICE_HOSTNAME},DNS:${SERVICE_DC_HOSTNAME},DNS:${REVERSE_SAN}"
     else
-        echo "DNS:${SERVICE_HOSTNAME},DNS:${HOSTNAME},DNS:${SERVICE_DC_HOSTNAME}"
+        echo "DNS:${SERVICE_HOSTNAME},DNS:${SERVICE_DC_HOSTNAME}"
     fi
 }
 
@@ -50,7 +49,7 @@ function generateHostCertificate {
     local REVERSE_SAN="${8}"
 
     # Correctly set Subject Alternate Name (env var is read inside the openssl configuration file)
-    export OPENSSL_SAN="$(getHostCertificateSan $HOSTNAME $SERVICE_HOSTNAME $SERVICE_DC_HOSTNAME $REVERSE_SAN)"
+    export OPENSSL_SAN="$(getHostCertificateSan $SERVICE_HOSTNAME $SERVICE_DC_HOSTNAME $REVERSE_SAN)"
     # Correctly set certificate CN (env var is read inside the openssl configuration file)
     export OPENSSL_CN="$(getHostCertificateCn $SERVICE_HOSTNAME)"
     # Correctly set certificate DIRECTORY (env var is read inside the openssl configuration file)
@@ -151,8 +150,10 @@ function generateClientCertificate {
     local CLIENT_CERTIFICATE_PATH=$(getClientCertificatePath ${CLIENT_TYPE} ${CLIENT_NAME})
     mkdir -p "${CLIENT_CERTIFICATE_PATH}"
     pki_logger "Generation de la clé..."
+    # Workaround to avoid passphrase with -nodes option problem while loading passphrase to nginx
     openssl req -newkey "${PARAM_KEY_CHIFFREMENT}" \
         -passout pass:"${MDP_KEY}" \
+        -nodes \
         -keyout "${CLIENT_CERTIFICATE_PATH}/${CLIENT_NAME}.key" \
         -out "${CLIENT_CERTIFICATE_PATH}/${CLIENT_NAME}.req" \
         -config "${REPERTOIRE_CONFIG}/crt-config" \

--- a/deployment/pki/scripts/lib/stores.sh
+++ b/deployment/pki/scripts/lib/stores.sh
@@ -259,8 +259,8 @@ function main() {
         #     rm -f ${JKS_GRANTED_STORE}
         # fi
         mkdir -p ${REPERTOIRE_KEYSTORES}/client-${CLIENT_TYPE}
-        # # client-${CLIENT_TYPE} keystores generation
-        for COMPONENT in $( ls ${REPERTOIRE_CERTIFICAT}/client-${CLIENT_TYPE}/clients 2>/dev/null | grep -vF -e "README" -e "external" ); do
+        # Do not generate keystores for ui- components, we don't need them
+        for COMPONENT in $( ls ${REPERTOIRE_CERTIFICAT}/client-${CLIENT_TYPE}/clients 2>/dev/null | grep -vF -e "README" -e "external" -e "^ui-"); do
 
             # Generate the p12 keystore
             pki_logger "-------------------------------------------"

--- a/deployment/roles/nginx_webapp/tasks/install.yml
+++ b/deployment/roles/nginx_webapp/tasks/install.yml
@@ -60,8 +60,8 @@
     owner: "{{ frontend_user }}"
     mode: "{{ vitam_defaults.folder.conf_permission }}"
   with_fileglob:
-    - "{{ inventory_dir }}/certs/server/hosts/{{ inventory_hostname }}/{{ vitamui_struct.vitamui_component }}.crt"
-    - "{{ inventory_dir }}/certs/server/hosts/{{ inventory_hostname }}/{{ vitamui_struct.vitamui_component }}.key"
+    - "{{ inventory_dir }}/certs/client-external/clients/{{ vitamui_struct.vitamui_component }}/{{ vitamui_struct.vitamui_component }}.crt"
+    - "{{ inventory_dir }}/certs/client-external/clients/{{ vitamui_struct.vitamui_component }}/{{ vitamui_struct.vitamui_component }}.key"
   notify: reload nginx
 
 - name: Put ssl configuration when secure is enabled

--- a/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
@@ -36,7 +36,12 @@ server {
     {% endfor %}
     deny all; # Deny access to all other IP addresses
 
-    proxy_pass {{ 'https' if vitamui.api_gateway.secure | default(secure) | bool else 'http' }}://API-GATEWAY;
+    {% if vitamui.api_gateway.secure | default(secure) | bool %}
+    set $api_gateway_dns "vitamui-{{ vitamui.api_gateway.vitamui_component }}.service.{{ consul_domain }}";
+    proxy_pass https://$api_gateway_dns:{{ vitamui.api_gateway.port_service }};
+    {% else %}
+    proxy_pass http://API-GATEWAY;
+    {% endif %}
     proxy_ssl_certificate {{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}.crt;
     proxy_ssl_certificate_key {{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}.key;
     proxy_ssl_session_reuse off;

--- a/deployment/roles/reinit_security_certificates/templates/security.populate_certificates.js.j2
+++ b/deployment/roles/reinit_security_certificates/templates/security.populate_certificates.js.j2
@@ -28,13 +28,13 @@ db.certificates.insertOne({
 {{ process('{{ pki_dir }}/server/hosts/%host%/cas-server.pem', 'cas_context', 'hosts_cas_server') }}
 {{ process('{{ pki_dir }}/server/hosts/%host%/iam-internal.pem', 'iam_internal_context', 'hosts_vitamui_iam_internal') }}
 
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-portal.pem', 'ui_portal_context', 'hosts_ui_portal') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-identity.pem', 'ui_identity_context', 'hosts_ui_identity') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-identity-admin.pem', 'ui_admin_identity_context', 'hosts_ui_identity_admin') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-referential.pem', 'ui_referential_context', 'hosts_ui_referential') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-archive-search.pem', 'ui_archive_search_context', 'hosts_ui_archive_search') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-ingest.pem', 'ui_ingest_context', 'hosts_ui_ingest') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-pastis.pem', 'ui_pastis_context', 'hosts_ui_pastis') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-collect.pem', 'ui_collect_context', 'hosts_ui_collect') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-portal/ui-portal.pem', 'ui_portal_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity/ui-identity.pem', 'ui_identity_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity-admin/ui-identity-admin.pem', 'ui_admin_identity_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-referential/ui-referential.pem', 'ui_referential_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-archive-search/ui-archive-search.pem', 'ui_archive_search_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-ingest/ui-ingest.pem', 'ui_ingest_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-pastis/ui-pastis.pem', 'ui_pastis_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-collect/ui-collect.pem', 'ui_collect_context') }}
 
 print("END security.populate_certificates.js");

--- a/deployment/roles/reinit_security_certificates/templates/security.populate_certificates.js.j2
+++ b/deployment/roles/reinit_security_certificates/templates/security.populate_certificates.js.j2
@@ -25,9 +25,9 @@ db.certificates.insertOne({
     {% endif %}
 {%- endmacro %}
 
-{{ process('{{ pki_dir }}/server/hosts/%host%/cas-server.pem', 'cas_context', 'hosts_cas_server') }}
 {{ process('{{ pki_dir }}/server/hosts/%host%/iam-internal.pem', 'iam_internal_context', 'hosts_vitamui_iam_internal') }}
 
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/cas-server/cas-server.pem', 'cas_context') }}
 {{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-portal/ui-portal.pem', 'ui_portal_context') }}
 {{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity/ui-identity.pem', 'ui_identity_context') }}
 {{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity-admin/ui-identity-admin.pem', 'ui_admin_identity_context') }}

--- a/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
@@ -120,7 +120,12 @@ server {
   }
 
   location ~ ^/cas/(login|logout|extras|webjars|css|icons|favicon|images|js|serviceValidate|oauth2.0|clientredirect|oidc) {
-    proxy_pass {{ 'https' if vitamui.cas_server.secure | default(secure) | bool else 'http' }}://CAS;
+    {% if vitamui.cas_server.secure | default(secure) | bool %}
+    set $cas_server_dns "vitamui-{{ vitamui.cas_server.vitamui_component }}.service.{{ consul_domain }}";
+    proxy_pass https://$cas_server_dns:{{ vitamui.cas_server.port_service }};
+    {% else %}
+    proxy_pass http://CAS;
+    {% endif %}
     include {{ nginx_conf_dir }}/proxy_params;
   }
 

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -133,6 +133,19 @@
     - update_vitamui_certificates # Mandatory to update configuration file containing keystore password
   notify: restart service
 
+- name: "Copy {{ vitamui_struct.vitamui_component }} jks keystore (client-external)"
+  copy:
+    src: "{{ inventory_dir }}/keystores/client-external/keystore_{{ vitamui_struct.vitamui_component }}.p12"
+    dest: "{{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.vitamui_component }}.p12"
+    owner: "{{ vitamui_defaults.users.vitamui }}"
+    group: "{{ vitamui_defaults.users.group }}"
+    mode: "{{ vitamui_defaults.folder.conf_permission }}"
+  when:
+    - vitamui_struct.vitamui_component == 'cas-server'
+    - lookup('pipe', 'test -f {{ inventory_dir }}/keystores/client-external/keystore_{{ vitamui_struct.vitamui_component }}.p12 || echo nofile') == ''
+  tags: update_vitamui_certificates
+  notify: restart service
+
 - name: "Copy {{ vitamui_struct.service_name | default(service_name) }} jks keystore (server)"
   copy:
     src: "{{ inventory_dir }}/keystores/server/{{ inventory_hostname }}/keystore_{{ vitamui_struct.vitamui_component }}.jks"

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -57,9 +57,8 @@ iam-client:
   secure: {{ vitamui.iam_external.secure | default(secure) | lower }}
   ssl-configuration:
     keystore:
-      key-path: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
-      key-password: {{ password_keystore }}
-      type: JKS
+      key-path: {{ vitamui_folder_conf }}/keystore_client_{{ vitamui_struct.vitamui_component }}.p12
+      key-password: {{ password_keystore_client }}
     truststore:
       key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
       key-password: {{ password_truststore }}

--- a/deployment/scripts/mongod/v7.1/000_security.populate_certificates.js.j2
+++ b/deployment/scripts/mongod/v7.1/000_security.populate_certificates.js.j2
@@ -28,13 +28,13 @@ db.certificates.insertOne({
 {{ process('{{ pki_dir }}/server/hosts/%host%/cas-server.pem', 'cas_context', 'hosts_cas_server') }}
 {{ process('{{ pki_dir }}/server/hosts/%host%/iam-internal.pem', 'iam_internal_context', 'hosts_vitamui_iam_internal') }}
 
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-portal.pem', 'ui_portal_context', 'hosts_ui_portal') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-identity.pem', 'ui_identity_context', 'hosts_ui_identity') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-identity-admin.pem', 'ui_admin_identity_context', 'hosts_ui_identity_admin') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-referential.pem', 'ui_referential_context', 'hosts_ui_referential') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-archive-search.pem', 'ui_archive_search_context', 'hosts_ui_archive_search') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-ingest.pem', 'ui_ingest_context', 'hosts_ui_ingest') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-pastis.pem', 'ui_pastis_context', 'hosts_ui_pastis') }}
-{{ process('{{ pki_dir }}/server/hosts/%host%/ui-collect.pem', 'ui_collect_context', 'hosts_ui_collect') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-portal/ui-portal.pem', 'ui_portal_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity/ui-identity.pem', 'ui_identity_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity-admin/ui-identity-admin.pem', 'ui_admin_identity_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-referential/ui-referential.pem', 'ui_referential_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-archive-search/ui-archive-search.pem', 'ui_archive_search_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-ingest/ui-ingest.pem', 'ui_ingest_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-pastis/ui-pastis.pem', 'ui_pastis_context') }}
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-collect/ui-collect.pem', 'ui_collect_context') }}
 
 print("END security.populate_certificates.js");

--- a/deployment/scripts/mongod/v7.1/000_security.populate_certificates.js.j2
+++ b/deployment/scripts/mongod/v7.1/000_security.populate_certificates.js.j2
@@ -25,9 +25,9 @@ db.certificates.insertOne({
     {% endif %}
 {%- endmacro %}
 
-{{ process('{{ pki_dir }}/server/hosts/%host%/cas-server.pem', 'cas_context', 'hosts_cas_server') }}
 {{ process('{{ pki_dir }}/server/hosts/%host%/iam-internal.pem', 'iam_internal_context', 'hosts_vitamui_iam_internal') }}
 
+{{ insertCertificate('{{ pki_dir }}/client-external/clients/cas-server/cas-server.pem', 'cas_context') }}
 {{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-portal/ui-portal.pem', 'ui_portal_context') }}
 {{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity/ui-identity.pem', 'ui_identity_context') }}
 {{ insertCertificate('{{ pki_dir }}/client-external/clients/ui-identity-admin/ui-identity-admin.pem', 'ui_admin_identity_context') }}


### PR DESCRIPTION
## Architecture générale

Voici l'architecture des communications entre les services.

```mermaid
graph TD

    %% Service Definitions
    RP[Reverse Proxy]

    subgraph SERVICES_UI[VitamUI-UI Services]
        direction TB
        UPO[ui-portal]
        UID[ui-identity]
        UIA[ui-identity-admin]
        UAS[ui-archive-search]
        URE[ui-referential]
        UCO[ui-collect]
        UPA[ui-pastis]
        UIN[ui-ingest]       
    end

    API_GW[api-gateway]
    CAS[cas-server]

    subgraph VITAM_UI_SERVICES[VitamUI Services]
        direction TB
        subgraph SERVICES_EXT[Services External]
            direction TB
            RE[referential-external]
            PE[pastis-external]
            IE[ingest-external]
            CE[collect-external]
            ASE[archive-search-external]
        end
        
        subgraph SERVICES_INT[Services Internal]
            direction TB
            RI[referential-internal]
            PI[pastis-internal]
            II[ingest-internal]
            CI[collect-internal]
            ASI[archive-search-internal]
        end
 
        IAM_EXT[iam-external]
        IAM_INT[iam-internal]
        SEC[security-internal]
    end

    %% Communications
    EXTERNAL -->|https| RP
    RP -->|http| SERVICES_UI
    RP -->|https| CAS
    SERVICES_UI -->|mTLS| API_GW
    API_GW -->|https + x-ssl-cert| SERVICES_EXT
    SERVICES_EXT -->|https| SERVICES_INT
    SERVICES_EXT -->|https| SEC
    SERVICES_EXT -->|https| IAM_INT
    SERVICES_INT -->|https| IAM_INT
    
    CAS -->|mTLS| IAM_EXT
    IAM_EXT -->|https| SEC
    IAM_EXT -->|https| IAM_INT
    IAM_INT -->|https| SEC
    IAM_INT -->|https| CAS
```

## Organisation des certificats

### Gestion des certificats Clients

Les composants ui-* ainsi que cas-server ont besoin de certificats clients pour effectuer les appels sur les APIs de VitamUI.

Veuillez vous référer aux paramètres de l'extension_client dans le fichier `pki/config/crt-config`.

Voici l'arborescence attendue:
```
environments/certs/client-external/
├── ca
│   ├── ca-intermediate.crt
│   └── ca-root.crt
└── clients
    ├── cas-server
    │   ├── cas-server.crt
    │   ├── cas-server.key
    │   └── cas-server.pem
    ├── ui-archive-search
    │   ├── ui-archive-search.crt
    │   ├── ui-archive-search.key
    │   └── ui-archive-search.pem
    ├── ui-collect
    │   ├── ui-collect.crt
    │   ├── ui-collect.key
    │   └── ui-collect.pem
    ├── ui-design-system
    │   ├── ui-design-system.crt
    │   ├── ui-design-system.key
    │   └── ui-design-system.pem
    ├── ui-identity
    │   ├── ui-identity.crt
    │   ├── ui-identity.key
    │   └── ui-identity.pem
    ├── ui-identity-admin
    │   ├── ui-identity-admin.crt
    │   ├── ui-identity-admin.key
    │   └── ui-identity-admin.pem
    ├── ui-ingest
    │   ├── ui-ingest.crt
    │   ├── ui-ingest.key
    │   └── ui-ingest.pem
    ├── ui-pastis
    │   ├── ui-pastis.crt
    │   ├── ui-pastis.key
    │   └── ui-pastis.pem
    ├── ui-portal
    │   ├── ui-portal.crt
    │   ├── ui-portal.key
    │   └── ui-portal.pem
    └── ui-referential
        ├── ui-referential.crt
        ├── ui-referential.key
        └── ui-referential.pem
```

> **Note**: Les .crt doivent être convertis au format .pem pour leur permettre d'être chargés dans la base `security -> certificates`.
> Les .key des composants ui-* ne doivent pas avoir de passphrase. Actuellement il n'y a pas de possibilité de charger cette passphrase lors des appels effectués par nginx via `proxy_ssl_certificate_key`.

### Gestion des certificats Serveurs

Chacun des composants applicatifs de VitamUI devra fournir des certificats à partir du moment où ils sont configurés en mode `secure: true`.

Veuillez vous référer aux paramètres de l'extension_server dans le fichier `pki/config/crt-config`.

Voici l'arborescence attendue à ajuster en fonction de la répartition des services entre les machines (Se référer à la répartition dans l'inventaire. Pour l'exemple suivant, nous allons utiliser `<inventory_hostname>`):
```
environments/certs/server/
├── ca
│   ├── ca-intermediate.crt
│   └── ca-root.crt
└── hosts
    └── <inventory_hostname>
        ├── api-gateway.crt
        ├── api-gateway.key
        ├── archive-search-external.crt
        ├── archive-search-external.key
        ├── archive-search-internal.crt
        ├── archive-search-internal.key
        ├── cas-server.crt
        ├── cas-server.key
        ├── collect-external.crt
        ├── collect-external.key
        ├── collect-internal.crt
        ├── collect-internal.key
        ├── iam-external.crt
        ├── iam-external.key
        ├── iam-internal.crt
        ├── iam-internal.key
        ├── iam-internal.pem
        ├── ingest-external.crt
        ├── ingest-external.key
        ├── ingest-internal.crt
        ├── ingest-internal.key
        ├── pastis-external.crt
        ├── pastis-external.key
        ├── referential-external.crt
        ├── referential-external.key
        ├── referential-internal.crt
        ├── referential-internal.key
        ├── reverse.crt
        ├── reverse.key
        ├── security-internal.crt
        └── security-internal.key
```

> **Note**: Il sera nécessaire de préciser les Subject Alternative Name (SAN) selon la convention suivante: `OPENSSL_SAN="DNS:vitamui-${COMPONENT}.service.${CONSUL_DOMAIN},DNS:vitamui-${COMPONENT}.service.${DC_NAME}.${CONSUL_DOMAIN}"`
> Si vous souhaitez multi-instancier certains services, vous pouvez dupliquer les mêmes certificats dans chacun des répertoires de `<inventory_hostname>` puisque le hostname-verification s'effectuera sur leur SAN.

### Gestion des keystores

Chacun des composants applicatifs de VitamUI devra fournir un keystore afin de permettre le chargement des certificats associés.

Voici l'arborescence attendue:
```
environments/keystores/
├── client-external
│   ├── keystore_cas-server.p12
│   └── truststore_external.jks
├── client-vitam
│   ├── keystore_vitamui.p12
│   └── truststore_vitam.jks
└── server
    ├── truststore_server.jks
    └── <inventory_hostname>
        ├── keystore_api-gateway.jks
        ├── keystore_archive-search-external.jks
        ├── keystore_archive-search-internal.jks
        ├── keystore_cas-server.jks
        ├── keystore_collect-external.jks
        ├── keystore_collect-internal.jks
        ├── keystore_iam-external.jks
        ├── keystore_iam-internal.jks
        ├── keystore_ingest-external.jks
        ├── keystore_ingest-internal.jks
        ├── keystore_pastis-external.jks
        ├── keystore_referential-external.jks
        ├── keystore_referential-internal.jks
        ├── keystore_reverse.jks
        └── keystore_security-internal.jks
```

> **Note**: Le composant `cas-server` possède 2 keystores distincts. Le premier sous client-external pour ses appels en tant qu'application cliente. Le second sous server pour l'exposition de son service en https aux autres applications (mode `secure: true`).
> Le `truststore_external` doit contenir les CA publiques de client-external et server.
> Le `truststore_server` ne contient que les CA publiques de server.

## Déploiement

Suite à l'application de ce patch de configuration:

Lors d'un déploiement initial, les certificats seront bien pris en compte à tous les niveaux (système et base de données). Vous n'avez rien de particulier à faire que de suivre la procédure de déploiement classique.

Cependant, en cas de mise à jour d'une infrastructure existante, il faudra procéder à la mise à jour des certificats dans la base de données `mongo-vitam: security.certificates` en jouant le playbook: `ansible-vitamui-exploitation/reinit_security_certificates.yml`.

## Type de changement

* PKI
* Ansiblerie
* Refactorisation de code

## Contributeur

* Programme Vitam