### PR TITLE
Story #15211: Fixing deployment since separated certificates.

### DIFF
--- a/deployment/ansible-vitamui/app_archive_search.yml
+++ b/deployment/ansible-vitamui/app_archive_search.yml
@@ -6,8 +6,6 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.archive_search }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_archive_search }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_archive_search }}"
-    password_truststore: "{{ truststores_client_external }}"
     vitam_cert: "{{ vitam_certs.vitamui }}"

--- a/deployment/ansible-vitamui/app_collect.yml
+++ b/deployment/ansible-vitamui/app_collect.yml
@@ -6,8 +6,6 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.collect }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_collect }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_collect }}"
-    password_truststore: "{{ truststores_client_external }}"
     vitam_cert: "{{ vitam_certs.vitamui }}"

--- a/deployment/ansible-vitamui/app_ingest.yml
+++ b/deployment/ansible-vitamui/app_ingest.yml
@@ -6,8 +6,6 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.ingest }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_ingest }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_ingest }}"
-    password_truststore: "{{ truststores_client_external }}"
     vitam_cert: "{{ vitam_certs.vitamui }}"

--- a/deployment/ansible-vitamui/app_pastis.yml
+++ b/deployment/ansible-vitamui/app_pastis.yml
@@ -6,8 +6,6 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.pastis }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_pastis }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_pastis }}"
-    password_truststore: "{{ truststores_client_external }}"
     vitam_cert: "{{ vitam_certs.vitamui }}"

--- a/deployment/ansible-vitamui/app_referential.yml
+++ b/deployment/ansible-vitamui/app_referential.yml
@@ -6,8 +6,6 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.referential }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_referential }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_referential }}"
-    password_truststore: "{{ truststores_client_external }}"
     vitam_cert: "{{ vitam_certs.vitamui }}"

--- a/deployment/ansible-vitamui/vitamui_apps.yml
+++ b/deployment/ansible-vitamui/vitamui_apps.yml
@@ -8,9 +8,7 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.security }}"
-    vitamui_certificate_type: server
     password_keystore_server: "{{ keystores_server_vitamui_services_security }}"
-    password_truststore: "{{ truststores_vitamui }}"
   tags: security
 
 # External apps
@@ -21,10 +19,8 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.iam }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_iam }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_iam }}"
-    password_truststore: "{{ truststores_client_external }}"
     vitam_cert: "{{ vitam_certs.vitamui }}"
   tags: iam
 
@@ -36,8 +32,6 @@
     - vitamui
   vars:
     vitamui_struct: "{{ vitamui.cas_server }}"
-    vitamui_certificate_type: external
     password_keystore_server: "{{ keystores_server_vitamui_services_cas_server }}"
     password_keystore_client: "{{ keystores_client_vitamui_services_cas_server }}"
-    password_truststore: "{{ truststores_client_external }}"
   tags: cas-server

--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -66,37 +66,46 @@ vitamui:
   ui_identity:
     vitamui_component: ui-identity
     port_service: 8002
+    secure: false
   ui_identity_admin:
     vitamui_component: ui-identity-admin
     port_service: 8401
+    secure: false
     package_name: vitamui-ui-identity-rsc
   ui_referential:
     vitamui_component: ui-referential
     port_service: 8005
+    secure: false
   ui_portal:
     vitamui_component: ui-portal
     port_service: 8003
+    secure: false
     has_tenant_list: true
     has_lang_selection: true
     has_site_selection: false
   ui_ingest:
     vitamui_component: ui-ingest
     port_service: 8008
+    secure: false
   ui_archive_search:
     vitamui_component: ui-archive-search
     port_service: 8009
+    secure: false
   ui_collect:
     vitamui_component: ui-collect
     port_service: 8010
+    secure: false
 #    offline_services: # Disables online search engines in collect
 #      - agencies
 #      - archive-unit-profiles
   ui_pastis:
     vitamui_component: ui-pastis
     port_service: 9015
+    secure: false
   ui_design_system:
     vitamui_component: ui-design-system
     port_service: 9016
+    secure: false
 
   # Applications
   api_gateway:

--- a/deployment/pki/scripts/generate_certs.sh
+++ b/deployment/pki/scripts/generate_certs.sh
@@ -43,7 +43,6 @@ function generateCerts {
     generateServerAndClientCertAndStorePassphrase   ui-archive-search   vitamui-services
     generateServerAndClientCertAndStorePassphrase   ui-collect          vitamui-services
     generateServerAndClientCertAndStorePassphrase   ui-pastis           vitamui-services
-    generateServerCertAndStorePassphrase            ui-design-system    vitamui-services
 
     #Reverse
     generateServerCertAndStorePassphrase            reverse             hosts_vitamui_reverseproxy    vitamui-services

--- a/deployment/pki/scripts/generate_certs_dev.sh
+++ b/deployment/pki/scripts/generate_certs_dev.sh
@@ -51,7 +51,6 @@ function generateCerts {
     generateServerAndClientCertAndStorePassphrase   ui-archive-search   vitamui-services
     generateServerAndClientCertAndStorePassphrase   ui-pastis           vitamui-services
     generateServerAndClientCertAndStorePassphrase   ui-collect          vitamui-services
-    generateServerCertAndStorePassphrase            ui-design-system    vitamui-services
 
     #Reverse
     generateServerCertAndStorePassphrase            reverse             hosts_vitamui_reverseproxy     vitamui-services

--- a/deployment/pki/scripts/lib/certs.sh
+++ b/deployment/pki/scripts/lib/certs.sh
@@ -150,8 +150,10 @@ function generateClientCertificate {
     local CLIENT_CERTIFICATE_PATH=$(getClientCertificatePath ${CLIENT_TYPE} ${CLIENT_NAME})
     mkdir -p "${CLIENT_CERTIFICATE_PATH}"
     pki_logger "Generation de la clé..."
+    # Workaround to avoid passphrase with -nodes option problem while loading passphrase to nginx
     openssl req -newkey "${PARAM_KEY_CHIFFREMENT}" \
         -passout pass:"${MDP_KEY}" \
+        -nodes \
         -keyout "${CLIENT_CERTIFICATE_PATH}/${CLIENT_NAME}.key" \
         -out "${CLIENT_CERTIFICATE_PATH}/${CLIENT_NAME}.req" \
         -config "${REPERTOIRE_CONFIG}/crt-config" \

--- a/deployment/roles/nginx_webapp/tasks/install.yml
+++ b/deployment/roles/nginx_webapp/tasks/install.yml
@@ -25,7 +25,7 @@
   set_fact:
     frontend_application_version: "{{ package_facts_result.ansible_facts.packages[ vitamui_struct.package_name | default(package_name) ][0].version }}"
 
-- name: Configure upsteam for API GW
+- name: Configure upstream for API GW
   template:
     src: frontend/upstream_gw.j2
     dest: "{{ nginx_conf_dir }}/upstream_gw"
@@ -52,16 +52,17 @@
     mode: "{{ vitam_defaults.folder.conf_permission }}"
   notify: reload nginx
 
-- name: "Add UI certificates for {{ vitamui_struct.vitamui_component }}"
+- name: "Add client certificates for {{ vitamui_struct.vitamui_component }}"
   copy:
-    src: "{{ item }}"
-    dest: "{{ nginx_ssl_dir }}"
+    src: "{{ inventory_dir }}/certs/vitamui-services/clients/{{ vitamui_struct.vitamui_component }}/{{ vitamui_struct.vitamui_component }}.{{ item }}"
+    dest: "{{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}_client.{{ item }}"
     group: "{{ frontend_group }}"
     owner: "{{ frontend_user }}"
     mode: "{{ vitam_defaults.folder.conf_permission }}"
-  with_fileglob:
-    - "{{ inventory_dir }}/certs/vitamui-services/server/{{ vitamui_struct.vitamui_component }}/{{ vitamui_struct.vitamui_component }}.crt"
-    - "{{ inventory_dir }}/certs/vitamui-services/server/{{ vitamui_struct.vitamui_component }}/{{ vitamui_struct.vitamui_component }}.key"
+  loop:
+    - crt
+    - key
+  tags: update_vitamui_certificates
   notify: reload nginx
 
 - name: Put ssl configuration when secure is enabled

--- a/deployment/roles/nginx_webapp/tasks/install.yml
+++ b/deployment/roles/nginx_webapp/tasks/install.yml
@@ -62,6 +62,7 @@
   loop:
     - crt
     - key
+  when: vitamui_struct.vitamui_component != "ui-design-system"
   tags: update_vitamui_certificates
   notify: reload nginx
 

--- a/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
@@ -24,6 +24,7 @@ server {
     }
     try_files $uri $uri/ /index.html;
   }
+{% if vitamui_struct.vitamui_component != 'ui-design-system' %}
 
   {% if vitamui_struct.vitamui_component == 'ui-identity-admin' %}
   location /identity-api {
@@ -59,4 +60,5 @@ server {
     client_max_body_size 0;
     {% endif %}
   }
+{% endif %}
 }

--- a/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
@@ -36,11 +36,16 @@ server {
     {% endfor %}
     deny all; # Deny access to all other IP addresses
 
-    proxy_pass {{ 'https' if vitamui.api_gateway.secure | default(secure) | bool else 'http' }}://API-GATEWAY;
-    proxy_ssl_certificate {{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}.crt;
-    proxy_ssl_certificate_key {{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}.key;
-    proxy_ssl_session_reuse off;
+    {% if vitamui.api_gateway.secure | default(secure) | bool %}
+    set $api_gateway_dns "vitamui-{{ vitamui.api_gateway.vitamui_component }}.service.{{ consul_domain }}";
+    proxy_pass https://$api_gateway_dns:{{ vitamui.api_gateway.port_service }};
+    {% else %}
+    proxy_pass http://API-GATEWAY;
+    {% endif %}
+    proxy_ssl_certificate {{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}_client.crt;
+    proxy_ssl_certificate_key {{ nginx_ssl_dir }}/{{ vitamui_struct.vitamui_component }}_client.key;
 
+    proxy_ssl_session_reuse off;
     {% if vitamui_struct.vitamui_component in [ 'ui-ingest', 'ui-collect' ] %}
     # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
     # The request body is sent to the proxied server immediately as it is received.

--- a/deployment/roles/reverse/templates/nginx/conf.d/upstream.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/upstream.j2
@@ -77,12 +77,12 @@ upstream PASTIS {
 {% endfor %}
 }
 {% endif %}
+{% if groups.get('hosts_ui_design_system', []) | length > 0 %}
 
-{% if groups.get('hosts_ui_design_system', [])|length > 0 %}
 upstream DESIGN_SYSTEM {
   ip_hash;
-{% for h in groups.get('hosts_ui_design_system', []) %}
+  {% for h in groups['hosts_ui_design_system'] %}
   server {{ hostvars[h].ip_service }}:{{ vitamui.ui_design_system.port_service }};
-{% endfor %}
+  {% endfor %}
 }
 {% endif %}

--- a/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
@@ -103,12 +103,12 @@ server {
     client_max_body_size 0;
   }
 {% endif %}
+{% if groups.get('hosts_ui_design_system', []) | length > 0 %}
 
-{% if groups.get('hosts_ui_design_system', [])|length > 0 %}
   # DESIGN SYSTEM
   location /design-system {
     rewrite /design-system/(.*) /$1 break;
-    proxy_pass {{ 'https' if vitamui.ui_design_system.secure | default(secure) | bool else 'http' }}://DESIGN_SYSTEM;
+    proxy_pass http://DESIGN_SYSTEM;
 
     include {{ nginx_conf_dir }}/proxy_params;
   }

--- a/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
@@ -120,7 +120,12 @@ server {
   }
 
   location ~ ^/cas/(login|logout|extras|webjars|css|icons|favicon|images|js|serviceValidate|oauth2.0|clientredirect|oidc) {
-    proxy_pass {{ 'https' if vitamui.cas_server.secure | default(secure) | bool else 'http' }}://CAS;
+    {% if vitamui.cas_server.secure | default(secure) | bool %}
+    set $cas_server_dns "vitamui-{{ vitamui.cas_server.vitamui_component }}.service.{{ consul_domain }}";
+    proxy_pass https://$cas_server_dns:{{ vitamui.cas_server.port_service }};
+    {% else %}
+    proxy_pass http://CAS;
+    {% endif %}
     include {{ nginx_conf_dir }}/proxy_params;
   }
 

--- a/deployment/roles/reverse/templates/nginx/ssl/reverse.crt.j2
+++ b/deployment/roles/reverse/templates/nginx/ssl/reverse.crt.j2
@@ -1,1 +1,1 @@
-{{ lookup('file', "{{ inventory_dir }}/certs/server/hosts/{{ inventory_hostname }}/reverse.crt" ) }}
+{{ lookup('file', "{{ inventory_dir }}/certs/vitamui-services/server/reverse/reverse.crt" ) }}

--- a/deployment/roles/reverse/templates/nginx/ssl/reverse.key.j2
+++ b/deployment/roles/reverse/templates/nginx/ssl/reverse.key.j2
@@ -1,2 +1,1 @@
-{{ lookup('file', "{{ inventory_dir }}/certs/server/hosts/{{ inventory_hostname }}/reverse.key" ) }}
-
+{{ lookup('file', "{{ inventory_dir }}/certs/vitamui-services/server/reverse/reverse.key" ) }}

--- a/deployment/roles/vitamui/tasks/main.yml
+++ b/deployment/roles/vitamui/tasks/main.yml
@@ -164,13 +164,10 @@
   copy:
     src: "{{ inventory_dir }}/keystores/vitamui-services/truststore_vitamui.jks"
     dest: "{{ vitamui_folder_conf }}/truststore_vitamui.jks"
-    owner: "{{ vitamui_defaults.users.vitamui | default('vitamui') }}"
-    group: "{{ vitamui_defaults.users.group | default('vitamui') }}"
-    mode: "{{ vitamui_defaults.folder.folder_permission | default('0750') }}"
-  when:
-    - vitamui_struct.secure | default(secure) | lower == 'true'
-    - vitamui_certificate_type | default('none') | lower == 'vitamui-services'
-    - lookup('pipe', 'test -f {{ inventory_dir }}/keystores/vitamui-services/truststore_vitamui.jks || echo nofile') == ''
+    owner: "{{ vitamui_defaults.users.vitamui }}"
+    group: "{{ vitamui_defaults.users.group }}"
+    mode: "{{ vitamui_defaults.folder.conf_permission }}"
+  when: vitamui_struct.secure | default(secure) | bool
   tags: update_vitamui_certificates
   notify: restart service
 

--- a/deployment/roles/vitamui/templates/archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search/application.yml.j2
@@ -27,8 +27,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
     client-auth: want
     client-certificate-header-name: {{ vitamui.api_gateway.client_certificate_header_name | default('x-ssl-cert') }}
 {% endif %}
@@ -71,8 +71,8 @@ archive-search:
     secure: {{ vitamui.security.secure | default(secure) | lower }}
     ssl-configuration:
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
   iam-client:
@@ -86,8 +86,8 @@ archive-search:
         key-password: {{ password_keystore_client }}
         type: JKS
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -71,8 +71,8 @@ iam-client:
       key-password: {{ password_keystore_client }}
       type: JKS
     truststore:
-      key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-      key-password: {{ password_truststore }}
+      key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+      key-password: {{ truststores_vitamui }}
     hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect/application.yml.j2
@@ -36,8 +36,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
     client-auth: want
     client-certificate-header-name: {{ vitamui.api_gateway.client_certificate_header_name | default('x-ssl-cert') }}
 {% endif %}
@@ -80,8 +80,8 @@ collect:
     secure: {{ vitamui.security.secure | default(secure) | lower }}
     ssl-configuration:
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
   iam-client:
@@ -95,8 +95,8 @@ collect:
         key-password: {{ password_keystore_client }}
         type: JKS
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/iam/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam/application.yml.j2
@@ -30,8 +30,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
     client-auth: want
     client-certificate-header-name: {{ vitamui.api_gateway.client_certificate_header_name | default('x-ssl-cert') }}
 {% endif %}
@@ -76,8 +76,8 @@ iam:
     secure: true
     ssl-configuration:
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
 
@@ -112,8 +112,8 @@ cas-client:
       key-password: {{ password_keystore_client }}
       type: JKS
     truststore:
-      key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-      key-password: {{ password_truststore }}
+      key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+      key-password: {{ truststores_vitamui }}
     hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/ingest/application.yml.j2
+++ b/deployment/roles/vitamui/templates/ingest/application.yml.j2
@@ -22,8 +22,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
     client-auth: want
     client-certificate-header-name: {{ vitamui.api_gateway.client_certificate_header_name | default('x-ssl-cert') }}
 {% endif %}
@@ -68,8 +68,8 @@ ingest:
     secure: {{ vitamui.security.secure | default(secure) | lower }}
     ssl-configuration:
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
   iam-client:
@@ -83,8 +83,8 @@ ingest:
         key-password: {{ password_keystore_client }}
         type: JKS
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/pastis/application.yml.j2
+++ b/deployment/roles/vitamui/templates/pastis/application.yml.j2
@@ -45,8 +45,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
     client-auth: want
     client-certificate-header-name: {{ vitamui.api_gateway.client_certificate_header_name | default('x-ssl-cert') }}
 {% endif %}
@@ -90,8 +90,8 @@ pastis:
     secure: {{ vitamui.security.secure | default(secure) | lower }}
     ssl-configuration:
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
   iam-client:
@@ -105,8 +105,8 @@ pastis:
         key-password: {{ password_keystore_client }}
         type: JKS
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/referential/application.yml.j2
+++ b/deployment/roles/vitamui/templates/referential/application.yml.j2
@@ -31,8 +31,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
     client-auth: want
     client-certificate-header-name: {{ vitamui.api_gateway.client_certificate_header_name | default('x-ssl-cert') }}
 {% endif %}
@@ -76,8 +76,8 @@ referential:
     secure: {{ vitamui.security.secure | default(secure) | lower }}
     ssl-configuration:
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
   iam-client:
@@ -91,8 +91,8 @@ referential:
         key-password: {{ password_keystore_client }}
         type: JKS
       truststore:
-        key-path: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-        key-password: {{ password_truststore }}
+        key-path: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+        key-password: {{ truststores_vitamui }}
       hostname-verification: true
 {% endif %}
 

--- a/deployment/roles/vitamui/templates/security/application.yml.j2
+++ b/deployment/roles/vitamui/templates/security/application.yml.j2
@@ -28,8 +28,8 @@ server:
     key-store: {{ vitamui_folder_conf }}/keystore_{{ vitamui_struct.service_name | default(service_name) }}.jks
     key-store-password: {{ password_keystore_server }}
     key-password: {{ password_keystore_server }}
-    trust-store: {{ vitamui_folder_conf }}/truststore_{{ vitamui_certificate_type }}.jks
-    trust-store-password: {{ password_truststore }}
+    trust-store: {{ vitamui_folder_conf }}/truststore_vitamui.jks
+    trust-store-password: {{ truststores_vitamui }}
 {% endif %}
   max-http-request-header-size: {{ vitamui_struct.server_max_http_header_size | default('10KB') }}
   tomcat:


### PR DESCRIPTION
## Description

> Fix following #3445

### PKI

* Generate client certificates without a password. Currently, there is no method to provide a password to nginx.

### Ansible
 
* Disabling HTTPS by default for UI components.
* Providing client certificates for UI components (using `proxy_ssl_certificate`).
* Providing correct reverse cert since updating PKI.
* Updating truststores for vitamui-services to the proper one.
* Disabling upstream for cas and api-gateway because https call need dns resolution (Certificates are generated with SAN without ipaddress).

## Architecture

Here is the current network architecture:

```mermaid
graph TD

    %% Service Definitions
    RP[Reverse Proxy]

    subgraph SERVICES_UI[VitamUI-UI Services]
        direction TB
        UPO[ui-portal]
        UID[ui-identity]
        UIA[ui-identity-admin]
        UAS[ui-archive-search]
        URE[ui-referential]
        UCO[ui-collect]
        UPA[ui-pastis]
        UIN[ui-ingest]
    end

    API_GW[api-gateway]
    CAS[cas-server]

    subgraph VITAM_UI_SERVICES[VitamUI Services]
        direction TB
        subgraph VUI_SERVICES[ ]
            direction TB
            R[referential]
            P[pastis]
            I[ingest]
            C[collect]
            AS[archive_search]
        end
 
        IAM[iam]
        SEC[security]
    end

    %% Communications
    EXTERNAL -->|https| RP
    RP -->|http| SERVICES_UI
    RP -->|https| CAS
    SERVICES_UI -->|mTLS| API_GW
    API_GW -->|https + x-ssl-cert| VITAM_UI_SERVICES
    VUI_SERVICES -->|mTLS| IAM
    VUI_SERVICES -->|https| SEC
    
    IAM <-->|mTLS| CAS
    IAM -->|https| SEC
```

## Type de changement

* PKI
* Ansiblerie
* Correction

## Contributeur

* Programme Vitam