### PR TITLE
CP V9.0 - Bug #15680: Fixing serviceId for identity-admin.

### DIFF
--- a/deployment/scripts/mongod/v7.1/004_TRV-400_enable_oidc_code_grant_type_on_identity_service_ref.js.j2
+++ b/deployment/scripts/mongod/v7.1/004_TRV-400_enable_oidc_code_grant_type_on_identity_service_ref.js.j2
@@ -27,7 +27,7 @@ db.services.insertOne({
   _id: NumberInt(3),
   _class: "org.apereo.cas.services.OidcRegisteredService",
   clientId: "{{ vitamui.ui_identity_admin.clientId | default('identity-admin') }}",
-  serviceId: "{{ vitamui.ui_identity_admin.serviceId | default('^' + vitamui.ui_identity_admin.base_url | default(url_prefix+'/identity_admin') + '/.*') }}",
+  serviceId: "{{ vitamui.ui_identity_admin.serviceId | default('^' + vitamui.ui_identity_admin.base_url | default(url_prefix+'/identity-admin') + '/.*') }}",
   name: "{{ vitamui.ui_identity_admin.name | default('Identity Admin Access Management Application') }}",
   bypassApprovalPrompt: true,
   supportedGrantTypes: ["authorization_code"],

--- a/deployment/scripts/mongod/v9.0/0-06_update_applications_serviceId.js.j2
+++ b/deployment/scripts/mongod/v9.0/0-06_update_applications_serviceId.js.j2
@@ -13,11 +13,6 @@ db.services.updateOne({ "_id": NumberInt(2) }, {
         serviceId: "{{ vitamui.ui_identity.serviceId | default('^' + vitamui.ui_identity.base_url | default(url_prefix+'/identity') | regex_escape() | replace('\\', '\\\\') + '/.*') }}"
     }
 });
-db.services.updateOne({ "_id": NumberInt(3) }, {
-    "$set": {
-        serviceId: "{{ vitamui.ui_identity_admin.serviceId | default('^' + vitamui.ui_identity_admin.base_url | default(url_prefix+'/identity_admin') | regex_escape() | replace('\\', '\\\\') + '/.*') }}"
-    }
-});
 db.services.updateOne({ "_id": NumberInt(4) }, {
     "$set": {
         serviceId: "{{ vitamui.ui_referential.serviceId | default('^' + vitamui.ui_referential.base_url | default(url_prefix+'/referential') | regex_escape() | replace('\\', '\\\\') + '/.*') }}"

--- a/deployment/scripts/mongod/v9.0/1-01_fix_identity_admin_serviceId.js.j2
+++ b/deployment/scripts/mongod/v9.0/1-01_fix_identity_admin_serviceId.js.j2
@@ -1,0 +1,11 @@
+db = db.getSiblingDB("cas");
+
+print("START v9.0.1-01_fix_identity_admin_serviceId.js");
+
+db.services.updateOne({ "_id": NumberInt(3) }, {
+    "$set": {
+        serviceId: "{{ vitamui.ui_identity_admin.serviceId | default('^' + vitamui.ui_identity_admin.base_url | default(url_prefix+'/identity-admin') | regex_escape() | replace('\\', '\\\\') + '/.*') }}"
+    }
+});
+
+print("END v9.0.1-01_fix_identity_admin_serviceId.js");


### PR DESCRIPTION
## Description

> Cherry-Picked from #3530

ERROR on cas-server
```
Unsupported [redirect_uri]: [https://myenv.fr/identity-admin/customer] does not match what is defined for registered service: [^https://myenv\.fr/identity_admin/.*]. Service is considered unauthorized. Verify the service matching strategy used in the service definition is correct and does in fact match the client [https://myenv.fr/identity-admin/customer]
```

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam