### PR TITLE
Bug #15683 : Missing red chip for objects with errors

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-unit-information-tab/archive-unit-information-tab.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-unit-information-tab/archive-unit-information-tab.component.html
@@ -51,13 +51,6 @@
       [value]="archiveUnit()?.EndDate | dateTime: 'dd/MM/yyyy'"
     />
   </div>
-
-  @if (archiveUnitErrors().length) {
-    <div class="text normal bold danger">{{ 'COLLECT.ARCHIVE_UNIT_PREVIEW.FIELDS.ENCOUNTERED_ERRORS' | translate | uppercase }}</div>
-    @for (error of archiveUnitErrors(); track $index) {
-      <vitamui-information-detail [error]="error" [hideEvDetData]="true"></vitamui-information-detail>
-    }
-  }
 </div>
 
 <button
@@ -69,10 +62,19 @@
   <i class="vitamui-icon vitamui-icon-deposit"></i>
 </button>
 
-@if (technicalObjectsGroupErrors().length || objectsGroupErrors().length) {
-  <vitamui-information-bloc
-    [withObjectsTabLink]="true"
-    [decoration]="'bordered'"
-    (openObjectsTab)="goToObjectsTab()"
-  ></vitamui-information-bloc>
-}
+<div class="gap-3 align-items-stretch">
+  @if (technicalObjectsGroupErrors().length || objectsGroupErrors().length) {
+    <vitamui-information-bloc
+      [withObjectsTabLink]="true"
+      [decoration]="'bordered'"
+      (openObjectsTab)="goToObjectsTab()"
+    ></vitamui-information-bloc>
+  }
+
+  @if (archiveUnitErrors().length) {
+    <div class="text normal bold danger">{{ 'COLLECT.ARCHIVE_UNIT_PREVIEW.FIELDS.ENCOUNTERED_ERRORS' | translate | uppercase }}</div>
+    @for (error of archiveUnitErrors(); track $index) {
+      <vitamui-information-detail [error]="error" [hideEvDetData]="true"></vitamui-information-detail>
+    }
+  }
+</div>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/collect-object-group-details-tab/collect-object-group-details-tab.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/collect-object-group-details-tab/collect-object-group-details-tab.component.html
@@ -34,7 +34,7 @@
   </div>
 
   @if (technicalObjectsGroupErrors().length) {
-    <div class="d-flex flex-column gap-2 align-items-stretch">
+    <div class="d-flex flex-column gap-2 align-items-stretch mt-1">
       <div class="text normal bold danger">
         {{ 'COLLECT.ARCHIVE_UNIT_PREVIEW.FIELDS.ENCOUNTERED_ERRORS' | translate | uppercase }}
       </div>
@@ -49,6 +49,7 @@
   <vitamui-common-physical-archive-viewer
     *ngIf="versionWithQualifier.qualifier === 'PhysicalMaster'"
     [archive]="versionWithQualifier"
+    [errorMessages]="errorMessagesGot"
   ></vitamui-common-physical-archive-viewer>
 
   <div
@@ -65,6 +66,9 @@
         {{
           ('COLLECT.UNIT_OBJECT_QUALIFIER_TYPE.' + versionWithQualifier?.qualifier | translate) + ' (' + versionWithQualifier?.version + ')'
         }}
+        @if (errorMessagesGot && errorMessagesGot[versionWithQualifier['#id']]) {
+          <div class="status-badge-red status-badge-mini ml-2 mt-1"></div>
+        }
       </div>
       <div class="line object-size">{{ versionWithQualifier.Size | bytes }}</div>
     </div>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/physical-archive-viewer/physical-archive-viewer.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/physical-archive-viewer/physical-archive-viewer.component.html
@@ -23,6 +23,9 @@
     </div>
     <div class="line shrink object-name">
       {{ ('ARCHIVE_SEARCH.UNIT_OBJECT_QUALIFIER_TYPE.' + archive.qualifier | translate) + ' (' + archive.version + ')' }}
+      @if (hasErrors()) {
+        <div class="status-badge-red status-badge-mini ml-2 mt-1"></div>
+      }
     </div>
     <div *ngIf="archive.qualifier !== 'PhysicalMaster'" class="line object-size">
       {{ archive.Size | bytes }}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/physical-archive-viewer/physical-archive-viewer.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/archive-unit/components/physical-archive-viewer/physical-archive-viewer.component.ts
@@ -36,7 +36,7 @@
  */
 import { Component, Input, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { ObjectQualifierType, VersionWithQualifierDto } from '../../../models';
+import { ObjectQualifierType, ValidationError, VersionWithQualifierDto } from '../../../models';
 
 interface Measurement {
   name: string;
@@ -68,6 +68,7 @@ type MeasurementDisplayMode = 'SYMBOL' | 'NAME';
 })
 export class PhysicalArchiveViewerComponent implements OnInit {
   @Input() archive: VersionWithQualifierDto;
+  @Input() errorMessages: Record<string, ValidationError[]>;
 
   // Component configuration
   private measurementDisplayMode: MeasurementDisplayMode = 'NAME';
@@ -109,6 +110,10 @@ export class PhysicalArchiveViewerComponent implements OnInit {
 
   private isAllowedDisplayValue(displayValue: DisplayValue): boolean {
     return this.displayAll || this.items.includes(displayValue.originalKey);
+  }
+
+  hasErrors() {
+    return this.errorMessages && this.errorMessages[this.archive['#id']] !== undefined;
   }
 
   private translateMeasurementDisplayValue(displayValue: DisplayValue): DisplayValue {


### PR DESCRIPTION
## Description

Pastille rouge manquante pour les objets techniques contenant des erreurs, suite à https://assistance.programmevitam.fr/plugins/tracker/?aid=15575

**EDIT** : Ce correctif embarque également un autre correctif concernant le mauvais placement du composant du détail des erreurs sur Collecte (Il doit être en-dessous du bouton "Télecharger le document" et non au-dessus)
