### PR TITLE
Bug #15653 : Missing translation in Tree and Plan criteria filters

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
@@ -89,7 +89,7 @@ export class CriteriaSearchComponent {
   getCriteriaLabel(key: string, criteriaValue: SearchCriteriaValue): string {
     if (criteriaValue.valueTranslated) {
       return this.translateService.instant(
-        `ARCHIVE_SEARCH.SEARCH_CRITERIA_FILTER.${this.getCategoryName(this.criteriaVal.category)}.${criteriaValue.label}`,
+        `ARCHIVE_SEARCH.SEARCH_CRITERIA_FILTER.${this.getCategoryName(this.criteriaVal.category)}.${criteriaValue.value.id}`,
       );
     }
     if (key === 'ALL_ARCHIVE_UNIT_TYPES') {


### PR DESCRIPTION
## Description

Des clés de traduction ne sont plus traduites sur Archive-Search après avoir sélectionné la mise à jour des règles et en quittant cette même interface
