### PR TITLE
CP V9.0 - Bug #15706: Removing mongo_arbiter support.

### DIFF
--- a/deployment/environments/hosts-ui.example
+++ b/deployment/environments/hosts-ui.example
@@ -131,7 +131,6 @@ hosts_vitamui_mongod
 #  - mongo_rs_bootstrap=true (default: false); mandatory for 1 node of the shard, some init commands will be executed on it
 #  - mongo_cluster_name=mongo-vitamui (default: mongo-vitamui)
 #  - mongo_shard_id=0 (default: 0)
-#  - mongo_arbiter=true ; the node will be only an arbiter, it will not store data ; do not add this parameter on a mongo_rs_bootstrap node, maximum 1 node per shard
 #  - mongod_memory=x (default: unset); this will force the wiredtiger cache size to x (unit is GB)
 #  - is_small=true (default: false); this will force the priority for this server to be lower when electing master ; hardware can be downgraded for this machine
 #  - mongo_express_enabled=true to deploy mongo_express (default: false)

--- a/deployment/environments/hosts.local
+++ b/deployment/environments/hosts.local
@@ -149,7 +149,6 @@ hosts_vitamui_mongod
 #  - mongo_rs_bootstrap=true (default: false); mandatory for 1 node of the shard, some init commands will be executed on it
 #  - mongo_cluster_name=mongo-vitamui (default: mongo-vitamui)
 #  - mongo_shard_id=0 (default: 0)
-#  - mongo_arbiter=true ; the node will be only an arbiter, it will not store data ; do not add this parameter on a mongo_rs_bootstrap node, maximum 1 node per shard
 #  - mongod_memory=x (default: unset); this will force the wiredtiger cache size to x (unit is GB)
 #  - is_small=true (default: false); this will force the priority for this server to be lower when electing master ; hardware can be downgraded for this machine
 #  - mongo_express_enabled=true to deploy mongo_express (default: false)

--- a/deployment/roles/checks/tasks/check_mongo_config.yml
+++ b/deployment/roles/checks/tasks/check_mongo_config.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Ensure no mongo_arbiter is present in production environments
+  fail:
+    msg: "ERROR: mongo_arbiter is enabled for server {{ inventory_hostname }} and it's not recommended on Production environments. Please follow the exploitation documentation to remove arbiter from your cluster."
+  when:
+    - mongo_arbiter | default(false) | bool
+    - deployment_mode | default('prod') == 'prod'
+
+- name: Check if mongo_rs_bootstrap is not set as mongo_arbiter
+  fail:
+    msg: "ERROR: mongo_rs_bootstrap node can't be mongo_arbiter !"
+  when:
+    - mongo_arbiter | default(false) | bool
+    - mongo_rs_bootstrap | default(false) | bool

--- a/deployment/roles/checks/tasks/main.yml
+++ b/deployment/roles/checks/tasks/main.yml
@@ -2,18 +2,21 @@
 
 - block:
 
-  - name: Check deployment_mode
-    assert:
-      fail_msg: "ERROR: Invalid deployment_mode. Expected values are 'prod' (default) or 'dev'"
-      success_msg: "{{ 'dev mode enabled, ignoring the following errors...' if deployment_mode | default('prod') == 'dev' else 'production mode enabled, execution will fail if errors are detected...' }}"
-      that: deployment_mode | default('prod') in ['prod', 'dev']
+    - name: Check deployment_mode
+      assert:
+        fail_msg: "ERROR: Invalid deployment_mode. Expected values are 'prod' (default) or 'dev'"
+        success_msg: "{{ 'dev mode enabled, ignoring the following errors...' if deployment_mode | default('prod') == 'dev' else 'production mode enabled, execution will fail if errors are detected...' }}"
+        that: deployment_mode | default('prod') in ['prod', 'dev']
 
-  - import_tasks: check_inventory.yml
+    - import_tasks: check_inventory.yml
 
-  - import_tasks: check_consul.yml
+    - import_tasks: check_consul.yml
 
-  - import_tasks: check_passwords.yml
+    - import_tasks: check_passwords.yml
 
-  - import_tasks: check_mongo_express.yml
+    - import_tasks: check_mongo_express.yml
 
   run_once: true
+
+- import_tasks: check_mongo_config.yml
+  when: inventory_hostname in groups['hosts_vitamui_mongod']


### PR DESCRIPTION
## Description

> Cherry-Picked from #3549

Retrait du support de mongo_arbiter dans les procédures d'exemple et vérification de la bonne configuration dans les checks.

## Type de changement

* Ansiblerie
* Correction
* Refactorisation de code

## Contributeur

* Programme Vitam