### PR TITLE
CP V8.1 - Bug #15713: Updating deprecated parameter for ansible.cfg

### DIFF
--- a/deployment/ansible.cfg
+++ b/deployment/ansible.cfg
@@ -2,7 +2,7 @@
 hash_behaviour = merge
 roles_path     = ./roles/
 filter_plugins = ./filter_plugins/
-callback_whitelist = timer, profile_tasks
+callbacks_enabled = timer, profile_tasks
 gathering = smart
 fact_caching_connection = environments/.facts_cache
 fact_caching = jsonfile

--- a/tools/docker/mongo/ansible.cfg
+++ b/tools/docker/mongo/ansible.cfg
@@ -3,7 +3,7 @@
 hash_behaviour = merge
 roles_path     = ../../../deployment/roles/
 filter_plugins = ../../../deployment/filter_plugins/
-callback_whitelist = timer, profile_tasks
+callbacks_enabled = timer, profile_tasks
 host_key_checking = False
 
 [ssh_connection]


### PR DESCRIPTION
## Description

> Cherry-Picked from #3553

Fixing the following deprecation warning while executing ansible commands:

```
[DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names 
to new standard, use callbacks_enabled instead. This feature will be removed 
from ansible-core in version 2.15. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
```

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam