### PR TITLE
Bug #15732: Manage reverse certificates outside of the PKI directory.

### DIFF
--- a/deployment/roles/reverse/tasks/apache/apache.yml
+++ b/deployment/roles/reverse/tasks/apache/apache.yml
@@ -90,9 +90,9 @@
     group: "{{ apache_group }}"
     mode: 0550
 
-- name: copy server certificate files when protocole https
+- name: copy server certificate files when protocol is https
   copy:
-    src: "{{ inventory_dir }}/certs/vitamui-services/servers/reverse/reverse.{{ item }}"
+    src: "{{ lookup('first_found', [ inventory_dir + '/files/reverse/reverse.' + item, inventory_dir + '/certs/vitamui-services/servers/reverse/reverse.' + item ]) }}"
     dest: "/etc/{{ apache_service }}/certs/reverse.{{ item }}"
     owner: "{{ apache_user }}"
     group: "{{ apache_group }}"

--- a/deployment/roles/reverse/templates/nginx/ssl/reverse.crt.j2
+++ b/deployment/roles/reverse/templates/nginx/ssl/reverse.crt.j2
@@ -1,1 +1,1 @@
-{{ lookup('file', "{{ inventory_dir }}/certs/vitamui-services/servers/reverse/reverse.crt" ) }}
+{{ lookup('file', lookup('first_found', ["{{ inventory_dir }}/files/reverse/reverse.crt", "{{ inventory_dir }}/certs/vitamui-services/servers/reverse/reverse.crt"])) }}

--- a/deployment/roles/reverse/templates/nginx/ssl/reverse.key.j2
+++ b/deployment/roles/reverse/templates/nginx/ssl/reverse.key.j2
@@ -1,1 +1,1 @@
-{{ lookup('file', "{{ inventory_dir }}/certs/vitamui-services/servers/reverse/reverse.key" ) }}
+{{ lookup('file', lookup('first_found', ["{{ inventory_dir }}/files/reverse/reverse.key", "{{ inventory_dir }}/certs/vitamui-services/servers/reverse/reverse.key"])) }}


### PR DESCRIPTION
## Description

To prevent reverse proxy certificates from being overwritten during the execution of the `generate_certs` script, you can now provide custom certificates for the reverse proxy by placing them in the following directory: `environments/files/reverse/reverse.{crt,key}`.

## Type de changement

* Ansiblerie
* Refactorisation de code

## Contributeur

* Programme Vitam