### PR TITLE
Fix #15691: fix missing config for increasing Nginx timeouts for big uploads

### DIFF
--- a/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/vhost.conf.j2
@@ -58,6 +58,16 @@ server {
     # Please be aware that browsers cannot correctly display this error.
     # Setting size to 0 disables checking of client request body size.
     client_max_body_size 0;
+
+    # Increase send timeout to allow the upstream more time to consume the stream.
+    # This prevents "Early EOF" errors during large uploads if the backend slows down.
+    # Note: This is a timeout between two successive write operations, not for the total duration.
+    proxy_send_timeout 600s;
+
+    # Increase read timeout to allow the backend to process the file after the upload is complete.
+    # Essential for large ZIPs where post-upload tasks can take some time.
+    # Note: This is a timeout between two successive read operations from the upstream.
+    proxy_read_timeout 600s;
     {% endif %}
   }
 {% endif %}


### PR DESCRIPTION
Dans la MR initiale (https://github.com/ProgrammeVitam/vitam-ui/pull/3552), il manquait les timeouts pour les upstreams qui font passe-plat