### PR TITLE
Bug #14246 : Archive-Search - Tree structure issue in left lateral panel

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/nodes/filing-holding-scheme.handler.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/nodes/filing-holding-scheme.handler.ts
@@ -401,6 +401,7 @@ export class FilingHoldingSchemeHandler {
       // DEPRECATED OR UNUSED :
       type: unit['#unitType'],
       hidden: false,
+      signingInformation: unit.SigningInformation,
     };
   }
 

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/nodes/node.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/nodes/node.interface.ts
@@ -34,7 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Id, UnitType } from '../index';
+import { Id, SigningInformation, UnitType } from '../index';
 import { DescriptionLevel } from '../units/description-level.enum';
 
 export interface FilingHoldingSchemeNode extends Id {
@@ -49,6 +49,7 @@ export interface FilingHoldingSchemeNode extends Id {
   children: FilingHoldingSchemeNode[];
   vitamId: string;
   virtualPath?: string;
+  signingInformation?: SigningInformation;
 
   // DISPLAY
   disabledChild?: boolean; // TODO: try to remove - used in VitamuiTreeNodeComponent to set indeterminate

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/services/leaves-tree-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/services/leaves-tree-api.service.ts
@@ -70,6 +70,7 @@ const UNIT_TYPE_FIELD = '#unitType';
 const UNIT_DESCRIPTION_LEVEL_FIELD = 'DescriptionLevel';
 const UNIT_OBJECTS_FIELD = '#object';
 const INGEST_TYPE = 'INGEST';
+const SIGNING_INFORMATION = 'SigningInformation';
 
 export class LeavesTreeApiService {
   constructor(private searchArchiveUnitsService: SearchArchiveUnitsInterface) {}
@@ -225,6 +226,7 @@ export class LeavesTreeApiService {
         UNIT_TYPE_FIELD,
         UNIT_DESCRIPTION_LEVEL_FIELD,
         UNIT_OBJECTS_FIELD,
+        UNITSUPS,
         ALLUNITSUPS,
       ],
       facets: [],
@@ -486,6 +488,40 @@ export class LeavesTreeApiService {
         UNIT_OBJECTS_FIELD,
         ALLUNITSUPS,
         virtualPathOriginField,
+      ],
+      facets: [],
+      sortingCriteria: { criteria: TITLE_FIELD, sorting: 'ASC' },
+    };
+    return this.sendSearchArchiveUnitsByCriteria(criteria).pipe(
+      map((pagedResult) => {
+        return pagedResult;
+      }),
+    );
+  }
+
+  retrieveChildrenOfSignedDocumentAU(searchCriteria: SearchCriteriaDto, pageNumber: number, pageSize: number) {
+    let newCriteriaList = [...searchCriteria.criteriaList];
+    newCriteriaList.push({
+      criteria: UNITSUPS,
+      operator: CriteriaOperator.EXISTS,
+      category: SearchCriteriaTypeEnum.FIELDS,
+      values: [],
+      dataType: CriteriaDataType.STRING,
+    });
+    const criteria: SearchCriteriaDto = {
+      pageNumber: pageNumber,
+      size: pageSize,
+      criteriaList: newCriteriaList,
+      includedFields: [
+        UNIT_ID_FIELD,
+        TITLE_FIELD,
+        TITLE_WITH_LANG_FIELD,
+        UNIT_TYPE_FIELD,
+        UNIT_DESCRIPTION_LEVEL_FIELD,
+        UNIT_OBJECTS_FIELD,
+        ALLUNITSUPS,
+        UNITSUPS,
+        SIGNING_INFORMATION,
       ],
       facets: [],
       sortingCriteria: { criteria: TITLE_FIELD, sorting: 'ASC' },

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/services/leaves-tree.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/services/leaves-tree.service.ts
@@ -37,7 +37,15 @@
 import { isEmpty } from 'lodash-es';
 import { EMPTY, firstValueFrom, forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { FACETS_DEFAULT_SIZE, FilingHoldingSchemeHandler, FilingHoldingSchemeNode, LeavesLoadingCriteria, UnitType } from '../models';
+import {
+  FACETS_DEFAULT_SIZE,
+  FilingHoldingSchemeHandler,
+  FilingHoldingSchemeNode,
+  LeavesLoadingCriteria,
+  ORPHANS_NODE_ID,
+  Unit,
+  UnitType,
+} from '../models';
 import { PagedResult, ResultFacet, SearchCriteriaDto } from '../models/criteria/search-criteria.interface';
 import { SearchArchiveUnitsInterface } from './search-archive-units.interface';
 import { DEFAULT_LEAVES_FIRST_PAGE_SIZE, DEFAULT_UNIT_PAGE_SIZE, LeavesTreeApiService } from './leaves-tree-api.service';
@@ -222,8 +230,13 @@ export class LeavesTreeService {
           node.realDirectNodeMatchingPage,
           leavesLoadingCriteria.nodeMatchingChildrenPageSize,
         ),
+        childrenOfSignedDocumentAU: this.leavesTreeApiService.retrieveChildrenOfSignedDocumentAU(
+          this.searchCriterias,
+          node.realDirectNodeMatchingPage,
+          leavesLoadingCriteria.nodeMatchingChildrenPageSize,
+        ),
       }).subscribe({
-        next: ({ realDirectChildrenAny, realDirectChildrenMatching }) => {
+        next: ({ realDirectChildrenAny, realDirectChildrenMatching, childrenOfSignedDocumentAU }) => {
           let realChildrenMap = new Map<string, FilingHoldingSchemeNode>();
           let virtualChildrenMap = new Map<string, FilingHoldingSchemeNode>();
           let hasMoreAnyElts = false;
@@ -236,6 +249,20 @@ export class LeavesTreeService {
             directContainersNodes.forEach((containerNode) => {
               realChildrenMap.set(containerNode.id, containerNode);
             });
+          }
+
+          if (childrenOfSignedDocumentAU && node.id === ORPHANS_NODE_ID) {
+            const filteredchildsOfSignedDocuments = childrenOfSignedDocumentAU.results.filter(
+              (unit: Unit) => unit.SigningInformation !== undefined && unit['#unitups'] !== undefined,
+            );
+            realDirectChildrenMatching.results = [...realDirectChildrenMatching.results, ...filteredchildsOfSignedDocuments];
+            console.log(realDirectChildrenMatching);
+          } else {
+            const filteredchildsOfSignedDocuments = childrenOfSignedDocumentAU.results.filter((unit: Unit) =>
+              unit['#allunitups'].includes(node.id),
+            );
+            realDirectChildrenMatching.results = [...realDirectChildrenMatching.results, ...filteredchildsOfSignedDocuments];
+            console.log(realDirectChildrenMatching);
           }
 
           if (realDirectChildrenAny) {


### PR DESCRIPTION
## Description

Suite versement d'un SIP comprenant une signature électronique avec des éléments de preuves ou une signature détachée (exemple en pièce jointe)

Lorsque l'on fait une recherche sur l'identifiant versement , dans l'APP Recherche et consultation des archives

Alors l'arborescence du panneau latérale de gauche n'affiche pas les unités archivistiques qui sont rattachées l'AU du document signé.
