### PR TITLE
Bug #15702: Switch back to upstream resolution based on IP address for cas-server.

### DIFF
--- a/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
+++ b/deployment/roles/reverse/templates/nginx/conf.d/vhosts.conf.j2
@@ -140,12 +140,7 @@ server {
   }
 
   location ~ ^/cas/(login|logout|extras|webjars|css|icons|favicon|images|js|serviceValidate|oauth2.0|clientredirect|oidc) {
-    {% if vitamui.cas_server.secure | default(secure) | bool %}
-    set $cas_server_dns "vitamui-{{ vitamui.cas_server.vitamui_component }}.service.{{ consul_domain }}";
-    proxy_pass https://$cas_server_dns:{{ vitamui.cas_server.port_service }};
-    {% else %}
-    proxy_pass http://CAS;
-    {% endif %}
+    proxy_pass {{ 'https' if vitamui.cas_server.secure | default(secure) | bool else 'http' }}://CAS;
     include {{ nginx_conf_dir }}/proxy_params;
   }
 


### PR DESCRIPTION
## Description

It currently still work because `proxy_ssl_verify` is by default to false.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam