### PR TITLE
Bug #15732: Add documentation for managing reverse certificates outside of the PKI directory.

### DIFF
--- a/deployment/environments/files/reverse/README.md
+++ b/deployment/environments/files/reverse/README.md
@@ -1,0 +1,32 @@
+# External Reverse Proxy Certificates
+
+Place your certificates provided by an external Certificate Authority (CA) in this directory. By providing these files manually, you prevent the VitamUI PKI scripts from overwriting them with generated self-signed certificates during deployment.
+
+## Expected Files
+
+The following files must be present in this directory:
+
+* **`reverse.crt`**: The certificate bundle.
+* **`reverse.key`**: The private key associated with the certificate.
+
+## Certificate Bundle Requirements
+
+The `reverse.crt` file must be a concatenation of your certificates in **PEM format**. For the reverse proxy to function correctly and provide a full trust chain to browsers, use the following order:
+
+1. The Entity (Domain) Certificate
+2. The Intermediate CA Certificate(s)
+3. The Root CA Certificate (optional, but recommended)
+
+> **Note:** You can create this bundle via the command line:
+> `cat domain.crt intermediate.crt root.crt > reverse.crt`
+
+## Configuration & Security
+
+If your private key (`reverse.key`) is encrypted with a passphrase, you **must** define it in the VitamUI vault to allow Nginx to start automatically.
+
+1. Open the vault file: `environments/group_vars/all/vault-vitamui.yml`
+2. Set the following variable:
+
+```yml
+nginx_cert_key_password: "your_password_here"
+```

--- a/docs/fr/installation/sections/procedure.md
+++ b/docs/fr/installation/sections/procedure.md
@@ -215,7 +215,7 @@ Visualiser la fin du script de génération pour comprendre quels services sont 
 
 #### Mise en place de certificats personnalisés pour reverse proxy
 
-Si vous avez des certificats personnalisés pour le reverse proxy, vous pouvez remplacer ceux générés sous `environments/certs/server/hosts/<hostname>/reverse.{crt,key}` par ceux fournis par votre autorité de certification.
+Si vous avez des certificats fournis par votre autorité de certification pour le reverse proxy, vous pouvez les placer directement sous `environments/files/reverse/reverse.{crt,key}`. Ils auront la priorité lors du déploiement sur ceux générés par la PKI VitamUI sous `environments/certs/vitamui-services/server/reverse/`.
 
 > Info: reverse.crt est la concatenation du certificat et de la CA.
 


### PR DESCRIPTION
## Description

Ajout d'une documentation pour expliquer l'utilisation de ce nouvel emplacement pour la gestion des certificats du reverse proxy.

## Type de changement

* Documentation

## Contributeur

* Programme Vitam