### PR TITLE
Bug #15746 : Wrong HTTP code returned following CSV/ZIP validation errors

### DIFF
--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/dto/VitamErrorResponseDto.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/dto/VitamErrorResponseDto.java
@@ -27,17 +27,28 @@
 
 package fr.gouv.vitamui.collect.common.dto;
 
+import fr.gouv.vitam.common.error.VitamError;
+import fr.gouv.vitam.common.error.VitamErrorDetails;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.HashMap;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class VitamErrorsDetailsDto {
+public class VitamErrorResponseDto {
 
-    private String key;
-    private HashMap<String, String> args;
+    public VitamErrorResponseDto(VitamError<?> vitamError) {
+        this.code = vitamError.getCode();
+        this.httpCode = vitamError.getHttpCode();
+        this.message = vitamError.getMessage();
+        this.errorsDetails = vitamError.getErrorsDetails();
+    }
+
+    private String code;
+    private int httpCode;
+    private String message;
+    private List<VitamErrorDetails> errorsDetails;
 }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionController.java
@@ -26,10 +26,10 @@
  */
 package fr.gouv.vitamui.collect.server.rest;
 
-import fr.gouv.vitam.common.error.VitamErrorDetails;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.archives.search.common.dto.ReclassificationCriteriaDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
+import fr.gouv.vitamui.collect.common.dto.VitamErrorResponseDto;
 import fr.gouv.vitamui.collect.common.rest.RestApi;
 import fr.gouv.vitamui.collect.server.service.ExternalParametersService;
 import fr.gouv.vitamui.collect.server.service.TransactionService;
@@ -60,7 +60,6 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.io.InputStream;
-import java.util.List;
 
 import static fr.gouv.vitamui.collect.common.rest.RestApi.ABORT_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.DOWNLOAD_SIP_PATH;
@@ -162,7 +161,7 @@ public class TransactionController {
         value = CommonConstants.TRANSACTION_PATH_ID + UPDATE_UNITS_METADATA_PATH,
         consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE
     )
-    public List<VitamErrorDetails> updateArchiveUnitsMetadataFromCsvFile(
+    public VitamErrorResponseDto updateArchiveUnitsMetadataFromCsvFile(
         final @PathVariable("transactionId") String transactionId,
         InputStream inputStream,
         @RequestHeader(value = CommonConstants.X_ORIGINAL_FILENAME_HEADER) final String originalFileName

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ProjectService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ProjectService.java
@@ -37,7 +37,7 @@ import fr.gouv.vitam.collect.common.dto.CriteriaProjectDto;
 import fr.gouv.vitam.collect.common.dto.ProjectDto;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
 import fr.gouv.vitam.collect.common.dto.UploadSipResult;
-import fr.gouv.vitam.collect.external.external.exception.CollectExternalClientInvalidRequestException;
+import fr.gouv.vitam.collect.external.exception.CollectExternalClientInvalidRequestException;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionService.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
 import fr.gouv.vitam.common.client.VitamContext;
-import fr.gouv.vitam.common.error.VitamErrorDetails;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
@@ -43,6 +42,7 @@ import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
 import fr.gouv.vitamui.archives.search.common.dto.ReclassificationCriteriaDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
+import fr.gouv.vitamui.collect.common.dto.VitamErrorResponseDto;
 import fr.gouv.vitamui.collect.server.service.converters.TransactionConverter;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
@@ -62,7 +62,6 @@ import reactor.core.publisher.Mono;
 
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.List;
 
 import static fr.gouv.vitamui.commons.api.utils.MetadataSearchCriteriaUtils.mapRequestToDslQuery;
 
@@ -179,7 +178,7 @@ public class TransactionService {
         }
     }
 
-    public List<VitamErrorDetails> updateArchiveUnitsFromCsvFile(
+    public VitamErrorResponseDto updateArchiveUnitsFromCsvFile(
         InputStream inputStream,
         String transactionId,
         VitamContext vitamContext
@@ -187,15 +186,11 @@ public class TransactionService {
         try {
             LOGGER.debug("[Internal] call update Archive Units From CSV File for transaction Id {}  ", transactionId);
             collectService.updateCollectArchiveUnitsWithCsv(vitamContext, transactionId, inputStream);
-            return List.of();
+            return new VitamErrorResponseDto();
         } catch (VitamClientException e) {
             LOGGER.debug(UNABLE_TO_PROCESS_UNIT_UPDATE, e);
-            if (
-                e.getVitamError().getHttpCode() == HttpStatus.BAD_REQUEST.value() &&
-                e.getVitamError() != null &&
-                !e.getVitamError().getErrorsDetails().isEmpty()
-            ) {
-                return e.getVitamError().getErrorsDetails();
+            if (e.getVitamError() != null && e.getVitamError().getHttpCode() == HttpStatus.BAD_REQUEST.value()) {
+                return new VitamErrorResponseDto(e.getVitamError());
             } else {
                 throw new InternalServerException(e.getMessage(), e);
             }

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/rest/TransactionControllerTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/rest/TransactionControllerTest.java
@@ -30,8 +30,8 @@
 package fr.gouv.vitamui.collect.server.rest;
 
 import fr.gouv.vitam.common.client.VitamContext;
-import fr.gouv.vitam.common.error.VitamErrorDetails;
 import fr.gouv.vitam.common.exception.VitamClientException;
+import fr.gouv.vitamui.collect.common.dto.VitamErrorResponseDto;
 import fr.gouv.vitamui.collect.server.service.ExternalParametersService;
 import fr.gouv.vitamui.collect.server.service.TransactionService;
 import fr.gouv.vitamui.commons.api.domain.IdDto;
@@ -126,7 +126,7 @@ class TransactionControllerTest extends ApiCollectControllerTest<IdDto> {
         // Given
         String fileName = "FileName";
         String transactionId = "transactionId";
-        List<VitamErrorDetails> expectedResponse = List.of();
+        VitamErrorResponseDto expectedResponse = new VitamErrorResponseDto("BAD_REQUEST", 400, "Message", List.of());
         String initialString = "csv file to update collect units";
         InputStream csvFile = new ByteArrayInputStream(initialString.getBytes());
 
@@ -139,7 +139,7 @@ class TransactionControllerTest extends ApiCollectControllerTest<IdDto> {
                 any(VitamContext.class)
             )
         ).thenReturn(expectedResponse);
-        List<VitamErrorDetails> response = transactionController.updateArchiveUnitsMetadataFromCsvFile(
+        VitamErrorResponseDto response = transactionController.updateArchiveUnitsMetadataFromCsvFile(
             transactionId,
             csvFile,
             fileName

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/TransactionServiceTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/TransactionServiceTest.java
@@ -42,6 +42,7 @@ import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
+import fr.gouv.vitamui.collect.common.dto.VitamErrorResponseDto;
 import fr.gouv.vitamui.collect.server.service.converters.TransactionConverter;
 import fr.gouv.vitamui.commons.vitam.api.collect.CollectService;
 import jakarta.ws.rs.core.Response;
@@ -254,7 +255,7 @@ class TransactionServiceTest {
             fakeResponse
         );
         // WHEN
-        List<VitamErrorDetails> resultedOperation = transactionService.updateArchiveUnitsFromCsvFile(
+        VitamErrorResponseDto resultedOperation = transactionService.updateArchiveUnitsFromCsvFile(
             csvContent,
             TRANSACTION_ID,
             vitamContext
@@ -267,19 +268,19 @@ class TransactionServiceTest {
     void shouldThrowExceptionWhenUpdateArchiveUnitsFromFile()
         throws VitamClientException, InvalidParseOperationException {
         // GIVEN
-        List<VitamErrorDetails> resultsDto = List.of(new VitamErrorDetails("ERROR_KEY", null));
+        List<VitamErrorDetails> errorDetail = List.of(new VitamErrorDetails("ERROR_KEY", null));
         RequestResponseOK<JsonNode> fakeResponse = new RequestResponseOK<>();
         fakeResponse.setHttpCode(200);
-        fakeResponse.addResult(JsonHandler.toJsonNode(resultsDto));
+        fakeResponse.addResult(JsonHandler.toJsonNode(errorDetail));
         VitamClientException exception = new VitamClientException("error message");
         exception.setVitamError(
             new VitamError<>("BAD_REQUEST")
                 .setHttpCode(400)
                 .setContext("Collect")
                 .setMessage("error message")
-                .setErrorsDetails(resultsDto)
+                .setErrorsDetails(errorDetail)
         );
-
+        VitamErrorResponseDto expectedResponse = new VitamErrorResponseDto(exception.getVitamError());
         String fakeContent = "Path;Name;blablabla";
         InputStream csvContent = new ByteArrayInputStream(fakeContent.getBytes());
 
@@ -288,14 +289,14 @@ class TransactionServiceTest {
             .thenThrow(exception)
             .thenReturn(fakeResponse);
 
-        List<VitamErrorDetails> response = transactionService.updateArchiveUnitsFromCsvFile(
+        VitamErrorResponseDto response = transactionService.updateArchiveUnitsFromCsvFile(
             csvContent,
             TRANSACTION_ID,
             vitamContext
         );
 
         // THEN
-        assertThat(response).isEqualTo(resultsDto);
+        assertThat(response).isEqualTo(expectedResponse);
     }
 
     @Test

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/UpdateArchiveUnitsMetadataServiceTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/UpdateArchiveUnitsMetadataServiceTest.java
@@ -37,6 +37,7 @@ import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitamui.collect.common.dto.VitamErrorResponseDto;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.vitam.api.collect.CollectService;
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,7 @@ class UpdateArchiveUnitsMetadataServiceTest {
         throws VitamClientException, InvalidParseOperationException {
         // Given
         VitamContext vitamContext = new VitamContext(1);
-        final List<VitamErrorDetails> resultsDto = List.of();
+        final VitamErrorResponseDto resultsDto = new VitamErrorResponseDto();
         RequestResponseOK<JsonNode> vitamResponse = new RequestResponseOK<>();
         vitamResponse.setHttpCode(200);
         vitamResponse.addResult(JsonHandler.toJsonNode(resultsDto));
@@ -82,7 +83,7 @@ class UpdateArchiveUnitsMetadataServiceTest {
         Mockito.when(
             collectService.updateCollectArchiveUnitsWithCsv(eq(vitamContext), eq(transactionId), any())
         ).thenReturn(vitamResponse);
-        List<VitamErrorDetails> response = transactionService.updateArchiveUnitsFromCsvFile(
+        VitamErrorResponseDto response = transactionService.updateArchiveUnitsFromCsvFile(
             csvFileInputStream,
             transactionId,
             vitamContext
@@ -105,6 +106,7 @@ class UpdateArchiveUnitsMetadataServiceTest {
                 .setMessage("error message")
                 .setErrorsDetails(errorDetailsList)
         );
+        VitamErrorResponseDto expectedResponse = new VitamErrorResponseDto(exception.getVitamError());
         final String transactionId = "transactionId";
         InputStream csvFileInputStream =
             UpdateArchiveUnitsMetadataServiceTest.class.getClassLoader()
@@ -115,14 +117,14 @@ class UpdateArchiveUnitsMetadataServiceTest {
             collectService.updateCollectArchiveUnitsWithCsv(eq(vitamContext), eq(transactionId), any())
         ).thenThrow(exception);
 
-        List<VitamErrorDetails> response = transactionService.updateArchiveUnitsFromCsvFile(
+        VitamErrorResponseDto response = transactionService.updateArchiveUnitsFromCsvFile(
             csvFileInputStream,
             transactionId,
             vitamContext
         );
 
         //Then
-        assertThat(response).isEqualTo(errorDetailsList);
+        assertThat(response).isEqualTo(expectedResponse);
     }
 
     @Test

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
@@ -35,7 +35,7 @@ import fr.gouv.vitam.collect.common.dto.ProjectDto;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
 import fr.gouv.vitam.collect.common.dto.UploadSipResult;
 import fr.gouv.vitam.collect.external.client.CollectExternalClient;
-import fr.gouv.vitam.collect.external.external.exception.CollectExternalClientException;
+import fr.gouv.vitam.collect.external.exception.CollectExternalClientException;
 import fr.gouv.vitam.common.CharsetUtils;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-collect.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-collect.service.ts
@@ -59,7 +59,7 @@ import {
   SnackBarService,
   Transaction,
   Unit,
-  VitamErrorDetails,
+  VitamError,
   VitamuiHttpHeaders,
 } from 'vitamui-library';
 import { ProjectsApiService } from '../core/api/project-api.service';
@@ -284,7 +284,7 @@ export class ArchiveCollectService extends SearchService<any> implements SearchA
     return this.sortByTitle(out);
   }
 
-  updateUnitsMetadataByCsvFile(csvFile: Blob, fileName: string, transactionId: string): Observable<VitamErrorDetails[]> {
+  updateUnitsMetadataByCsvFile(csvFile: Blob, fileName: string, transactionId: string): Observable<VitamError> {
     let headers = new HttpHeaders();
     headers = headers.append('Content-Type', 'application/octet-stream');
     headers = headers.append(VitamuiHttpHeaders.X_ORIGINAL_FILENAME, fileName);

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.html
@@ -51,8 +51,12 @@
     <div>
       <div class="text bold medium">{{ 'COLLECT.UPDATE_UNITS_METADATA.LIST_IDENTIFIED_ERRORS' | translate }}</div>
       <ul class="scroll-area pl-5 mt-0">
-        @for (errorsDetail of errorsDetails; track errorsDetails) {
-          <li>{{ translateErrorKeys(errorsDetail) }}</li>
+        @if (errorsDetails) {
+          @for (errorsDetail of errorsDetails; track errorsDetail) {
+            <li>{{ translateErrorKeys(errorsDetail) }}</li>
+          }
+        } @else {
+          <li>{{ errorMessage }}</li>
         }
       </ul>
     </div>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.ts
@@ -52,6 +52,7 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
 
   fileToUpload: File = undefined;
   errorsDetails: VitamErrorDetails[];
+  errorMessage: string;
 
   subscriptions: Subscription;
 
@@ -91,27 +92,31 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
 
     this.subscriptions = this.archiveCollectService
       .updateUnitsMetadataByCsvFile(this.fileToUpload, this.fileToUpload.name, this.data.selectedTransaction.id)
-      .subscribe(
-        (data) => {
+      .subscribe({
+        next: (data) => {
           this.isLoadingData = false;
-          if (data.length === 0) {
+          if (data.httpCode === 200) {
             this.dialogRef.close(true);
             this.snackBarService.open({
               message: 'COLLECT.UPDATE_UNITS_METADATA.SUCCESS_MESSAGE',
               duration: 100_000,
             });
           } else {
-            this.errorsDetails = data;
+            if (data.errorsDetails !== null) {
+              this.errorsDetails = data.errorsDetails;
+            } else {
+              this.errorMessage = data.message;
+            }
             this.dialogRefToClose = this.dialog.open(this.displayCsvErrorsDialog);
           }
         },
-        (error: any) => {
+        error: (error: any) => {
           this.isLoadingData = false;
           this.dialogRef.close(true);
           this.logger.error('Error message :', error);
           return throwError(error);
         },
-      );
+      });
   }
 
   translateErrorKeys(errorDetails: VitamErrorDetails) {

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
@@ -47,7 +47,7 @@ import {
   SearchResponse,
   Transaction,
   Unit,
-  VitamErrorDetails,
+  VitamError,
 } from 'vitamui-library';
 
 @Injectable({
@@ -94,8 +94,8 @@ export class TransactionApiService extends PaginatedHttpClient<Transaction> {
     });
   }
 
-  updateUnitsMetadataByCsvFile(transactionId: string, file: Blob, headers: HttpHeaders): Observable<VitamErrorDetails[]> {
-    return this.http.put<VitamErrorDetails[]>(`${this.apiUrl}/${transactionId}/update-units-metadata`, file, {
+  updateUnitsMetadataByCsvFile(transactionId: string, file: Blob, headers: HttpHeaders): Observable<VitamError> {
+    return this.http.put<VitamError>(`${this.apiUrl}/${transactionId}/update-units-metadata`, file, {
       responseType: 'json',
       headers,
     });

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
@@ -597,7 +597,7 @@
     <div>
       <div class="text bold medium">{{ 'COLLECT.UPDATE_UNITS_METADATA.LIST_IDENTIFIED_ERRORS' | translate }}</div>
       <ul class="scroll-area pl-5 mt-0">
-        @for (errorsDetail of errorsDetails; track errorsDetails) {
+        @for (errorsDetail of errorsDetails; track errorsDetail) {
           <li>{{ translateErrorKeys(errorsDetail) }}</li>
         }
       </ul>


### PR DESCRIPTION
## Description

*Description des modifications*

Après certaines opérations de création de projet ou de mise à jour de métadonnées, une pop-up avec une erreur 500 est retournée au lieu de celle avec les erreurs remontées. Liée à la PR en back : [https://gitlab.dev.programmevitam.fr/vitam/vitam/-/merge_requests/11004](https://gitlab.dev.programmevitam.fr/vitam/vitam/-/merge_requests/11004)

A noter : certains retours d'erreur ne sont pas liés à une clé de traduction, dans ce cas-là, on renvoie le message d'erreur lui-même, qui n'est pas traduisible en back-office.

Adaptations effectuées + clean code.
