### PR TITLE
Fix #15691: Improve Angular interceptor timeout

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/vitamui-http-interceptor.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/vitamui-http-interceptor.ts
@@ -38,9 +38,9 @@ import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest
 import { Inject, Injectable, Injector } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import moment from 'moment';
-import { Observable, throwError } from 'rxjs';
+import { Observable, throwError, timeout } from 'rxjs';
 
-import { catchError, timeoutWith } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 
 import { SnackBarService } from './components/snack-bar/snack-bar.service';
@@ -53,7 +53,7 @@ import { StartupService } from './startup.service';
 import { SKIP_ERROR_NOTIFICATION } from './utils';
 import { VitamuiHttpHeaders } from './vitamui-http-headers.enum';
 
-const URLS_INCREASED_TIMEOUT = ['file', 'download', 'export', 'documents', 'ingest', 'upload'];
+const URLS_INCREASED_TIMEOUT = ['file', 'download', 'export'];
 // @ts-ignore
 const HTTP_STATUS_CODE_BAD_REQUEST = 400;
 const HTTP_STATUS_CODE_UNAUTHORIZED = 401;
@@ -82,7 +82,6 @@ const ERROR_NOTIFICATION_MESSAGE_BY_HTTP_STATUS: Map<number, string> = new Map([
 @Injectable()
 export class VitamUIHttpInterceptor implements HttpInterceptor {
   private errorDialog: MatDialogRef<ErrorDialogComponent>;
-  private apiTimeout: number;
   private snackBarService: SnackBarService;
 
   constructor(
@@ -92,9 +91,7 @@ export class VitamUIHttpInterceptor implements HttpInterceptor {
     private authService: AuthService,
     private injector: Injector,
     @Inject(ENVIRONMENT) private environment: any,
-  ) {
-    this.apiTimeout = environment?.apiTimeout ? environment.apiTimeout : DEFAULT_API_TIMEOUT;
-  }
+  ) {}
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     this.initSnackBarService();
@@ -112,10 +109,18 @@ export class VitamUIHttpInterceptor implements HttpInterceptor {
     if (!applicationId) {
       applicationId = this.startupService.CURRENT_APP_ID;
     }
-    const headerTimeout = request.headers.get(VitamuiHttpHeaders.X_API_TIMEOUT);
-    if (headerTimeout && !isNaN(Number(headerTimeout))) {
-      this.apiTimeout = Number(headerTimeout);
-    }
+
+    const headerTimeout = Number(request.headers.get(VitamuiHttpHeaders.X_API_TIMEOUT));
+    const isUpload = request.headers.get('Content-Type') === 'application/octet-stream';
+    const isBigDownload = URLS_INCREASED_TIMEOUT.some((url) => request.url.includes(url));
+    const apiTimeout =
+      headerTimeout && !isNaN(headerTimeout)
+        ? headerTimeout
+        : isUpload || isBigDownload
+          ? DEFAULT_DOWNLOAD_UPLOAD_API_TIMEOUT
+          : this.environment?.apiTimeout
+            ? this.environment.apiTimeout
+            : DEFAULT_API_TIMEOUT;
 
     const reqWithCredentials = request.clone({
       withCredentials: true,
@@ -135,10 +140,7 @@ export class VitamUIHttpInterceptor implements HttpInterceptor {
     }
 
     return next.handle(reqWithCredentials).pipe(
-      timeoutWith(
-        URLS_INCREASED_TIMEOUT.some((url) => request.url.includes(url)) ? DEFAULT_DOWNLOAD_UPLOAD_API_TIMEOUT : this.apiTimeout,
-        throwError(new VitamUITimeoutError()),
-      ),
+      timeout({ each: apiTimeout, with: () => throwError(() => new VitamUITimeoutError()) }),
       catchError((response) => {
         if (response instanceof HttpErrorResponse && response.status !== errorToByPass) {
           this.logger.log(this, 'Processing http error', response);


### PR DESCRIPTION
- plutôt que de détecter les points d'API d'upload par path, on les identifie par leur header "Content-Type", c'est plus fiable
- apiTimeout n'a aucune raison d'être un attribut du service, d'autant que si un header VitamuiHttpHeaders.X_API_TIMEOUT était fourni sur une requête, alors il modifiait le timeout pour toutes les requêtes suivantes
- remplacement de code déprécié par sa version non dépréciée