### PR TITLE
BUG #15876 - [Collection] – Clicking on a attachment position displays an attachment instead of the tree.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/filing-holding-scheme/filing-holding-scheme.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/filing-holding-scheme/filing-holding-scheme.component.ts
@@ -229,13 +229,14 @@ export class FilingHoldingSchemeComponent implements OnInit, OnDestroy {
       const isDefaultKey = key === 'id';
 
       if (isDefaultKey && inCollectAttachment) {
-        const { title, unitType, hasObject } = inCollectAttachment;
+        const { title, unitType, hasObject, vitamId } = inCollectAttachment;
         return {
           // internalAttachment
           ...node,
           title,
           unitType,
           hasObject,
+          vitamId,
         };
       }
 


### PR DESCRIPTION
Le panneau latéral droit doit afficher les informations de la position de rattachement sélectionnée (arbre de positionnement).