### PR TITLE
BUG #15797 - [Collect] – Import: after selecting SIP/ZIP and then switching to “Import folders and files,” the selector keeps the “single file only” constraint.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.ts
@@ -192,6 +192,10 @@ export class AddUnitsComponent implements OnInit {
 
   resetFilesToImportList() {
     this.filesToUploadControl.setValue([]);
+    this.filesToUploadControl.clearValidators();
+    this.filesToUploadControl.setValidators([Validators.required]);
+    this.filesToUploadControl.updateValueAndValidity();
+    this.filesToUploadControl.markAsUntouched();
   }
 
   private handleUploadSuccess(operationId: string | null): void {

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
@@ -585,6 +585,10 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
 
   resetFilesToImportList() {
     this.filesToUploadControl.setValue([]);
+    this.filesToUploadControl.clearValidators();
+    this.filesToUploadControl.setValidators([Validators.required]);
+    this.filesToUploadControl.updateValueAndValidity();
+    this.filesToUploadControl.markAsUntouched();
   }
 
   private setDefaultArchivingSystemValue() {


### PR DESCRIPTION
[Collecte] -Import : après avoir sélectionné SIP/ZIP puis basculé vers “Import de dossiers et fichiers”, le sélecteur conserve la contrainte “1 seul fichier”