### PR TITLE
Bug #15783 - [Pastis] Incorrect label when editing a PUA.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/edit-profile/file-tree-metadata/file-tree-metadata.component.ts
@@ -245,23 +245,15 @@ export class FileTreeMetadataComponent implements OnInit, OnDestroy {
         this.breadcrumbDataMetadata = this.breadcrumbService.computeBreadcrumb({ node, root });
       });
     this.sedaVersionLabel = this.profileService.getSedaVersionLabel();
-    // BreadCrump Top for navigation
-    this.profileModeLabel =
-      this.profileService.profileType === ProfileType.PUA
-        ? 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PUA'
-        : 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PA';
-    this.breadcrumbDataTop = [
-      {
-        label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.PORTAIL',
-        url: this.startupService.getPortalUrl(),
-        external: true,
-      },
-      { label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.CREER_ET_GERER_PROFIL', url: '/' },
-      { label: this.profileModeLabel },
-    ];
+    this.updateBreadcrumbTop();
 
     this._fileServiceSubscription = this.fileService.currentTree
-      .pipe(tap((_node) => (this.sedaVersionLabel = this.profileService.getSedaVersionLabel())))
+      .pipe(
+        tap((_node) => {
+          this.sedaVersionLabel = this.profileService.getSedaVersionLabel();
+          this.updateBreadcrumbTop();
+        }),
+      )
       .subscribe((fileTree) => {
         if (fileTree) {
           this.clickedNode = fileTree[0];
@@ -947,5 +939,21 @@ export class FileTreeMetadataComponent implements OnInit, OnDestroy {
       }
     }
     return false;
+  }
+
+  private updateBreadcrumbTop(): void {
+    this.profileModeLabel =
+      this.profileService.profileType === ProfileType.PUA
+        ? 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PUA'
+        : 'PROFILE.EDIT_PROFILE.FILE_TREE_METADATA.PA';
+    this.breadcrumbDataTop = [
+      {
+        label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.PORTAIL',
+        url: this.startupService.getPortalUrl(),
+        external: true,
+      },
+      { label: 'PROFILE.EDIT_PROFILE.BREADCRUMB.CREER_ET_GERER_PROFIL', url: '/' },
+      { label: this.profileModeLabel },
+    ];
   }
 }


### PR DESCRIPTION
Le problème est que le breadcrumb du titre est initialisé dans ngOnInit() avant que le type de profil ne soit correctement chargé depuis le backend.