### PR TITLE
Bug #15800 - [Collect] – “Update metadata” and “Validate” buttons disabled after an archive search returns no results.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -65,21 +65,13 @@
             [icon]="'vitamui-icon-more-horiz'"
             [vitamuiTooltip]="'COLLECT.OTHER_ACTION' | translate"
           >
-            <button
-              mat-menu-item
-              [disabled]="(isNotOpen$ | async) || isArchiveUnitsEmpty() || !hasBulkUpdateUnitRole"
-              (click)="openUpdateUnitsForm()"
-            >
+            <button mat-menu-item [disabled]="(isNotOpen$ | async) || !hasBulkUpdateUnitRole" (click)="openUpdateUnitsForm()">
               {{ 'COLLECT.UPDATE_UNITS_METADATA.ACTION_UPDATE' | translate }}
             </button>
             <button mat-menu-item [disabled]="isNotOpen$ | async" (click)="openAddUnitsForm()">
               {{ 'COLLECT.ADD_UNITS.ACTION_TITLE' | translate }}
             </button>
-            <button
-              mat-menu-item
-              (click)="validateTransaction()"
-              [disabled]="!hasCloseTransactionRole || isArchiveUnitsEmpty() || (isNotOpen$ | async)"
-            >
+            <button mat-menu-item (click)="validateTransaction()" [disabled]="!hasCloseTransactionRole || (isNotOpen$ | async)">
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
             <button mat-menu-item (click)="sendTransaction()" [disabled]="!canSend(transaction)">


### PR DESCRIPTION
Boutons « Mettre à jour les métadonnées » et « Valider » désactivés après une recherche d’archive sans résultat