### PR TITLE
bugs #15854 refactor(auth): implement dynamic OIDC redirection and reactive configuration

### DIFF
--- a/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
@@ -38,11 +38,6 @@
   {% endif %}
   "OIDC_CONFIG": {
     "issuer": "{{ vitamui.cas_server.base_url | default(url_prefix+'/cas') }}/oidc",
-    {% if vitamui_struct.vitamui_component == 'ui-portal' %}
-    "redirectUri": "{{ vitamui_struct.base_url | default(url_prefix + '/') }}",
-    {% else %}
-    "redirectUri": "{{ vitamui_struct.base_url | default(url_prefix + '/' + vitamui_struct.vitamui_component | regex_replace('^ui-', '') + '/' + vitamui_struct.vitamui_component | regex_replace('^ui-', '')) }}",
-    {% endif %}
     "postLogoutRedirectUri": "{{ vitamui.ui_portal.base_url | default(url_prefix+'/') }}",
     "clientId": "{{ vitamui_struct.vitamui_component | regex_replace('^ui-', '') }}",
     "responseType": "code",

--- a/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
@@ -20,7 +20,6 @@
   "ALLOWED_URLS": ["/archive-search-api"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4209/archive-search",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4209/archive-search",
     "clientId": "archive-search",
     "responseType": "code",

--- a/ui/ui-frontend/projects/collect/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/collect/src/assets/config-dev.json
@@ -20,7 +20,6 @@
   "ALLOWED_URLS": ["/collect-api"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4210/collect",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4210/collect",
     "clientId": "collect",
     "responseType": "code",

--- a/ui/ui-frontend/projects/identity/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/identity/src/assets/config-dev.json
@@ -20,7 +20,6 @@
   "ALLOWED_URLS": ["/identity-api"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4201/user",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4201/user",
     "clientId": "identity",
     "responseType": "code",

--- a/ui/ui-frontend/projects/ingest/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/ingest/src/assets/config-dev.json
@@ -19,7 +19,6 @@
   "ALLOWED_URLS": ["/ingest-api"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4208/ingest",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4208/ingest",
     "clientId": "ingest",
     "responseType": "code",

--- a/ui/ui-frontend/projects/pastis/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/pastis/src/assets/config-dev.json
@@ -20,7 +20,6 @@
   "ALLOWED_URLS": ["/pastis"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4251/pastis",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4251/pastis",
     "clientId": "pastis",
     "responseType": "code",

--- a/ui/ui-frontend/projects/portal/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/portal/src/assets/config-dev.json
@@ -19,7 +19,6 @@
   "ALLOWED_URLS": ["/portal-api"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4200/",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4200/",
     "clientId": "portal",
     "responseType": "code",

--- a/ui/ui-frontend/projects/referential/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/referential/src/assets/config-dev.json
@@ -19,7 +19,6 @@
   "ALLOWED_URLS": ["/referential-api"],
   "OIDC_CONFIG": {
     "issuer": "https://dev.vitamui.com:8080/cas/oidc",
-    "redirectUri": "https://dev.vitamui.com:4202/ingest-contract",
     "postLogoutRedirectUri": "https://dev.vitamui.com:4202/ingest-contract",
     "clientId": "referential",
     "responseType": "code",

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/cas-authenticator.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/cas-authenticator.service.ts
@@ -34,16 +34,31 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+import { Inject, Injectable } from '@angular/core';
+import { first } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
 import { AuthenticatorService } from './authenticator.service';
+import { WINDOW_LOCATION } from '../../injection-tokens';
+import { ConfigService } from '../../config.service';
 
+@Injectable({
+  providedIn: 'root',
+})
 export class CasAuthenticatorService implements AuthenticatorService {
+  private loginUrl: string;
+  private logoutUrl: string;
+  private logoutRedirectUiUrl: string;
+
   constructor(
-    private location: any,
-    private loginUrl: string,
-    private logoutUrl: string,
-    private logoutRedirectUiUrl: string,
-  ) {}
+    @Inject(WINDOW_LOCATION) private location: any,
+    private configService: ConfigService,
+  ) {
+    this.configService.config$.pipe(first((config) => !!config)).subscribe((config) => {
+      this.loginUrl = config.CAS_URL;
+      this.logoutUrl = config.CAS_LOGOUT_URL;
+      this.logoutRedirectUiUrl = config.LOGOUT_REDIRECT_UI_URL;
+    });
+  }
 
   public login(): Observable<boolean> {
     return of(true);

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-authenticator.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-authenticator.service.ts
@@ -37,19 +37,37 @@
 import { OAuthService } from 'angular-oauth2-oidc';
 import { from, Observable } from 'rxjs';
 import { AuthenticatorService } from './authenticator.service';
-import { map, tap } from 'rxjs/operators';
+import { first, map, tap } from 'rxjs/operators';
+import { ConfigService } from '../../config.service';
+import { OidcUrlCleaner } from './oidc-url-cleaner';
+import { Inject, Injectable } from '@angular/core';
+import { WINDOW_LOCATION } from '../../injection-tokens';
 
-const OIDC_PARAMS = ['code', 'state', 'id_token', 'access_token', 'token_type', 'session_state', 'nonce'];
-
+@Injectable({
+  providedIn: 'root',
+})
 export class OidcAuthenticatorService implements AuthenticatorService {
   constructor(
     private oAuthService: OAuthService,
-    private location: any,
-  ) {}
+    @Inject(WINDOW_LOCATION) private location: any, // Native Location object
+    private configService: ConfigService,
+    private urlCleaner: OidcUrlCleaner,
+  ) {
+    this.configService.config$.pipe(first((config) => !!config?.OIDC_CONFIG)).subscribe((config) => {
+      const oidcConfig = { ...config.OIDC_CONFIG };
+      // Initialize deep linking support
+      oidcConfig.redirectUri = this.urlCleaner.resolveValidRedirectUri(oidcConfig.redirectUri, this.location.href);
+      oidcConfig.postLogoutRedirectUri = this.urlCleaner.resolveValidRedirectUri(oidcConfig.postLogoutRedirectUri, this.location.href);
+      this.oAuthService.configure(oidcConfig);
+    });
+  }
 
   public login(): Observable<boolean> {
     const url = new URL(this.location.href);
-    const returnUrl = this.cleanOidcParams(this.location.pathname + this.location.search);
+    const returnUrl = this.urlCleaner.getCleanedPath(this.location.pathname + this.location.search, this.location.origin);
+
+    // Ensure redirectUri is up-to-date with current URL (important for subrogation and deep links)
+    this.oAuthService.redirectUri = this.urlCleaner.resolveValidRedirectUri(this.oAuthService.redirectUri, this.location.href);
 
     if (url.searchParams.get('isSubrogation')) {
       return from(this.startSubrogationFlow(url, returnUrl));
@@ -64,7 +82,6 @@ export class OidcAuthenticatorService implements AuthenticatorService {
 
   private async startSubrogationFlow(url: URL, returnUrl: string): Promise<boolean> {
     await this.oAuthService.loadDiscoveryDocument();
-    this.oAuthService.redirectUri = this.buildAbsoluteRedirectUri();
     this.oAuthService.initCodeFlow(returnUrl, {
       superUserEmail: url.searchParams.get('superUserEmail'),
       superUserCustomerId: url.searchParams.get('superUserCustomerId'),
@@ -76,7 +93,6 @@ export class OidcAuthenticatorService implements AuthenticatorService {
 
   private async startLoginWithUsername(url: URL, returnUrl: string): Promise<boolean> {
     await this.oAuthService.loadDiscoveryDocument();
-    this.oAuthService.redirectUri = this.buildAbsoluteRedirectUri();
     this.oAuthService.initCodeFlow(returnUrl, { username: url.searchParams.get('username') });
     return true;
   }
@@ -90,15 +106,6 @@ export class OidcAuthenticatorService implements AuthenticatorService {
       tap((authenticated) => {
         if (authenticated) {
           this.cleanUrlAfterLogin();
-          const claims = this.oAuthService.getIdentityClaims() as any;
-          if (claims?.state) {
-            const parts = claims.state.split(';');
-            // The state format is `<nonce>;<encoded_url>` — we take parts[1].
-            const redirectPath = parts.length > 1 ? decodeURIComponent(parts[1]) : null;
-            if (redirectPath && redirectPath !== '/') {
-              this.location.href = this.location.origin + redirectPath;
-            }
-          }
         }
       }),
     );
@@ -109,15 +116,23 @@ export class OidcAuthenticatorService implements AuthenticatorService {
   }
 
   public logoutSubrogationAndRedirectToLoginPage(username: string): void {
-    this.oAuthService.postLogoutRedirectUri += this.getUrlSeparator(this.oAuthService.postLogoutRedirectUri) + 'username=' + username;
+    this.updatePostLogoutRedirectUri({ username });
     this.oAuthService.revokeTokenAndLogout();
   }
 
-  public initSubrogationFlow(superUser: string, superUserCustomerId: string, surrogate: string, surrogateCustomerId: string): void {
-    const sep = this.getUrlSeparator(this.oAuthService.postLogoutRedirectUri);
-    this.oAuthService.postLogoutRedirectUri +=
-      sep +
-      `isSubrogation=true&superUserEmail=${superUser}&superUserCustomerId=${superUserCustomerId}&surrogateEmail=${surrogate}&surrogateCustomerId=${surrogateCustomerId}`;
+  public initSubrogationFlow(
+    superUserEmail: string,
+    superUserCustomerId: string,
+    surrogateEmail: string,
+    surrogateCustomerId: string,
+  ): void {
+    this.updatePostLogoutRedirectUri({
+      isSubrogation: 'true',
+      superUserEmail,
+      superUserCustomerId,
+      surrogateEmail,
+      surrogateCustomerId,
+    });
     this.oAuthService.revokeTokenAndLogout();
   }
 
@@ -125,33 +140,16 @@ export class OidcAuthenticatorService implements AuthenticatorService {
     this.oAuthService.revokeTokenAndLogout();
   }
 
-  private cleanOidcParams(path: string): string {
-    const u = new URL(path, this.location.origin);
-    OIDC_PARAMS.forEach((p) => u.searchParams.delete(p));
-    return u.pathname + (u.search || '');
+  /** Update postLogoutRedirectUri by adding search parameters */
+  private updatePostLogoutRedirectUri(params: Record<string, string>): void {
+    const url = new URL(this.oAuthService.postLogoutRedirectUri, this.location.origin);
+    Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+    this.oAuthService.postLogoutRedirectUri = url.toString();
   }
 
+  /** Clean address bar URL after authentication */
   private cleanUrlAfterLogin(): void {
-    history.replaceState(null, '', this.cleanOidcParams(this.location.pathname + this.location.search));
-  }
-
-  private getUrlSeparator(url: string): string {
-    const idx = url.indexOf('?');
-    if (idx === -1) return '?';
-    if (idx === url.length - 1) return '';
-    return '&';
-  }
-
-  private buildAbsoluteRedirectUri(): string {
-    const postLogoutUri = this.oAuthService.postLogoutRedirectUri;
-
-    try {
-      const u = new URL(postLogoutUri);
-      const forbiddenParams = ['code', 'state', 'id_token', 'access_token', 'token_type', 'session_state'];
-      forbiddenParams.forEach((p) => u.searchParams.delete(p));
-      return u.toString();
-    } catch {
-      return this.location.origin + postLogoutUri;
-    }
+    const cleanedPath = this.urlCleaner.getCleanedPath(this.location.pathname + this.location.search, this.location.origin);
+    history.replaceState(null, '', cleanedPath);
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-url-cleaner.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-url-cleaner.ts
@@ -34,56 +34,62 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import { ModuleWithProviders, NgModule, provideAppInitializer } from '@angular/core';
-import { OAuthModule } from 'angular-oauth2-oidc';
-import { first, tap } from 'rxjs/operators';
-import { AuthService } from '../auth.service';
-import { ConfigService } from '../config.service';
-import { AuthenticationInterceptor } from './authentication-interceptor';
-import { CasAuthenticatorService } from './services/cas-authenticator.service';
-import { OidcAuthenticatorService } from './services/oidc-authenticator.service';
+import { Injectable } from '@angular/core';
 
-@NgModule({
-  declarations: [],
-  imports: [],
-  providers: [
-    provideAppInitializer(() => {
-      const initializerFn = AuthenticationModule.loadModule();
-      return initializerFn();
-    }),
-  ],
+/**
+ * Service dedicated to cleaning and validating URLs during OIDC authentication flows.
+ */
+@Injectable({
+  providedIn: 'root',
 })
-export class AuthenticationModule {
-  private static loading: Promise<any> = null;
+export class OidcUrlCleaner {
+  private readonly OIDC_PARAMS = [
+    'code',
+    'state',
+    'id_token',
+    'access_token',
+    'token_type',
+    'session_state',
+    'nonce',
+    'error',
+    'error_description',
+  ];
 
-  private static loadModule() {
-    // Do NOT inline the variable.
-    const result = () => this.loading;
-    return result;
+  /** Removes all OIDC-related parameters from the provided URL object */
+  public removeOidcParams(url: URL): void {
+    this.OIDC_PARAMS.forEach((p) => url.searchParams.delete(p));
   }
 
-  constructor(
-    private configService: ConfigService,
-    private oidcAuthenticator: OidcAuthenticatorService,
-    private casAuthenticator: CasAuthenticatorService,
-    authService: AuthService,
-  ) {
-    AuthenticationModule.loading = this.configService.config$
-      .pipe(
-        first((config) => !!config),
-        tap((config) => {
-          const authenticatorService = config.GATEWAY_ENABLED ? this.oidcAuthenticator : this.casAuthenticator;
-          authService.configure(authenticatorService);
-        }),
-      )
-      .toPromise();
+  /** Returns a relative path (pathname + search) cleaned of OIDC parameters */
+  public getCleanedPath(pathWithSearch: string, origin: string): string {
+    const url = new URL(pathWithSearch, origin);
+    this.removeOidcParams(url);
+    return url.pathname + (url.search || '');
   }
 
-  static forRoot(): ModuleWithProviders<AuthenticationModule> {
-    return {
-      ngModule: AuthenticationModule,
-      providers: [{ provide: HTTP_INTERCEPTORS, useClass: AuthenticationInterceptor, multi: true }, OAuthModule.forRoot().providers],
-    };
+  /**
+   * Resolves a valid absolute redirect URI.
+   * If the provided URI is not absolute or is invalid, it returns the current URL (cleaned).
+   */
+  public resolveValidRedirectUri(uri: string | undefined, currentHref: string): string {
+    if (this.isAbsoluteUrl(uri)) {
+      return uri!;
+    }
+
+    const url = new URL(currentHref);
+    this.removeOidcParams(url);
+    return url.origin + url.pathname + url.search;
+  }
+
+  private isAbsoluteUrl(url: string | undefined): boolean {
+    if (!url) {
+      return false;
+    }
+    try {
+      const u = new URL(url);
+      return !!u.host && !!u.protocol;
+    } catch {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
- Move OIDC configuration logic from AuthenticationModule to OidcAuthenticatorService
- Implement reactive setup in OidcAuthenticatorService by subscribing to ConfigService
- Automatically clean OIDC return parameters (code, state, etc.) from dynamic redirectUri
- Remove hardcoded redirectUri from all config-dev.json files and Jinja templates
- Simplify AuthenticationModule by delegating OauthService setup to the authenticator This change allows for seamless deep linking in new browser tabs by dynamically determining the redirectUri while ensuring it remains "clean" for CAS/OIDC token exchange requirements.