### PR TITLE
Bug #15503 fix(pastis): can not update a PA containing an UpdateOpera…

### DIFF
--- a/api/api-pastis/pastis-commons/src/main/java/fr/gouv/vitamui/pastis/common/util/RNGConstants.java
+++ b/api/api-pastis/pastis-commons/src/main/java/fr/gouv/vitamui/pastis/common/util/RNGConstants.java
@@ -265,6 +265,8 @@ public class RNGConstants {
         TypesMap.put("unCompressedSize", DataType.POSITIVE_INTEGER);
         TypesMap.put("unit", DataType.STRING);
         TypesMap.put("when", DataType.TOKEN);
+        TypesMap.put("MetadataName", DataType.TOKEN);
+        TypesMap.put("MetadataValue", DataType.STRING);
     }
 
     public static boolean isElement(String type) {


### PR DESCRIPTION
fix(pastis): restore missing type on rng:data for MetadataName/MetadataValue

When saving a PA containing ArchiveUnitIdentifierKey, generated RNG could contain:

<rng:data/>

instead of:

<rng:data type="token"/>
<rng:data type="string"/>

Root cause:
MetadataName and MetadataValue were missing from RNGConstants.TypesMap,
which is used to resolve XSD types during RNG generation.

Fix:
- add MetadataName -> TOKEN
- add MetadataValue -> STRING

Impact:
- generated RNG is now valid
- fixes VITAM rejection

See Tuleap: #15503