### PR TITLE
CP V9.0 - Bug #16111 fix(collect): the access contract prevents updating archive units

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
@@ -8,13 +8,7 @@
   (onclose)="emitClose()"
 >
   <vitamui-menu-button [overlayPos]="'end'" [icon]="'vitamui-icon-more-horiz'">
-    <button
-      mat-menu-item
-      vitamuiTooltip="{{ !accessContractAllowUpdating ? hasAccessContractManagementPermissionsMessage : '' }}"
-      [vitamuiTooltipShowDelay]="300"
-      (click)="updateMetadataDesc()"
-      [disabled]="transactionIsNotOpen || updateStarted || !accessContractAllowUpdating || !hasUnitaryUpdateUnitRole"
-    >
+    <button mat-menu-item (click)="updateMetadataDesc()" [disabled]="transactionIsNotOpen || updateStarted || !hasUnitaryUpdateUnitRole">
       {{ 'UNIT_UPDATE.UPDATE_DESC_METADATA' | translate }}
     </button>
   </vitamui-menu-button>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.ts
@@ -50,7 +50,6 @@ import { ArchiveSharedDataService } from '../../core/archive-shared-data.service
 export class ArchivePreviewComponent implements OnChanges, AfterViewInit {
   @Input() archiveUnit: Unit;
   @Input() isPopup: boolean;
-  @Input() accessContractAllowUpdating: boolean;
   @Input() hasUnitaryUpdateUnitRole: boolean;
   @Input() transactionId: string;
   @Input() transactionIsNotOpen: boolean;

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -22,7 +22,6 @@
       (showExtendedLateralPanel)="showExtendedLateralPanel()"
       [archiveUnit]="openedItem"
       (backToNormalLateralPanel)="backToNormalLateralPanel()"
-      [accessContractAllowUpdating]="accessContractAllowUpdating"
       [hasUnitaryUpdateUnitRole]="hasUnitaryUpdateUnitRole"
       [transactionId]="transaction?.id"
       [transactionIsNotOpen]="isNotOpen$ | async"

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -122,7 +122,6 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   transaction: Transaction;
   private transaction$: Observable<Transaction>;
   foundAccessContract = false;
-  accessContractAllowUpdating = false;
   accessContractUpdatingRestrictedDesc: boolean;
   hasUnitaryUpdateUnitRole = false;
   hasDeleteArchiveUnitActionRole = false;
@@ -555,7 +554,6 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     this.subscriptions.add(
       this.archiveUnitCollectService.getAccessContractById(this.accessContract).subscribe(
         (ac: AccessContract) => {
-          this.accessContractAllowUpdating = ac.writingPermission;
           this.accessContractUpdatingRestrictedDesc = ac.writingRestrictedDesc;
         },
         (error: any) => {


### PR DESCRIPTION
## Description

> Cherry-Picked from #3654

The accessContractAllowUpdating flag is not intended to control whether the update descriptive metadata button should be enabled or not.
