### PR TITLE
CP V8.0 - Bug #16111 fix(collect): the access contract prevents updating archive units

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
@@ -8,12 +8,8 @@
   (onclose)="emitClose()"
 >
   <vitamui-common-menu-button [overlayPos]="'end'" [icon]="'vitamui-icon-more-horiz'">
-    <button
-      mat-menu-item
-      (click)="updateMetadataDesc()"
-      [disabled]="transactionIsNotOpen || updateStarted || !hasUnitaryUpdateUnitRole">
-
-    {{ 'UNIT_UPDATE.UPDATE_DESC_METADATA' | translate }}
+    <button mat-menu-item (click)="updateMetadataDesc()" [disabled]="transactionIsNotOpen || updateStarted || !hasUnitaryUpdateUnitRole">
+      {{ 'UNIT_UPDATE.UPDATE_DESC_METADATA' | translate }}
     </button>
   </vitamui-common-menu-button>
 </vitamui-common-sidenav-header>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.html
@@ -10,13 +10,10 @@
   <vitamui-common-menu-button [overlayPos]="'end'" [icon]="'vitamui-icon-more-horiz'">
     <button
       mat-menu-item
-      matTooltip="{{ !accessContractAllowUpdating ? hasAccessContractManagementPermissionsMessage : '' }}"
-      matTooltipClass="vitamui-tooltip"
-      [matTooltipShowDelay]="300"
       (click)="updateMetadataDesc()"
-      [disabled]="transactionIsNotOpen || updateStarted || !accessContractAllowUpdating || !hasUnitaryUpdateUnitRole"
-    >
-      {{ 'UNIT_UPDATE.UPDATE_DESC_METADATA' | translate }}
+      [disabled]="transactionIsNotOpen || updateStarted || !hasUnitaryUpdateUnitRole">
+
+    {{ 'UNIT_UPDATE.UPDATE_DESC_METADATA' | translate }}
     </button>
   </vitamui-common-menu-button>
 </vitamui-common-sidenav-header>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-preview/archive-preview.component.ts
@@ -53,7 +53,6 @@ import { ArchiveUnitDescriptionTabComponent } from './archive-unit-description-t
 export class ArchivePreviewComponent implements OnChanges, AfterViewInit {
   @Input() archiveUnit: Unit;
   @Input() isPopup: boolean;
-  @Input() accessContractAllowUpdating: boolean;
   @Input() hasUnitaryUpdateUnitRole: boolean;
   @Input() transactionId: string;
   @Input() transactionIsNotOpen: boolean;

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -22,7 +22,6 @@
       (showExtendedLateralPanel)="showExtendedLateralPanel()"
       [archiveUnit]="openedItem"
       (backToNormalLateralPanel)="backToNormalLateralPanel()"
-      [accessContractAllowUpdating]="accessContractAllowUpdating"
       [hasUnitaryUpdateUnitRole]="hasUnitaryUpdateUnitRole"
       [transactionId]="transaction.id"
       [transactionIsNotOpen]="isNotOpen$ | async"

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -110,7 +110,6 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   transaction: Transaction;
   projectId: string;
   foundAccessContract = false;
-  accessContractAllowUpdating = false;
   accessContractUpdatingRestrictedDesc: boolean;
   hasUnitaryUpdateUnitRole = false;
   hasBulkUpdateUnitRole = false;
@@ -442,7 +441,6 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   fetchVitamAccessContract() {
     this.accessContractSubscription = this.archiveUnitCollectService.getAccessContractById(this.accessContract).subscribe(
       (ac: AccessContract) => {
-        this.accessContractAllowUpdating = ac.writingPermission;
         this.accessContractUpdatingRestrictedDesc = ac.writingRestrictedDesc;
       },
       (error: any) => {


### PR DESCRIPTION
## Description

The accessContractAllowUpdating flag is not intended to control whether the update descriptive metadata button should be enabled or not.