### PR TITLE
Story #15427: Disable originating agency reassignment by unit by default

### DIFF
--- a/deployment/environments/group_vars/all/vitamui_vars.yml
+++ b/deployment/environments/group_vars/all/vitamui_vars.yml
@@ -91,7 +91,7 @@ vitamui:
     vitamui_component: ui-archive-search
     port_service: 8009
     secure: false
-    reassignment_enabled: true # Set to true to enable the reassignment feature in archive search
+    reassignment_enabled: false # Set to true to enable the reassignment feature in archive search
   ui_collect:
     vitamui_component: ui-collect
     port_service: 8010

--- a/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
@@ -74,6 +74,6 @@
   }
   {% endif %}
   {% if (vitamui_struct.vitamui_component == "ui-archive-search") %}
-  ,"REASSIGNMENT_ENABLED": {{vitamui.ui_archive_search.reassignment_enabled | default(false) | bool | lower }}
+  ,"REASSIGNMENT_ENABLED": {{ vitamui.ui_archive_search.reassignment_enabled | default(false) | bool | lower }}
   {% endif %}
 }

--- a/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
@@ -63,5 +63,5 @@
       "order": 5
     }
   ],
-  "REASSIGNMENT_ENABLED": true
+  "REASSIGNMENT_ENABLED": false
 }


### PR DESCRIPTION
Désactiver la fonctionnalité de réattribution de service producteur basé sur les units par default