### PR TITLE
Bug #16150: fix persistent LDAP popup blocking authentication

### DIFF
--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/password/CustomCasWebSecurityConfigurerAdapter.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/password/CustomCasWebSecurityConfigurerAdapter.java
@@ -64,6 +64,7 @@ public class CustomCasWebSecurityConfigurerAdapter extends CasWebSecurityConfigu
     protected List<String> getAllowedPatternsToIgnore() {
         val patterns = super.getAllowedPatternsToIgnore();
         patterns.add("/extras/**");
+        patterns.add("/icons/**");
         return patterns;
     }
 }


### PR DESCRIPTION
## Description

Une pop-up LDAP s’affiche en boucle et empêche l’authentification.

## Changement

Ajout du path `/icons/**` de CAS dans les chemins autorisés.