### PR TITLE
Bug #15854 fix(oidc): restore deep link navigation after OIDC callback

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-authenticator.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-authenticator.service.ts
@@ -90,6 +90,15 @@ export class OidcAuthenticatorService implements AuthenticatorService {
       tap((authenticated) => {
         if (authenticated) {
           this.cleanUrlAfterLogin();
+          const claims = this.oAuthService.getIdentityClaims() as any;
+          if (claims?.state) {
+            const parts = claims.state.split(';');
+            // The state format is `<nonce>;<encoded_url>` — we take parts[1].
+            const redirectPath = parts.length > 1 ? decodeURIComponent(parts[1]) : null;
+            if (redirectPath && redirectPath !== '/') {
+              this.location.href = this.location.origin + redirectPath;
+            }
+          }
         }
       }),
     );


### PR DESCRIPTION
## Contexte

Quand un utilisateur colle une URL directe dans un nouvel onglet, 
le sessionStorage est vide. Angular relance le flow OIDC et envoie 
l'URL cible dans le paramètre `state` vers CAS. CAS la retourne 
intacte dans les claims du `id_token` après authentification.

## Problème

`startStandardLogin()` appelait `cleanUrlAfterLogin()` et s'arrêtait 
là. Le `state` contenant l'URL cible était ignoré, l'utilisateur 
atterrissait toujours sur `/search`.

## Correction

Après `cleanUrlAfterLogin()`, on lit `getIdentityClaims().state`, 
on extrait le chemin après le séparateur `;` et on navigue vers l'URL 
d'origine.
