### PR TITLE
Bug #16214- [Collection] - Edit button active on a validated transaction leading to a technical error (Producing Service profile).

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
@@ -254,7 +254,7 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
     this.archiveCollectService.hasCollectRole('ROLE_SEND_TRANSACTIONS', Number(this.tenantIdentifier)).subscribe((result) => {
       this.hasSendTransactionRole = result;
     });
-    this.archiveCollectService.hasCollectRole('ROLE_UPDATE_TRANSACTIONS', Number(this.tenantIdentifier)).subscribe((result) => {
+    this.archiveCollectService.hasCollectRole('ROLE_REOPEN_TRANSACTIONS', Number(this.tenantIdentifier)).subscribe((result) => {
       this.hasEditTransactionRole = result;
     });
     this.archiveCollectService.hasCollectRole('ROLE_CLOSE_TRANSACTIONS', Number(this.tenantIdentifier)).subscribe((result) => {


### PR DESCRIPTION
il y a une discordance entre les rôles vérifiés au frontend et au backend: 
 - front (transaction-list.component) : vérifie le rôle ROLE_UPDATE_TRANSACTIONS
 - back (TransactionController) : l'endpoint /reopen nécessite le rôle ROLE_REOPEN_TRANSACTIONS
 
le front vérifie le mauvais rôle, donc le bouton n'est pas désactivé