### PR TITLE
Bug #16212 - [Search App] SP Reassignment: Missing label above the?Source producing service field in the reassignment pop-in.

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/originating-agency-reassignment-dialog/originating-agency-reassignment-dialog.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/originating-agency-reassignment-dialog/originating-agency-reassignment-dialog.component.html
@@ -2,11 +2,10 @@
 
 <form [formGroup]="form" (ngSubmit)="reassign()">
   <mat-dialog-content class="gap-3 align-items-stretch">
-    <p class="text bold primary m-0">
-      {{ sectionTitle | translate }}
-    </p>
-
     <ng-container *ngIf="reassignmentMode !== ReassignmentMode.BY_ID">
+      <p class="text bold primary m-0 mt-1">
+        {{ 'ARCHIVE_SEARCH.ENTRY_OPERATION_REASSIGNMENT.ENTRY_OPERATION_IDS_SECTION_TITLE' | translate }}
+      </p>
       <vitamui-input
         formControlName="entryOperationIds"
         [placeholder]="'ARCHIVE_SEARCH.ENTRY_OPERATION_REASSIGNMENT.ENTRY_OPERATION_IDS_LABEL' | translate"
@@ -20,6 +19,9 @@
       </div>
     </ng-container>
 
+    <p class="text bold primary m-0">
+      {{ sectionTitle | translate }}
+    </p>
     <vitamui-select
       [multiple]="false"
       [enableSearch]="true"

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/originating-agency-reassignment-dialog/originating-agency-reassignment-dialog.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/originating-agency-reassignment-dialog/originating-agency-reassignment-dialog.component.ts
@@ -146,7 +146,7 @@ export class OriginatingAgencyReassignmentDialogComponent implements OnInit, OnD
   get sectionTitle(): string {
     return this.reassignmentMode === ReassignmentMode.BY_ID
       ? 'ARCHIVE_SEARCH.ORIGINATING_AGENCY_REASSIGNMENT.SOURCE_ORIGINATING_AGENCY_LABEL'
-      : 'ARCHIVE_SEARCH.ENTRY_OPERATION_REASSIGNMENT.ENTRY_OPERATION_IDS_SECTION_TITLE';
+      : 'ARCHIVE_SEARCH.ENTRY_OPERATION_REASSIGNMENT.SOURCE_ORIGINATING_AGENCY_LABEL';
   }
 
   protected readonly ReassignmentMode = ReassignmentMode;

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/input/input.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/input/input.component.ts
@@ -125,7 +125,6 @@ export class InputComponent extends AbstractFormInputDirective {
 
   onFocus(i: number) {
     this.focused = i;
-    this.onTouched();
   }
 
   onBlur(i: number) {


### PR DESCRIPTION
il manque les indications au dessus du 2eme champs : “Indiquer le service producteur source des opérations d’entrées saisies”. 