### PR TITLE
Bug #15864 fix(ingest): bypass AWT font initialization in ODT report generation

### DIFF
--- a/api/api-archive-search/archive-search-commons/pom.xml
+++ b/api/api-archive-search/archive-search-commons/pom.xml
@@ -55,5 +55,11 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/api/api-archive-search/archive-search-commons/src/test/java/fr/gouv/vitamui/archives/search/common/arch/ArchitectureTest.java
+++ b/api/api-archive-search/archive-search-commons/src/test/java/fr/gouv/vitamui/archives/search/common/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.archives.search.common.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-archive-search/archive-search/pom.xml
+++ b/api/api-archive-search/archive-search/pom.xml
@@ -207,7 +207,12 @@
             <artifactId>mongodb</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/arch/ArchitectureTest.java
+++ b/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.archives.search.server.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-collect/collect/pom.xml
+++ b/api/api-collect/collect/pom.xml
@@ -175,6 +175,12 @@
             <artifactId>podam</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/arch/ArchitectureTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.collect.server.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-ingest/ingest/pom.xml
+++ b/api/api-ingest/ingest/pom.xml
@@ -168,6 +168,11 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/service/IngestGeneratorODTFile.java
+++ b/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/service/IngestGeneratorODTFile.java
@@ -40,6 +40,7 @@
 package fr.gouv.vitamui.ingest.server.service;
 
 import fr.gouv.vitamui.commons.api.exception.IngestFileGenerationException;
+import fr.gouv.vitamui.commons.utils.OdfUtils;
 import fr.gouv.vitamui.commons.vitam.seda.LevelType;
 import fr.gouv.vitamui.iam.common.dto.CustomerDto;
 import fr.gouv.vitamui.ingest.common.dto.ArchiveUnitDto;
@@ -166,10 +167,10 @@ public class IngestGeneratorODTFile {
         Table table = document.addTable(2, 2);
         Cell cellOne = table.getColumnByIndex(0).getCellByIndex(0);
         Cell cellTwo = table.getColumnByIndex(0).getCellByIndex(1);
-        cellOne.setStringValue("Service producteur :");
-        cellTwo.setStringValue("Service versant :");
         table.getColumnByIndex(0).setWidth(50);
 
+        OdfUtils.setCellText(cellOne, "Service producteur :");
+        OdfUtils.setCellText(cellTwo, "Service versant :");
         Font fontCellOne = cellOne.getFont();
         fontCellOne.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         cellOne.setFont(fontCellOne);
@@ -178,11 +179,11 @@ public class IngestGeneratorODTFile {
         fontCellTwo.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         cellTwo.setFont(fontCellTwo);
 
-        table
-            .getColumnByIndex(1)
-            .getCellByIndex(0)
-            .setStringValue(getManifestPrincipalData(manifest, "OriginatingAgencyIdentifier"));
-        table.getColumnByIndex(1).getCellByIndex(1).setStringValue(getServiceVersant(manifest));
+        OdfUtils.setCellText(
+            table.getColumnByIndex(1).getCellByIndex(0),
+            getManifestPrincipalData(manifest, "OriginatingAgencyIdentifier")
+        );
+        OdfUtils.setCellText(table.getColumnByIndex(1).getCellByIndex(1), getServiceVersant(manifest));
 
         addSpace(document);
     }
@@ -203,35 +204,37 @@ public class IngestGeneratorODTFile {
         table.getColumnByIndex(0).setWidth(50);
 
         Cell tableCellOne = table.getColumnByIndex(0).getCellByIndex(0);
-        tableCellOne.setStringValue("Numéro du versement :");
+        OdfUtils.setCellText(tableCellOne, "Numéro du versement :");
         Font fontCellOne = tableCellOne.getFont();
         fontCellOne.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         tableCellOne.setFont(fontCellOne);
 
         Cell tableCellTwo = table.getColumnByIndex(0).getCellByIndex(1);
-        tableCellTwo.setStringValue("Présentation du contenu :");
+        OdfUtils.setCellText(tableCellTwo, "Présentation du contenu :");
         Font fontCellTwo = tableCellTwo.getFont();
         fontCellTwo.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         tableCellTwo.setFont(fontCellTwo);
 
         Cell tableCellThree = table.getColumnByIndex(0).getCellByIndex(2);
-        tableCellThree.setStringValue("Dates extrêmes :");
+        OdfUtils.setCellText(tableCellThree, "Dates extrêmes :");
         Font fontCellThree = tableCellThree.getFont();
         fontCellThree.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         tableCellThree.setFont(fontCellThree);
 
         Cell tableCellFour = table.getColumnByIndex(0).getCellByIndex(3);
-        tableCellFour.setStringValue("Historique des conservations :");
+        OdfUtils.setCellText(tableCellFour, "Historique des conservations :");
         Font fontCellFour = tableCellFour.getFont();
         fontCellFour.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         tableCellFour.setFont(fontCellFour);
 
-        table
-            .getColumnByIndex(1)
-            .getCellByIndex(0)
-            .setStringValue(getManifestPrincipalData(manifest, "MessageIdentifier"));
-
-        table.getColumnByIndex(1).getCellByIndex(1).setStringValue(getManifestPrincipalData(manifest, "Comment"));
+        OdfUtils.setCellText(
+            table.getColumnByIndex(1).getCellByIndex(0),
+            getManifestPrincipalData(manifest, "MessageIdentifier")
+        );
+        OdfUtils.setCellText(
+            table.getColumnByIndex(1).getCellByIndex(1),
+            getManifestPrincipalData(manifest, "Comment")
+        );
         if (!archiveUnitDtoList.isEmpty()) {
             table
                 .getColumnByIndex(1)
@@ -242,7 +245,7 @@ public class IngestGeneratorODTFile {
                 .getCellByIndex(2)
                 .addParagraph("Date de fin : " + getEndDate(getArchiveUnitEndDatesList(archiveUnitDtoList)));
         }
-        table.getColumnByIndex(1).getCellByIndex(3).setStringValue(getCustodialHistory(manifest));
+        OdfUtils.setCellText(table.getColumnByIndex(1).getCellByIndex(3), getCustodialHistory(manifest));
 
         addSpace(document);
     }
@@ -259,19 +262,19 @@ public class IngestGeneratorODTFile {
         table.getColumnByIndex(0).setWidth(50);
 
         Cell cellOne = table.getColumnByIndex(0).getCellByIndex(0);
-        cellOne.setStringValue("Nombre de fichiers binaires:");
+        OdfUtils.setCellText(cellOne, "Nombre de fichiers binaires:");
         Font fontCellOne = cellOne.getFont();
         fontCellOne.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         cellOne.setFont(fontCellOne);
 
         Cell cellTwo = table.getColumnByIndex(0).getCellByIndex(1);
-        cellTwo.setStringValue("Identifiant de l’opération d’entrée :");
+        OdfUtils.setCellText(cellTwo, "Identifiant de l'opération d'entrée :");
         Font fontCellTwo = cellTwo.getFont();
         fontCellTwo.setFontStyle(StyleTypeDefinitions.FontStyle.BOLD);
         cellTwo.setFont(fontCellTwo);
 
-        table.getColumnByIndex(1).getCellByIndex(0).setStringValue(getBinaryFileNumber(manifest) + " fichiers");
-        table.getColumnByIndex(1).getCellByIndex(1).setStringValue(id);
+        OdfUtils.setCellText(table.getColumnByIndex(1).getCellByIndex(0), getBinaryFileNumber(manifest) + " fichiers");
+        OdfUtils.setCellText(table.getColumnByIndex(1).getCellByIndex(1), id);
 
         addSpace(document);
         addSpace(document);
@@ -292,19 +295,19 @@ public class IngestGeneratorODTFile {
         table.getRowByIndex(1).setHeight(25, false);
 
         Cell tableCellOne = table.getColumnByIndex(0).getCellByIndex(0);
-        tableCellOne.setStringValue("Date de signature : ");
+        OdfUtils.setCellText(tableCellOne, "Date de signature : ");
         tableCellOne.addParagraph("");
 
         Cell tableCellTwo = table.getColumnByIndex(0).getCellByIndex(1);
-        tableCellTwo.setStringValue("Le responsable du versement :");
+        OdfUtils.setCellText(tableCellTwo, "Le responsable du versement :");
         tableCellTwo.addParagraph("");
 
         Cell tableCellThree = table.getColumnByIndex(1).getCellByIndex(0);
-        tableCellThree.setStringValue("Date de signature :");
+        OdfUtils.setCellText(tableCellThree, "Date de signature :");
         tableCellThree.addParagraph("");
 
         Cell tableCellFour = table.getColumnByIndex(1).getCellByIndex(1);
-        tableCellFour.setStringValue("Le responsable du service d'archives :");
+        OdfUtils.setCellText(tableCellFour, "Le responsable du service d'archives :");
         tableCellFour.addParagraph("");
 
         tableCellOne.setBorders(StyleTypeDefinitions.CellBordersType.NONE, border);

--- a/api/api-ingest/ingest/src/test/java/fr/gouv/vitamui/ingest/server/arch/ArchitectureTest.java
+++ b/api/api-ingest/ingest/src/test/java/fr/gouv/vitamui/ingest/server/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.ingest.server.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-pastis/pastis-commons/pom.xml
+++ b/api/api-pastis/pastis-commons/pom.xml
@@ -244,5 +244,17 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>fr.gouv.vitamui.commons</groupId>
+            <artifactId>commons-test</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/api/api-pastis/pastis-commons/src/test/java/fr/gouv/vitamui/pastis/common/service/arch/ArchitectureTest.java
+++ b/api/api-pastis/pastis-commons/src/test/java/fr/gouv/vitamui/pastis/common/service/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.pastis.common.service.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-pastis/pastis-standalone/pom.xml
+++ b/api/api-pastis/pastis-standalone/pom.xml
@@ -148,6 +148,18 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>fr.gouv.vitamui.commons</groupId>
+            <artifactId>commons-test</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/api/api-pastis/pastis-standalone/src/test/java/fr/gouv/vitamui/pastis/standalone/arch/ArchitectureTest.java
+++ b/api/api-pastis/pastis-standalone/src/test/java/fr/gouv/vitamui/pastis/standalone/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.pastis.standalone.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-pastis/pastis/pom.xml
+++ b/api/api-pastis/pastis/pom.xml
@@ -215,6 +215,12 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/api-pastis/pastis/src/test/java/fr/gouv/vitamui/pastis/server/arch/ArchitectureTest.java
+++ b/api/api-pastis/pastis/src/test/java/fr/gouv/vitamui/pastis/server/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.pastis.server.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-referential/referential-commons/pom.xml
+++ b/api/api-referential/referential-commons/pom.xml
@@ -80,6 +80,18 @@
 		    <artifactId>assertj-core</artifactId>
 		    <scope>test</scope>
 		</dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.gouv.vitamui.commons</groupId>
+            <artifactId>commons-test</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/api-referential/referential-commons/src/test/java/fr/gouv/vitamui/referential/common/arch/ArchitectureTest.java
+++ b/api/api-referential/referential-commons/src/test/java/fr/gouv/vitamui/referential/common/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.referential.common.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/api/api-referential/referential/pom.xml
+++ b/api/api-referential/referential/pom.xml
@@ -223,6 +223,12 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/arch/ArchitectureTest.java
+++ b/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/arch/ArchitectureTest.java
@@ -1,0 +1,13 @@
+package fr.gouv.vitamui.referential.server.arch;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import fr.gouv.vitamui.commons.test.arch.OdfToolkitRules;
+
+@AnalyzeClasses(packages = "fr.gouv.vitamui")
+public class ArchitectureTest {
+
+    @ArchTest
+    static final ArchTests rules = ArchTests.in(OdfToolkitRules.class);
+}

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,6 +74,7 @@
         <spring-security-cas.version>6.2.8</spring-security-cas.version>
         <swagger.version>3.0.0</swagger.version>
         <testcontainers.version>1.21.4</testcontainers.version>
+        <archunit.version>1.4.1</archunit.version>
         <thaiopensource.jing.version>20220510</thaiopensource.jing.version>
         <vitam.version>9.1.0-SNAPSHOT</vitam.version>
         <xdocreport.version>2.2.0</xdocreport.version>
@@ -838,7 +839,12 @@
                 <version>${testcontainers.version}</version>
                 <scope>test</scope>
             </dependency>
-
+            <dependency>
+                <groupId>com.tngtech.archunit</groupId>
+                <artifactId>archunit-junit5</artifactId>
+                <version>${archunit.version}</version>
+                <scope>test</scope>
+            </dependency>
             <!-- CUCUMBER SERENITY -->
             <dependency>
                 <groupId>net.serenity-bdd</groupId>

--- a/commons/commons-test/pom.xml
+++ b/commons/commons-test/pom.xml
@@ -42,7 +42,14 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.odftoolkit</groupId>
+            <artifactId>odfdom-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.odftoolkit</groupId>
+            <artifactId>simple-odf</artifactId>
+        </dependency>
         <!-- TEST -->
         <dependency>
             <groupId>fr.gouv.vitamui.commons</groupId>
@@ -77,6 +84,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <!-- Arch-->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/commons/commons-test/src/test/java/fr/gouv/vitamui/commons/test/arch/OdfToolkitRules.java
+++ b/commons/commons-test/src/test/java/fr/gouv/vitamui/commons/test/arch/OdfToolkitRules.java
@@ -1,0 +1,33 @@
+package fr.gouv.vitamui.commons.test.arch;
+
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.odftoolkit.simple.table.Cell;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+public class OdfToolkitRules {
+
+    /**
+     * Forbid usage of Cell#setStringValue().
+     *
+     * Reason:
+     * - This method indirectly triggers AWT via Cell.optimizeCellSize().
+     * - In environments without system fonts (e.g. minimal Linux / no fontconfig),
+     *   this leads to runtime failures:
+     *   "Fontconfig head is null, check your fonts or fonts configuration".
+     *
+     * Recommended alternative:
+     * - Use Cell#setCellText(), which writes directly to the ODT DOM
+     *   and does not rely on AWT.
+     *
+     * This rule prevents reintroducing the issue in CI.
+     */
+    @ArchTest
+    public static final ArchRule no_set_string_value_usage = noClasses()
+        .should()
+        .callMethod(Cell.class, "setStringValue", String.class)
+        .because(
+            "setStringValue() triggers AWT via optimizeCellSize() and crashes in environments without system fonts. Use OdfUtils.setCellText() instead."
+        );
+}

--- a/commons/commons-utils/pom.xml
+++ b/commons/commons-utils/pom.xml
@@ -99,6 +99,29 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.odftoolkit</groupId>
+            <artifactId>odfdom-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.odftoolkit</groupId>
+            <artifactId>simple-odf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <scope>test</scope>

--- a/commons/commons-utils/src/main/java/fr/gouv/vitamui/commons/utils/OdfUtils.java
+++ b/commons/commons-utils/src/main/java/fr/gouv/vitamui/commons/utils/OdfUtils.java
@@ -1,0 +1,49 @@
+package fr.gouv.vitamui.commons.utils;
+
+import org.odftoolkit.odfdom.dom.attribute.office.OfficeValueTypeAttribute;
+import org.odftoolkit.odfdom.incubator.doc.text.OdfTextParagraph;
+import org.odftoolkit.odfdom.pkg.OdfFileDom;
+import org.odftoolkit.simple.table.Cell;
+
+public final class OdfUtils {
+
+    private OdfUtils() {}
+
+    /**
+     * Utility methods for writing content into ODF cells without triggering AWT.
+     *
+     * Problem:
+     * - Cell#setStringValue() indirectly invokes AWT via optimizeCellSize()
+     * (through setDisplayTextContent() => JTextField => getFontMetrics()).
+     * - In environments without system fonts (e.g. Alpine / minimal JRE),
+     * this leads to runtime failures:
+     * "Fontconfig head is null, check your fonts or fonts configuration".
+     *
+     * Solution:
+     * - This utility writes directly into the ODT XML DOM:
+     *  . sets the value type to STRING
+     *  . sets the office:string-value attribute
+     *  . creates the text paragraph node
+     * - This bypasses any AWT dependency.
+     *
+     * Usage:
+     * - Always use this method instead of Cell#setStringValue().
+     *
+     * For more details, see:
+     * <a href="https://assistance.programmevitam.fr/plugins/tracker/?aid=15864">...</a>
+     */
+    public static void setCellText(Cell cell, String text) {
+        if (text == null) {
+            text = "";
+        }
+
+        cell.getOdfElement().setOfficeStringValueAttribute(text);
+        cell.getOdfElement().setOfficeValueTypeAttribute(OfficeValueTypeAttribute.Value.STRING.toString());
+
+        OdfFileDom dom = (OdfFileDom) cell.getOdfElement().getOwnerDocument();
+        OdfTextParagraph paragraph = new OdfTextParagraph(dom);
+        paragraph.setTextContent(text);
+
+        cell.getOdfElement().appendChild(paragraph);
+    }
+}


### PR DESCRIPTION
## Bug #15864 — Erreur 500 lors du téléchargement du bordereau de versement

### Context

Downloading a document returns HTTP 500 only on ITREC (AlmaLinux 9), not on INT (Debian).

### Root cause

`odftoolkit` triggers Java AWT through the following chain:

```
setStringValue() → setDisplayTextContent() → optimizeCellSize() → new JTextField() → getFontMetrics() → RuntimeException: Fontconfig head is null
```

In environments without `fontconfig`, the JVM cannot find a font manager → crash.

| Environment | OS | fontconfig | Result |
|---|---|---|---|
| INT | Debian Bookworm | ✅ via LibreOffice | OK |
| ITREC | AlmaLinux 9 | ❌ missing | crash |

### Fix

Replaced `setStringValue()` with `setCellText()` in `IngestGeneratorODTFile`. `setCellText()` writes directly into the ODT XML DOM without going through AWT: sets `office:value-type` to `string`, sets `office:string-value`, creates the text paragraph via `appendChild()`.

### Prevention

ArchUnit rule added in `commons-test/OdfToolkitRules`, referenced in each module via `ArchitectureTest`. Any reintroduction of `setStringValue()` will be caught automatically at CI build time.

```java
noClasses()
    .should()
    .callMethod(Cell.class, "setStringValue", String.class)
    .because("setStringValue() triggers AWT via optimizeCellSize() and crashes in environments without system fonts. Use OdfUtils.setCellText() instead.");
```
