### PR TITLE
Bug #16215: Fix redirect after relogin

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-authenticator.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/authentication/services/oidc-authenticator.service.ts
@@ -39,7 +39,7 @@ import { from, Observable } from 'rxjs';
 import { AuthenticatorService } from './authenticator.service';
 import { map, tap } from 'rxjs/operators';
 
-const OIDC_PARAMS = ['code', 'state', 'id_token', 'access_token', 'token_type', 'session_state', 'nonce'];
+const OIDC_PARAMS = ['code', 'state', 'id_token', 'access_token', 'token_type', 'session_state', 'nonce', 'client_id'];
 
 export class OidcAuthenticatorService implements AuthenticatorService {
   constructor(


### PR DESCRIPTION
## Description

Lors d’une reconnexion, le paramètre `client_id` de l’application reste présent dans l’URL.

Ce paramètre résiduel perturbe la redirection vers les autres applications au premier clic après reconnexion.

## Changement

Ajout de `client_id` à la liste des paramètres OIDC nettoyés de l’URL après authentification.