### PR TITLE
Bug #16209 - [Management Rule Update] The start date DatePicker must be inactive as long as the target date switch is not set to ON && The “end date” date picker does not display its icon.

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/update-unit-rules/update-unit-rules.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/update-unit-rules/update-unit-rules.component.html
@@ -48,6 +48,7 @@
               outputType="Date"
               format="dd/MM/yyyy"
               class="w-100"
+              [disabled]="isStartDateDisabled"
             ></vitamui-datepicker>
             <button
               [ngStyle]="{
@@ -66,7 +67,17 @@
           </div>
         </div>
 
-        <vitamui-input class="col" formControlName="endDate" [placeholder]="'RULES.APPRAISAL_RULES.END_DATE' | translate"> </vitamui-input>
+        <div class="col">
+          <div class="hgap-2">
+            <vitamui-datepicker
+              [label]="'RULES.APPRAISAL_RULES.END_DATE' | translate"
+              formControlName="endDate"
+              outputType="Date"
+              format="dd/MM/yyyy"
+              class="w-100"
+            ></vitamui-datepicker>
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
- si switch OFF alors DatePicker inactif
- date picker de" date de fin" inactif n'a pas son picto