### PR TITLE
Bug #15760 - [App Search & Collect] Automatic unchecking of options in the “Producing service(s)” and “Archival unit profile(s)” selectors.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -286,7 +286,12 @@ export class SelectComponent extends AbstractFormInputDirective implements After
     this.sd
       .scrolled()
       .pipe(filter((scrollable) => this.cdkVirtualScrollViewport === scrollable))
-      .subscribe(() => this.updateSelectAll());
+      .subscribe(() => {
+        this.updateSelectAll();
+        this.syncRenderedOptionsSelection();
+      });
+
+    this.optionKeys.changes.subscribe(() => this.syncRenderedOptionsSelection());
 
     this.addEventListeners();
 
@@ -295,6 +300,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
       Promise.resolve().then(() => {
         this.synchronizeSelectedOptions();
         this.updateMatSelectTriggerContent();
+        this.syncRenderedOptionsSelection();
         this.cd.detectChanges();
       });
     }
@@ -435,12 +441,14 @@ export class SelectComponent extends AbstractFormInputDirective implements After
 
     if (this.selectedOptions.length === 0) {
       this.clearAllSelectedOptions();
+      this.updateMatSelectTriggerContent(this._multiple ? [] : undefined);
     } else {
       const selectedKeys = [...this.selectedOptions.map((option) => option.key)].sort();
-      this.onChange(this._multiple ? selectedKeys : selectedKeys[0]);
+      const valueToPropagate = this._multiple ? selectedKeys : selectedKeys[0];
+      this.onChange(valueToPropagate);
+      this.updateMatSelectTriggerContent(valueToPropagate);
     }
-
-    this.updateMatSelectTriggerContent();
+    this.syncRenderedOptionsSelection();
   }
 
   public readonly compareOptions = (o1: any, o2: any): boolean => {
@@ -590,7 +598,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
     }
   }
 
-  private updateMatSelectTriggerContent(): void {
+  private updateMatSelectTriggerContent(valueOverride?: any): void {
     if (!this.matSelect || this.isUpdatingTrigger) return;
 
     Object.defineProperties(this.matSelect, {
@@ -600,12 +608,14 @@ export class SelectComponent extends AbstractFormInputDirective implements After
       },
     });
 
-    if (this.control?.value != null) {
+    const valueToDisplay = valueOverride ?? this.control?.value;
+
+    if (valueToDisplay != null) {
       this.isUpdatingTrigger = true;
 
       try {
-        this.matSelect.value = this.control.value;
-        this.matSelect._onChange(this.control.value);
+        this.matSelect.value = valueToDisplay;
+        this.matSelect._onChange(valueToDisplay);
         this.matSelect.stateChanges.next();
       } finally {
         this.isUpdatingTrigger = false;
@@ -653,7 +663,25 @@ export class SelectComponent extends AbstractFormInputDirective implements After
       if (this.multiple && Array.isArray(this.control.value)) {
         this.selectedOptions = this.allOptions.filter((option) => this.control.value.includes(option.key));
       }
+      this.syncRenderedOptionsSelection();
       this.cd.detectChanges();
+    });
+  }
+
+  private syncRenderedOptionsSelection(): void {
+    if (!this.optionKeys) return;
+
+    const selectedKeys = new Set(this.selectedOptions.map((option) => String(option.key)));
+    this.optionKeys.forEach((optionKey) => {
+      if (optionKey.value === this.SELECT_ALL_OPTIONS) return;
+
+      const shouldBeSelected = selectedKeys.has(String(optionKey.value));
+      if (shouldBeSelected && !optionKey.selected) {
+        optionKey.select(false);
+      }
+      if (!shouldBeSelected && optionKey.selected) {
+        optionKey.deselect(false);
+      }
     });
   }
 


### PR DESCRIPTION
**1. Bug 1 (2e sélection décoche visuellement la 1re)**

**• Cause**: en multi-sélection, l’UI se recalait parfois sur control.value (retardé avec updateOn: 'blur') au lieu de la valeur réellement cliquée.
**• Fix:**
◦ dans onSelectionChange, on calcule valueToPropagate et on l’utilise pour synchroniser l’affichage immédiatement.
◦ updateMatSelectTriggerContent accepte une valeur optionnelle (valueOverride) pour forcer la bonne valeur visuelle.

**2. Bug 2 (scroll puis retour: décochage visuel uniquement)**

**• Cause:** avec le virtual scroll (cdkVirtualFor), les mat-option sont recyclées et leur état visuel pouvait se désynchroniser de selectedOptions.
**• Fix:**
◦ ajout de syncRenderedOptionsSelection() qui resynchronise explicitement chaque option rendue (select/deselect) selon selectedOptions.
◦ appel de cette synchro:  après scroll, quand optionKeys change (re-render), après sélection utilisateur, lors des phases d’initialisation/ensure display.