### PR TITLE
CP V8.1 - Bug #16201 [Access Contract] The “Validate” button remains active without any position selected when editing an access contract.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-nodes-tab/access-contract-nodes-update/access-contract-node-update.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-nodes-tab/access-contract-nodes-update/access-contract-node-update.component.html
@@ -25,7 +25,7 @@
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button type="submit" class="btn primary">
+    <button type="submit" class="btn primary" [disabled]="isInvalid()">
       {{ 'COMMON.VALIDATE' | translate }}
     </button>
     <button type="button" class="btn cancel link" (click)="onCancel()">

--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-nodes-tab/access-contract-nodes-update/access-contract-node-update.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-nodes-tab/access-contract-nodes-update/access-contract-node-update.component.ts
@@ -92,6 +92,13 @@ export class AccessContractNodeUpdateComponent implements OnInit {
     this.dialogRef.close();
   }
 
+  isInvalid(): boolean {
+    return (
+      this.allRootUnitsControl.value === false &&
+      (!this.selectNodesForm.get('rootUnits').value || this.selectNodesForm.get('rootUnits').value.length === 0)
+    );
+  }
+
   updateAccessContractNodes() {
     const rootUnits: string[] = this.allRootUnitsControl.value ? [] : this.selectNodesForm.get('rootUnits').value;
     const excludedRootUnits: string[] = this.allRootUnitsControl.value ? [] : this.selectNodesForm.get('excludedRootUnits').value;


### PR DESCRIPTION
see: https://github.com/ProgrammeVitam/vitam-ui/pull/3709