### PR TITLE
CP V9.0 - Story #15307: Add missing retries for package installation.

### DIFF
--- a/deployment/roles/filebeat/tasks/install.yml
+++ b/deployment/roles/filebeat/tasks/install.yml
@@ -4,6 +4,10 @@
   package:
     name: "{{ filebeat_package }}"
     state: present
+  register: result
+  retries: "{{ packages_install_retries_number }}"
+  until: result is succeeded
+  delay: "{{ packages_install_retries_delay }}"
   notify: "filebeat - restart service"
   when: install_mode != "container"
 


### PR DESCRIPTION
## Description

> Cherry-Picked from #3715 

Ajout des paramètres de retry lors de l'installation de Filebeat.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam