### PR TITLE
Bug #16431 [Collect]  Fix reclassification workflow UI errors caused by invalid validator return value.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/reclassification-dialog/reclassification-dialog.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/reclassification-dialog/reclassification-dialog.component.ts
@@ -82,7 +82,7 @@ interface ActionOption extends Option {
 const atLeastOneFilingPlan: ValidatorFn = (control) => {
   if (control.value?.included?.length > 0) return;
 
-  return { required: 'Requires at least one selection' };
+  return { required: true };
 };
 
 @Component({


### PR DESCRIPTION
Le validateur retournait une chaîne **'Requires at least one selection'** au lieu de **true** (les validateurs Angular doivent retourner un objet avec des valeurs Boolean pas string)