### PR TITLE
Bug #14926: Secure *.findHistoryById methods

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/service/CustomerService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/service/CustomerService.java
@@ -37,26 +37,22 @@
 
 package fr.gouv.vitamui.iam.server.customer.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.converter.Converter;
 import fr.gouv.vitamui.commons.api.domain.OwnerDto;
 import fr.gouv.vitamui.commons.api.enums.AttachmentType;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.InvalidFormatException;
 import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.api.utils.CastUtils;
 import fr.gouv.vitamui.commons.api.utils.EnumUtils;
+import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.utils.VitamUIUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.dto.CustomerCreationFormData;
 import fr.gouv.vitamui.iam.common.dto.CustomerDto;
 import fr.gouv.vitamui.iam.common.dto.CustomerPatchFormData;
@@ -668,7 +664,7 @@ public class CustomerService extends AbstractResourceClientService<CustomerDto, 
         Assert.isTrue(owners != null && owners.size() > 0, message + ": a customer must have owners.");
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         LOGGER.debug("findHistoryById for id" + id);
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
@@ -677,18 +673,12 @@ public class CustomerService extends AbstractResourceClientService<CustomerDto, 
 
         final Optional<Customer> customer = getRepository().findById(id);
         customer.orElseThrow(() -> new NotFoundException("No user found with id : %s".formatted(id)));
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                customer.get().getIdentifier(),
-                MongoDbCollections.CUSTOMERS,
-                vitamContext
-            )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            customer.get().getIdentifier(),
+            MongoDbCollections.CUSTOMERS,
+            vitamContext,
+            List.of(EventType.EXT_VITAMUI_CREATE_CUSTOMER.name(), EventType.EXT_VITAMUI_UPDATE_CUSTOMER.name())
+        );
     }
 
     /**

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/externalparamprofile/service/ExternalParamProfileService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/externalparamprofile/service/ExternalParamProfileService.java
@@ -36,8 +36,6 @@
  */
 package fr.gouv.vitamui.iam.server.externalparamprofile.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.CommonConstants;
@@ -51,13 +49,11 @@ import fr.gouv.vitamui.commons.api.domain.ProfileDto;
 import fr.gouv.vitamui.commons.api.domain.QueryDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
+import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.builder.ExternalParamDtoBuilder;
 import fr.gouv.vitamui.iam.server.common.builder.ProfileDtoBuilder;
@@ -195,7 +191,7 @@ public class ExternalParamProfileService {
         return externalParamProfileRepository.findByIdProfile(id);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
             .setAccessContract(securityService.getTenant(tenantIdentifier).getAccessContractLogbookIdentifier())
@@ -212,14 +208,15 @@ public class ExternalParamProfileService {
             "externalparamprofile",
             vitamContext
         );
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(id, EXTERNAL_PARAM_PROFILE, vitamContext)
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            id,
+            EXTERNAL_PARAM_PROFILE,
+            vitamContext,
+            List.of(
+                EventType.EXT_VITAMUI_CREATE_EXTERNAL_PARAM_PROFILE.name(),
+                EventType.EXT_VITAMUI_UPDATE_EXTERNAL_PARAM_PROFILE.name()
+            )
+        );
     }
 
     @Transactional

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/group/service/GroupService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/group/service/GroupService.java
@@ -36,8 +36,6 @@
  */
 package fr.gouv.vitamui.iam.server.group.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.CommonConstants;
@@ -51,7 +49,6 @@ import fr.gouv.vitamui.commons.api.domain.QueryDto;
 import fr.gouv.vitamui.commons.api.domain.QueryOperator;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.ForbiddenException;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.api.exception.NotImplementedException;
 import fr.gouv.vitamui.commons.api.exception.UnexpectedDataException;
@@ -59,8 +56,8 @@ import fr.gouv.vitamui.commons.api.utils.CastUtils;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.mongo.utils.MongoUtils;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookEventDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
@@ -644,7 +641,7 @@ public class GroupService extends AbstractResourceClientService<GroupDto, Group>
         return groupConverter;
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         LOGGER.debug("findHistoryById for id" + id);
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
@@ -653,18 +650,12 @@ public class GroupService extends AbstractResourceClientService<GroupDto, Group>
 
         final Optional<Group> group = getRepository().findById(id);
         group.orElseThrow(() -> new NotFoundException("No group found with id : %s".formatted(id)));
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                group.get().getIdentifier(),
-                MongoDbCollections.GROUPS,
-                vitamContext
-            )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            group.get().getIdentifier(),
+            MongoDbCollections.GROUPS,
+            vitamContext,
+            List.of(EXT_VITAMUI_CREATE_GROUP.name(), EXT_VITAMUI_UPDATE_GROUP.name())
+        );
     }
 
     /**

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/owner/service/OwnerService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/owner/service/OwnerService.java
@@ -37,21 +37,16 @@
 
 package fr.gouv.vitamui.iam.server.owner.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.converter.Converter;
 import fr.gouv.vitamui.commons.api.domain.OwnerDto;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.api.utils.CastUtils;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.domain.Address;
 import fr.gouv.vitamui.iam.server.common.domain.MongoDbCollections;
@@ -82,6 +77,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+
+import static fr.gouv.vitamui.commons.logbook.common.EventType.EXT_VITAMUI_CREATE_OWNER;
+import static fr.gouv.vitamui.commons.logbook.common.EventType.EXT_VITAMUI_CREATE_TENANT;
+import static fr.gouv.vitamui.commons.logbook.common.EventType.EXT_VITAMUI_UPDATE_OWNER;
+import static fr.gouv.vitamui.commons.logbook.common.EventType.EXT_VITAMUI_UPDATE_TENANT;
 
 /**
  * The service to read, create, update and delete the tenants.
@@ -290,7 +290,7 @@ public class OwnerService extends AbstractResourceClientService<OwnerDto, Owner>
         );
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         LOGGER.debug("findHistoryById for id {}", id);
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
@@ -302,18 +302,17 @@ public class OwnerService extends AbstractResourceClientService<OwnerDto, Owner>
 
         LOGGER.info("Find History EvIdAppSession : {} ", vitamContext.getApplicationSessionId());
 
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                owner.get().getIdentifier(),
-                MongoDbCollections.OWNERS,
-                vitamContext
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            owner.get().getIdentifier(),
+            MongoDbCollections.OWNERS,
+            vitamContext,
+            List.of(
+                EXT_VITAMUI_CREATE_OWNER.name(),
+                EXT_VITAMUI_UPDATE_OWNER.name(),
+                EXT_VITAMUI_CREATE_TENANT.name(),
+                EXT_VITAMUI_UPDATE_TENANT.name()
             )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        );
     }
 
     private void checkIsReadonly(final boolean readonly, final String message) {

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/profile/service/ProfileService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/profile/service/ProfileService.java
@@ -37,8 +37,6 @@
 
 package fr.gouv.vitamui.iam.server.profile.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.CommonConstants;
@@ -49,17 +47,15 @@ import fr.gouv.vitamui.commons.api.domain.QueryDto;
 import fr.gouv.vitamui.commons.api.domain.QueryOperator;
 import fr.gouv.vitamui.commons.api.domain.Role;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.api.exception.NotImplementedException;
 import fr.gouv.vitamui.commons.api.utils.CastUtils;
+import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.mongo.utils.MongoUtils;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.dto.common.EmbeddedOptions;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.ApiIamConstants;
@@ -528,7 +524,7 @@ public class ProfileService extends AbstractResourceClientService<ProfileDto, Pr
         return profileConverter;
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
             .setAccessContract(securityService.getTenant(tenantIdentifier).getAccessContractLogbookIdentifier())
@@ -547,18 +543,12 @@ public class ProfileService extends AbstractResourceClientService<ProfileDto, Pr
             MongoDbCollections.PROFILES,
             vitamContext
         );
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                profile.get().getIdentifier(),
-                MongoDbCollections.PROFILES,
-                vitamContext
-            )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            profile.get().getIdentifier(),
+            MongoDbCollections.PROFILES,
+            vitamContext,
+            List.of(EventType.EXT_VITAMUI_CREATE_PROFILE.name(), EventType.EXT_VITAMUI_UPDATE_PROFILE.name())
+        );
     }
 
     /**

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/CustomerController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/CustomerController.java
@@ -49,7 +49,7 @@ import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.enums.ContentDispositionType;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.dto.CustomerCreationFormData;
 import fr.gouv.vitamui.iam.common.dto.CustomerDto;
 import fr.gouv.vitamui.iam.common.dto.CustomerPatchFormData;
@@ -89,6 +89,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -240,8 +241,8 @@ public class CustomerController implements CrudController<CustomerDto> {
 
     @Operation(operationId = "customers_findHistoryById", summary = "Find history for a customer by its id")
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    @Secured(ServicesData.ROLE_GET_CUSTOMERS)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         LOGGER.debug("get logbook for customer with id :{}", id);
         SanityChecker.checkSecureParameter(id);
         return customerService.findHistoryById(id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ExternalParamProfileController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ExternalParamProfileController.java
@@ -50,7 +50,7 @@ import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.utils.EnumUtils;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.dto.common.EmbeddedOptions;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.server.externalparamprofile.service.ExternalParamProfileService;
@@ -74,6 +74,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -179,7 +180,7 @@ public class ExternalParamProfileController implements CrudController<ExternalPa
     )
     @GetMapping(CommonConstants.PATH_LOGBOOK)
     @Secured(ServicesData.ROLE_SEARCH_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/GroupController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/GroupController.java
@@ -50,7 +50,7 @@ import fr.gouv.vitamui.commons.api.utils.CastUtils;
 import fr.gouv.vitamui.commons.api.utils.EnumUtils;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.dto.common.EmbeddedOptions;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
@@ -216,7 +216,8 @@ public class GroupController implements CrudController<GroupDto> {
 
     @GetMapping(CommonConstants.PATH_LOGBOOK)
     @Operation(operationId = "groups_findHistoryById", summary = "Get group history by id")
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    @Secured(ServicesData.ROLE_GET_GROUPS)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, VitamClientException {
         ParameterChecker.checkParameter("Identifier is mandatory : ", id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/OwnerController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/OwnerController.java
@@ -47,7 +47,7 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.server.owner.service.OwnerService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,6 +72,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -166,7 +167,8 @@ public class OwnerController implements CrudController<OwnerDto> {
 
     @GetMapping(CommonConstants.PATH_LOGBOOK)
     @Operation(operationId = "owners_findHistoryById", summary = "Get owner history by its id")
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    @Secured(ServicesData.ROLE_GET_OWNERS)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, VitamClientException {
         ParameterChecker.checkParameter("Identifier is mandatory : ", id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ProfileController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ProfileController.java
@@ -50,7 +50,7 @@ import fr.gouv.vitamui.commons.api.utils.CastUtils;
 import fr.gouv.vitamui.commons.api.utils.EnumUtils;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.dto.common.EmbeddedOptions;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
@@ -224,7 +224,8 @@ public class ProfileController implements CrudController<ProfileDto> {
 
     @Operation(operationId = "profiles_findHistoryById", summary = "Get profile history by its id")
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    @Secured(ServicesData.ROLE_GET_PROFILES)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws VitamClientException, InvalidParseOperationException {
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/TenantController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/TenantController.java
@@ -46,7 +46,7 @@ import fr.gouv.vitamui.commons.api.domain.TenantDto;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.server.tenant.service.TenantService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -181,8 +181,8 @@ public class TenantController implements CrudController<TenantDto> {
 
     @Operation(operationId = "tenants_findHistoryById", summary = "Get history by tenant's id")
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    @Secured({ ServicesData.ROLE_GET_TENANTS, ServicesData.ROLE_GET_ALL_TENANTS })
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for tenant with id :{}", id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/UserController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/UserController.java
@@ -49,7 +49,7 @@ import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.CrudController;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
 import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.user.service.ConnectionHistoryService;
@@ -222,7 +222,8 @@ public class UserController implements CrudController<UserDto> {
 
     @Operation(operationId = "users_findHistoryById", summary = "Get user history by its id")
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    @Secured(ServicesData.ROLE_GET_USERS)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws VitamClientException, InvalidParseOperationException {
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/UserInfoController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/UserInfoController.java
@@ -46,7 +46,7 @@ import fr.gouv.vitamui.commons.api.domain.UserInfoDto;
 import fr.gouv.vitamui.commons.api.exception.NotImplementedException;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.CrudController;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.server.user.service.UserInfoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -70,6 +70,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -171,8 +172,8 @@ public class UserInfoController implements CrudController<UserInfoDto> {
 
     @GetMapping(CommonConstants.PATH_LOGBOOK)
     @Operation(operationId = "userInfo_findHistoryById", summary = "Get user info history by id")
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    @Secured(ServicesData.ROLE_GET_USER_INFOS)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for user info with id :{}", id);

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/tenant/service/TenantService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/tenant/service/TenantService.java
@@ -37,8 +37,6 @@
 
 package fr.gouv.vitamui.iam.server.tenant.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.CommonConstants;
@@ -54,19 +52,17 @@ import fr.gouv.vitamui.commons.api.domain.TenantDto;
 import fr.gouv.vitamui.commons.api.domain.UserDto;
 import fr.gouv.vitamui.commons.api.domain.VitamConfigurationDto;
 import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.NoRightsException;
 import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.api.exception.NotImplementedException;
 import fr.gouv.vitamui.commons.api.utils.CastUtils;
+import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.mongo.CustomSequencesConstants;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.administration.ConfigurationService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.common.enums.Application;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.ApiIamConstants;
@@ -590,7 +586,7 @@ public class TenantService extends AbstractResourceClientService<TenantDto, Tena
         groupService.updateProfilesById(adminGroupDto.getId(), adminGroupDto.getProfileIds());
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         LOGGER.debug("findHistoryById for id" + id);
 
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
@@ -605,18 +601,12 @@ public class TenantService extends AbstractResourceClientService<TenantDto, Tena
             "Tenant History EvIdAppSession : {} ",
             securityService.buildVitamContext(securityService.getTenantIdentifier()).getApplicationSessionId()
         );
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                String.valueOf(tenant.get().getIdentifier()),
-                MongoDbCollections.TENANTS,
-                vitamContext
-            )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            String.valueOf(tenant.get().getIdentifier()),
+            MongoDbCollections.TENANTS,
+            vitamContext,
+            List.of(EventType.EXT_VITAMUI_CREATE_TENANT.name(), EventType.EXT_VITAMUI_UPDATE_TENANT.name())
+        );
     }
 
     @Override

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/OperationParser.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/OperationParser.java
@@ -35,17 +35,6 @@ public class OperationParser {
         return parse(json, NEW_VALUE_PREFIX);
     }
 
-    public String parseUserId(String evIdAppSession) {
-        if (evIdAppSession == null) {
-            return null;
-        }
-        String[] sessionData = evIdAppSession.split(":");
-        if (sessionData.length < 4) {
-            return null;
-        }
-        return sessionData[3];
-    }
-
     private String parse(String json, String prefix) {
         try {
             final HashMap<String, HashMap<String, String>> updateOperation = objectMapper.readValue(

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserExportService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserExportService.java
@@ -4,6 +4,7 @@ import fr.gouv.vitamui.commons.api.domain.UserDto;
 import fr.gouv.vitamui.commons.api.exception.UnexpectedDataException;
 import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookEventDto;
+import fr.gouv.vitamui.commons.vitam.api.util.EvIdAppSessionParser;
 import fr.gouv.vitamui.commons.vitam.xls.ExcelFileGeneratorUtils;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
@@ -116,7 +117,7 @@ public class UserExportService {
         String operationDateTime = operation.getEvDateTime();
         row.createCell(1).setCellValue(dateFormatService.formatDate(operationDateTime));
         row.createCell(2).setCellValue(dateFormatService.formatTime(operationDateTime));
-        row.createCell(3).setCellValue(operationParser.parseUserId(operation.getEvIdAppSession()));
+        row.createCell(3).setCellValue(EvIdAppSessionParser.parseUserId(operation.getEvIdAppSession()));
         row.createCell(4).setCellValue(translateService.translate(operation.getEvType()));
         row.createCell(5).setCellValue(parseOldValues(operation));
         row.createCell(6).setCellValue(parseNewValues(operation));

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserInfoService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserInfoService.java
@@ -37,23 +37,19 @@
 
 package fr.gouv.vitamui.iam.server.user.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.converter.Converter;
 import fr.gouv.vitamui.commons.api.domain.UserInfoDto;
 import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
-import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.api.utils.CastUtils;
+import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.dto.EventDiffDto;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.server.common.domain.MongoDbCollections;
 import fr.gouv.vitamui.iam.server.common.domain.SequencesConstants;
@@ -69,10 +65,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -176,7 +172,7 @@ public class UserInfoService extends AbstractResourceClientService<UserInfoDto, 
         return userInfoConverter;
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         LOGGER.debug("findHistoryById for id " + id);
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
@@ -185,18 +181,12 @@ public class UserInfoService extends AbstractResourceClientService<UserInfoDto, 
 
         final Optional<UserInfo> userInfo = getRepository().findById(id);
         userInfo.orElseThrow(() -> new NotFoundException("No user information found with id : %s".formatted(id)));
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                userInfo.get().getIdentifier(),
-                MongoDbCollections.USER_INFOS,
-                vitamContext
-            )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            userInfo.get().getIdentifier(),
+            MongoDbCollections.USER_INFOS,
+            vitamContext,
+            List.of(EventType.EXT_VITAMUI_CREATE_USER_INFO.name(), EventType.EXT_VITAMUI_UPDATE_USER_INFO.name())
+        );
     }
 
     @Override
@@ -206,14 +196,6 @@ public class UserInfoService extends AbstractResourceClientService<UserInfoDto, 
         super.checkIdentifier(dto.getIdentifier(), message);
 
         dto.setIdentifier(getNextSequenceId(SequencesConstants.USER_INFOS_IDENTIFIER));
-    }
-
-    private UserInfo find(final String id, final String message) {
-        Assert.isTrue(StringUtils.isNotEmpty(id), message + ": no id");
-
-        return getRepository()
-            .findById(id)
-            .orElseThrow(() -> new IllegalArgumentException(message + ": no user info found for id " + id));
     }
 
     @Override

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
@@ -36,9 +36,7 @@
  */
 package fr.gouv.vitamui.iam.server.user.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.gouv.vitam.common.client.VitamContext;
@@ -76,9 +74,9 @@ import fr.gouv.vitamui.commons.security.client.config.password.PasswordConfigura
 import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
 import fr.gouv.vitamui.commons.security.client.dto.BasicCustomerDto;
 import fr.gouv.vitamui.commons.security.client.dto.GraphicIdentityDto;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.utils.VitamUIUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookEventDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
@@ -1167,7 +1165,7 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
         return userConverter;
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         LOGGER.debug("findHistoryById for id " + id);
         final Integer tenantIdentifier = securityService.getTenantIdentifier();
         final VitamContext vitamContext = new VitamContext(tenantIdentifier)
@@ -1176,18 +1174,12 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
 
         final Optional<User> user = getRepository().findById(id);
         user.orElseThrow(() -> new NotFoundException("No user found with id : %s".formatted(id)));
-        final JsonNode body = logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                user.get().getIdentifier(),
-                MongoDbCollections.USERS,
-                vitamContext
-            )
-            .toJsonNode();
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            user.get().getIdentifier(),
+            MongoDbCollections.USERS,
+            vitamContext,
+            USER_OPERATIONS_EVENT_TYPES.stream().map(Enum::name).collect(Collectors.toList())
+        );
     }
 
     /**

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/owner/service/OwnerServiceIntegrationTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/owner/service/OwnerServiceIntegrationTest.java
@@ -1,11 +1,7 @@
 package fr.gouv.vitamui.iam.server.owner.service;
 
 import com.google.common.collect.ImmutableMap;
-import fr.gouv.vitam.common.GlobalDataRest;
 import fr.gouv.vitam.common.exception.VitamClientException;
-import fr.gouv.vitam.common.model.RequestResponse;
-import fr.gouv.vitam.common.model.RequestResponseOK;
-import fr.gouv.vitam.common.model.logbook.LogbookOperation;
 import fr.gouv.vitamui.commons.api.domain.OwnerDto;
 import fr.gouv.vitamui.commons.api.domain.TenantDto;
 import fr.gouv.vitamui.commons.logbook.common.EventType;
@@ -15,7 +11,7 @@ import fr.gouv.vitamui.commons.rest.client.HttpContext;
 import fr.gouv.vitamui.commons.test.VitamClientTestConfig;
 import fr.gouv.vitamui.commons.utils.VitamUIUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.server.common.domain.MongoDbCollections;
 import fr.gouv.vitamui.iam.server.common.service.AddressService;
 import fr.gouv.vitamui.iam.server.customer.dao.CustomerRepository;
@@ -27,7 +23,6 @@ import fr.gouv.vitamui.iam.server.owner.domain.Owner;
 import fr.gouv.vitamui.iam.server.tenant.dao.TenantRepository;
 import fr.gouv.vitamui.iam.server.tenant.domain.Tenant;
 import fr.gouv.vitamui.iam.server.utils.IamServerUtilsTest;
-import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,11 +40,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -206,15 +203,11 @@ public class OwnerServiceIntegrationTest extends AbstractLogbookIntegrationTest 
 
         Mockito.when(securityService.getTenantIdentifier()).thenReturn(tenant.getIdentifier());
         Mockito.when(securityService.getTenant(eq(tenant.getIdentifier()))).thenReturn(tenant);
-        final RequestResponse<LogbookOperation> operationsResponse = new RequestResponseOK<LogbookOperation>()
-            .addHeader(GlobalDataRest.X_REQUEST_ID, "requestId")
-            .addHeader(GlobalDataRest.X_APPLICATION_ID, "appId")
-            .setHttpCode(Response.Status.OK.getStatusCode());
         Mockito.when(
-            logbookService.findEventsByIdentifierAndCollectionNames(anyString(), anyString(), any())
-        ).thenReturn(operationsResponse);
+            logbookService.findEventsByIdentifierAndCollectionNames(anyString(), anyString(), any(), anyList())
+        ).thenReturn(List.of());
 
-        final LogbookOperationsCommonResponseDto historyResult = ownerService.findHistoryById(ownerCreated.getId());
+        final List<HistoryEventDto> historyResult = ownerService.findHistoryById(ownerCreated.getId());
 
         assertThat(historyResult).isNotNull();
         Mockito.verify(securityService).getTenantIdentifier();

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/user/service/OperationParserTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/user/service/OperationParserTest.java
@@ -25,12 +25,6 @@ class OperationParserTest {
         assertThat(operationParser.parseNewValues(json)).isEqualTo(expectedValue);
     }
 
-    @ParameterizedTest
-    @MethodSource("parseUserIdParameters")
-    void should_parse_user_id(String evIdAppSession, String expectedValue) {
-        assertThat(operationParser.parseUserId(evIdAppSession)).isEqualTo(expectedValue);
-    }
-
     private static Stream<Arguments> parseOldValuesParameters() {
         return Stream.of(
             Arguments.of(
@@ -55,16 +49,6 @@ class OperationParserTest {
                 "{\"diff\":{\"-Nom\":\"-\",\"+Nom\":\"-\",\"-Email\":\"-\",\"+Email\":\"-\",\"-Nom de la rue\":\"-\",\"+Nom de la rue\":\"-\",\"-Code postal\":\"-\",\"+Code postal\":\"-\",\"-Ville\":\"-\",\"+Ville\":\"-\",\"-Pays\":\"-\",\"+Pays\":\"-\",\"-Numéro mobile\":\"-\",\"+Numéro mobile\":\"-\",\"-Numéro fixe\":\"-\",\"+Numéro fixe\":\"-\",\"-Statut\":\"inactif\",\"+Statut\":\"supprimé\",\"-Date de suppression\":\"\",\"+Date de suppression\":\"2023-06-06T12:04:17.510768+02:00\",\"-Groupe de profils\":\"135\",\"+Groupe de profils\":\"Optional.empty\",\"-Prénom\":\"-\",\"+Prénom\":\"-\",\"-Code du site\":\"\",\"+Code du site\":\"\",\"-Code interne\":\"\",\"+Code interne\":\"\"},\"Date d'opération\":\"2023-06-06T10:04:17.513\"}",
                 "Nom:-,Email:-,Nom de la rue:-,Code postal:-,Ville:-,Pays:-,Numéro mobile:-,Numéro fixe:-,Statut:supprimé,Date de suppression:2023-06-06T12:04:17.51076802:00,Groupe de profils:Optional.empty,Prénom:-,Code du site:,Code interne:"
             )
-        );
-    }
-
-    private static Stream<Arguments> parseUserIdParameters() {
-        return Stream.of(
-            Arguments.of("CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity:101:-:1", "101"),
-            Arguments.of("CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity", null),
-            Arguments.of("CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity:101", "101"),
-            Arguments.of("CUSTOMERS_APP", null),
-            Arguments.of(null, null)
         );
     }
 }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AccessContractController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AccessContractController.java
@@ -47,7 +47,7 @@ import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.accesscontract.AccessContractService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -76,6 +76,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -170,8 +171,7 @@ public class AccessContractController {
 
     @Secured(ServicesData.ROLE_GET_ACCESS_CONTRACTS)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for accessContract with id :{}", id);
         return accessContractService.findHistoryById(id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AgencyController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/AgencyController.java
@@ -49,7 +49,7 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.utils.ApiUtils;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.AgencyDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.agency.AgencyService;
@@ -79,6 +79,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -181,7 +182,7 @@ public class AgencyController {
 
     @Secured(ServicesData.ROLE_GET_AGENCIES)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter(MANDATORY_IDENTIFIER, id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ContextController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ContextController.java
@@ -45,7 +45,7 @@ import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.utils.ApiUtils;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.ContextDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.context.ContextService;
@@ -72,6 +72,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -159,8 +160,7 @@ public class ContextController {
 
     @Secured(ServicesData.ROLE_GET_CONTEXTS)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for context with id :{}", id);
         ParameterChecker.checkParameter("Identifier is mandatory : ", id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/FileFormatController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/FileFormatController.java
@@ -49,7 +49,7 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.utils.ApiUtils;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.FileFormatDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.fileformat.FileFormatService;
@@ -80,6 +80,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -182,8 +183,7 @@ public class FileFormatController {
         return fileFormatService.patch(partialDto);
     }
 
-    private LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    private List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for accessContract with id :{}", id);
         ParameterChecker.checkParameter("Identifier is mandatory : ", id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/IngestContractController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/IngestContractController.java
@@ -44,7 +44,7 @@ import fr.gouv.vitamui.commons.api.domain.DirectionDto;
 import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.IngestContractDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.ingestcontract.IngestContractService;
@@ -75,6 +75,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -173,8 +174,7 @@ public class IngestContractController {
 
     @Secured(ServicesData.ROLE_GET_INGEST_CONTRACTS)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
-        throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id) throws VitamClientException {
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for ingestContract with id :{}", id);
         ParameterChecker.checkParameter("Identifier is mandatory : ", id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ManagementContractController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/ManagementContractController.java
@@ -39,7 +39,7 @@ import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.managementcontract.service.ManagementContractService;
 import jakarta.validation.Valid;
@@ -65,6 +65,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -169,7 +170,7 @@ public class ManagementContractController {
 
     @GetMapping(CommonConstants.PATH_ID + "/history")
     @Secured(ServicesData.ROLE_GET_MANAGEMENT_CONTRACT)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter(MANDATORY_IDENTIFIER, id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OntologyController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OntologyController.java
@@ -49,7 +49,7 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.dtos.VitamUiOntologyDto;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.OntologyDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.ontology.OntologyService;
@@ -181,11 +181,8 @@ public class OntologyController {
 
     @Secured(ServicesData.ROLE_GET_ONTOLOGIES)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, PreconditionFailedException, VitamClientException {
-        SanityChecker.checkSecureParameter(id);
-        LOGGER.debug("get logbook for ontology with id :{}", id);
-        ParameterChecker.checkParameter("Identifier is mandatory : ", id);
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("get logbook for ontology with id :{}", id);
         return ontologyService.findHistoryById(id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OperationController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/OperationController.java
@@ -51,7 +51,7 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.utils.EnumUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.LogbookOperationDto;
 import fr.gouv.vitamui.referential.common.dto.ReportType;
 import fr.gouv.vitamui.referential.common.model.AuditCreateOptions;
@@ -86,6 +86,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -94,7 +95,7 @@ import java.util.Optional;
 @Setter
 public class OperationController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AgencyController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationController.class);
 
     @Autowired
     private OperationService operationService;
@@ -129,7 +130,7 @@ public class OperationController {
 
     @Secured(ServicesData.ROLE_GET_OPERATIONS)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException {
         LOGGER.debug("get logbook for audit with id :{}", id);
         ParameterChecker.checkParameter("The Identifier is a mandatory parameter: ", id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/RuleController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/RuleController.java
@@ -50,7 +50,7 @@ import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.dto.RuleDto;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.rule.RuleService;
 import jakarta.validation.Valid;
@@ -79,6 +79,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -181,7 +182,7 @@ public class RuleController {
 
     @Secured(ServicesData.ROLE_GET_RULES)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter(IDENTIFIER_MANDATORY_MESSAGE, id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/SecurityProfileController.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/rest/SecurityProfileController.java
@@ -46,7 +46,7 @@ import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.referential.common.dto.SecurityProfileDto;
 import fr.gouv.vitamui.referential.common.rest.RestApi;
 import fr.gouv.vitamui.referential.server.service.securityprofile.SecurityProfileService;
@@ -74,6 +74,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -168,7 +169,7 @@ public class SecurityProfileController {
 
     @Secured(ServicesData.ROLE_GET_SECURITY_PROFILES)
     @GetMapping(CommonConstants.PATH_LOGBOOK)
-    public LogbookOperationsCommonResponseDto findHistoryById(final @PathVariable("id") String id)
+    public List<HistoryEventDto> findHistoryById(final @PathVariable("id") String id)
         throws InvalidParseOperationException, PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter("Identifier is mandatory : ", id);
         SanityChecker.checkSecureParameter(id);

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/accesscontract/AccessContractService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/accesscontract/AccessContractService.java
@@ -68,12 +68,10 @@ import fr.gouv.vitamui.commons.api.enums.ErrorImportFileMessage;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.administration.AccessContractCommonService;
 import fr.gouv.vitamui.commons.vitam.api.dto.AccessContractResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.openapiclient.ApplicationsApi;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
@@ -333,18 +331,14 @@ public class AccessContractService extends AbstractService {
         }
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         final VitamContext vitamContext = this.buildVitamContext();
 
-        final JsonNode body = this.findHistoryByIdentifier(vitamContext, id);
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String id)
+        throws VitamClientException {
         LOGGER.debug(
             "Find History Access Contract By ID {}, EvIdAppSession : {}",
             id,
@@ -352,7 +346,10 @@ public class AccessContractService extends AbstractService {
         );
 
         try {
-            return logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext).toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext),
+                List.of("STP_UPDATE_ACCESS_CONTRACT", "STP_IMPORT_ACCESS_CONTRACT", "STP_BACKUP_ACCESS_CONTRACT")
+            );
         } catch (InvalidCreateOperationException e) {
             throw new InternalServerException("Unable to fetch history", e);
         }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/agency/AgencyService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/agency/AgencyService.java
@@ -55,11 +55,9 @@ import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.VitamUIException;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.administration.AgencyCommonService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.referential.common.dto.AgencyDto;
@@ -318,23 +316,22 @@ public class AgencyService extends AbstractService {
         return null;
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String id)
+        throws VitamClientException {
         try {
-            return logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext).toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext),
+                List.of("EXT_VITAMUI_UPDATE_ACCESS_CONTRACT", "EXT_VITAMUI_CREATE_ACCESS_CONTRACT")
+            );
         } catch (InvalidCreateOperationException e) {
             throw new InternalServerException("Unable to fetch history", e);
         }
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         final VitamContext vitamContext = this.buildVitamContext();
 
-        final JsonNode body = this.findHistoryByIdentifier(vitamContext, id);
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 
     public JsonNode importAgencies(String fileName, MultipartFile file) {

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/context/ContextService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/context/ContextService.java
@@ -59,10 +59,8 @@ import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.VitamUIException;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.referential.common.dto.ContextDto;
@@ -297,17 +295,16 @@ public class ContextService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String identifier)
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String identifier)
         throws VitamClientException {
         LOGGER.debug("findHistoryById for identifier" + identifier);
         LOGGER.debug("Find Context History EvIdAppSession : {} ", vitamContext.getApplicationSessionId());
-        return logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                identifier,
-                AdminCollections.ACCESS_CONTRACTS.getName(),
-                vitamContext
-            )
-            .toJsonNode();
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            identifier,
+            AdminCollections.ACCESS_CONTRACTS.getName(),
+            vitamContext,
+            List.of("EXT_VITAMUI_UPDATE_ACCESS_CONTRACT", "EXT_VITAMUI_CREATE_ACCESS_CONTRACT")
+        );
     }
 
     public ContextDto getOne(String identifier) {
@@ -346,14 +343,9 @@ public class ContextService extends AbstractService {
         return this.patch(vitamContext, partialDto);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(String identifier) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(String identifier) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
 
-        JsonNode body = this.findHistoryByIdentifier(vitamContext, identifier);
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, identifier);
     }
 }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/fileformat/FileFormatService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/fileformat/FileFormatService.java
@@ -54,10 +54,8 @@ import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.VitamUIException;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.referential.common.dto.FileFormatDto;
@@ -298,13 +296,16 @@ public class FileFormatService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String identifier)
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String identifier)
         throws VitamClientException {
         LOGGER.debug("findHistoryById for identifier" + identifier);
         LOGGER.debug("File Format History EvIdAppSession : {} ", vitamContext.getApplicationSessionId());
-        return logbookService
-            .findEventsByIdentifierAndCollectionNames(identifier, AdminCollections.AGENCIES.getName(), vitamContext)
-            .toJsonNode();
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            identifier,
+            AdminCollections.AGENCIES.getName(),
+            vitamContext,
+            List.of("EXT_VITAMUI_UPDATE_FILE_FORMAT", "EXT_VITAMUI_CREATE_FILE_FORMAT")
+        );
     }
 
     public JsonNode importFileFormats(VitamContext context, String fileName, MultipartFile file) {
@@ -348,15 +349,10 @@ public class FileFormatService extends AbstractService {
         this.delete(vitamContext, id);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(String identifier) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(String identifier) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
 
-        JsonNode body = this.findHistoryByIdentifier(vitamContext, identifier);
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return findHistoryByIdentifier(vitamContext, identifier);
     }
 
     public PaginatedValuesDto<FileFormatDto> getAllPaginated(

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/ingestcontract/IngestContractService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/ingestcontract/IngestContractService.java
@@ -63,10 +63,8 @@ import fr.gouv.vitamui.commons.api.enums.ErrorImportFileMessage;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.openapiclient.ApplicationsApi;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
@@ -405,10 +403,14 @@ public class IngestContractService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String id)
+        throws VitamClientException {
         try {
             LOGGER.info("Ingest Contract History EvIdAppSession : {} ", vitamContext.getApplicationSessionId());
-            return logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext).toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext),
+                List.of("EXT_VITAMUI_UPDATE_INGEST_CONTRACT", "EXT_VITAMUI_CREATE_INGEST_CONTRACT")
+            );
         } catch (InvalidCreateOperationException e) {
             throw new InternalServerException("Unable to fetch history", e);
         }
@@ -578,15 +580,10 @@ public class IngestContractService extends AbstractService {
         return this.create(vitamContext, ingestContractDto);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(String id) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
 
-        final JsonNode body = this.findHistoryByIdentifier(vitamContext, id);
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 
     public ResponseEntity<Void> importIngestContracts(MultipartFile file) {

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/managementcontract/service/ManagementContractService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/managementcontract/service/ManagementContractService.java
@@ -48,11 +48,9 @@ import fr.gouv.vitamui.commons.api.domain.ManagementContractDto;
 import fr.gouv.vitamui.commons.api.domain.PaginatedValuesDto;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.administration.ManagementContractCommonService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
-import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.referential.common.dto.ManagementContractResponseDto;
@@ -266,10 +264,14 @@ public class ManagementContractService extends AbstractService {
         return getOne(vitamContext, identifier);
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String id)
+        throws VitamClientException {
         try {
             LOGGER.debug(MANAGEMENT_CONTRACT_EVENT_ID_APP_SESSION, vitamContext.getApplicationSessionId());
-            return logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext).toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext),
+                List.of("STP_UPDATE_MANAGEMENT_CONTRACT", "STP_IMPORT_MANAGEMENT_CONTRACT")
+            );
         } catch (InvalidCreateOperationException e) {
             LOGGER.error("Unable to fetch history");
             throw new InternalServerException("Unable to fetch history", e);
@@ -346,15 +348,9 @@ public class ManagementContractService extends AbstractService {
         return this.check(vitamContext, managementContractDto);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(String id) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
 
-        final JsonNode body = this.findHistoryByIdentifier(vitamContext, id);
-
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/ontology/OntologyService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/ontology/OntologyService.java
@@ -58,9 +58,8 @@ import fr.gouv.vitamui.commons.api.dtos.VitamUiOntologyDto;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.utils.OntologyServiceReader;
-import fr.gouv.vitamui.commons.utils.JsonUtils;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
@@ -296,9 +295,13 @@ public class OntologyService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String id)
+        throws VitamClientException {
         try {
-            return logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext).toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(id), vitamContext),
+                List.of("STP_UPDATE_ONTOLOGY", "STP_IMPORT_ONTOLOGY")
+            );
         } catch (InvalidCreateOperationException e) {
             throw new InternalServerException("Unable to fetch history", e);
         }
@@ -372,15 +375,9 @@ public class OntologyService extends AbstractService {
         return this.importOntologies(vitamContext, fileName, file);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(String id) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
 
-        final JsonNode body = this.findHistoryByIdentifier(vitamContext, id);
-
-        try {
-            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false);
-        } catch (final JsonProcessingException e) {
-            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/operation/OperationService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/operation/OperationService.java
@@ -64,7 +64,7 @@ import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.referential.common.dto.LogbookOperationDto;
@@ -362,11 +362,13 @@ public class OperationService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, String id) {
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, String id) {
         try {
             LOGGER.info("Operation History EvIdAppSession : {} ", vitamContext.getApplicationSessionId());
-            RequestResponse<LogbookOperation> requestResponse = logbookService.selectOperationbyId(id, vitamContext);
-            return requestResponse.toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperationbyId(id, vitamContext),
+                List.of("EXT_VITAMUI_UPDATE_AUDIT", "EXT_VITAMUI_CREATE_AUDIT")
+            );
         } catch (VitamClientException e) {
             throw new InternalServerException("Unable to fetch history", e);
         }
@@ -417,14 +419,9 @@ public class OperationService extends AbstractService {
         return true; // Suppose que l'opération est toujours réussie
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(String id) {
+    public List<HistoryEventDto> findHistoryById(String id) {
         VitamContext vitamContext = buildVitamContext();
-        JsonNode history = this.findHistoryByIdentifier(vitamContext, id);
-        try {
-            return objectMapper.treeToValue(history, LogbookOperationsCommonResponseDto.class);
-        } catch (JsonProcessingException e) {
-            throw new InternalServerException("Error parsing history data", e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 
     public ResponseEntity<Resource> export(String id, ReportType type) {

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/rule/RuleService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/rule/RuleService.java
@@ -56,7 +56,7 @@ import fr.gouv.vitamui.commons.api.exception.VitamUIException;
 import fr.gouv.vitamui.commons.rest.dto.RuleDto;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.config.converter.RuleConverter;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.RuleNodeResponseDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
@@ -281,12 +281,13 @@ public class RuleService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamContext, final String identifier)
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamContext, final String identifier)
         throws VitamClientException {
         try {
-            return logbookService
-                .selectOperations(VitamQueryHelper.buildOperationQuery(identifier), vitamContext)
-                .toJsonNode();
+            return logbookService.toHistoryEvents(
+                logbookService.selectOperations(VitamQueryHelper.buildOperationQuery(identifier), vitamContext),
+                List.of("EXT_VITAMUI_UPDATE_FILE_FORMAT", "EXT_VITAMUI_CREATE_FILE_FORMAT")
+            );
         } catch (InvalidCreateOperationException exception) {
             LOGGER.error("Unable to fetch history", exception);
             throw new InternalServerException("Unable to fetch history", exception);
@@ -361,13 +362,8 @@ public class RuleService extends AbstractService {
         return null;
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
-        JsonNode history = this.findHistoryByIdentifier(vitamContext, id);
-        try {
-            return objectMapper.treeToValue(history, LogbookOperationsCommonResponseDto.class);
-        } catch (JsonProcessingException e) {
-            throw new InternalServerException("Error parsing history data", e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 }

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/securityprofile/SecurityProfileService.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/service/securityprofile/SecurityProfileService.java
@@ -59,7 +59,7 @@ import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.VitamUIException;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
-import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.referential.common.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.referential.common.dto.SecurityProfileDto;
@@ -289,17 +289,16 @@ public class SecurityProfileService extends AbstractService {
         }
     }
 
-    public JsonNode findHistoryByIdentifier(VitamContext vitamSecurityProfile, final String identifier)
+    public List<HistoryEventDto> findHistoryByIdentifier(VitamContext vitamSecurityProfile, final String identifier)
         throws VitamClientException {
         LOGGER.debug("findHistoryById for identifier" + identifier);
         LOGGER.info(" Security Profile History EvIdAppSession : {} ", vitamSecurityProfile.getApplicationSessionId());
-        return logbookService
-            .findEventsByIdentifierAndCollectionNames(
-                identifier,
-                AdminCollections.ACCESS_CONTRACTS.getName(),
-                vitamSecurityProfile
-            )
-            .toJsonNode();
+        return logbookService.findEventsByIdentifierAndCollectionNames(
+            identifier,
+            AdminCollections.ACCESS_CONTRACTS.getName(),
+            vitamSecurityProfile,
+            List.of("EXT_VITAMUI_UPDATE_ACCESS_CONTRACT", "EXT_VITAMUI_CREATE_ACCESS_CONTRACT")
+        );
     }
 
     public SecurityProfileDto getOne(final String id) {
@@ -350,13 +349,8 @@ public class SecurityProfileService extends AbstractService {
         return delete(vitamContext, id);
     }
 
-    public LogbookOperationsCommonResponseDto findHistoryById(final String id) throws VitamClientException {
+    public List<HistoryEventDto> findHistoryById(final String id) throws VitamClientException {
         VitamContext vitamContext = buildVitamContext();
-        JsonNode history = this.findHistoryByIdentifier(vitamContext, id);
-        try {
-            return objectMapper.treeToValue(history, LogbookOperationsCommonResponseDto.class);
-        } catch (JsonProcessingException e) {
-            throw new InternalServerException("Error parsing history data", e);
-        }
+        return this.findHistoryByIdentifier(vitamContext, id);
     }
 }

--- a/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/ContextServiceTest.java
+++ b/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/ContextServiceTest.java
@@ -47,7 +47,6 @@ import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.RequestResponseOK;
 import fr.gouv.vitam.common.model.administration.ContextModel;
-import fr.gouv.vitam.common.model.logbook.LogbookOperation;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.UnavailableServiceException;
@@ -69,6 +68,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -367,38 +367,6 @@ public class ContextServiceTest {
     }
 
     @Test
-    public void findHistoryByIdentifier_should_return_ok_when_vitamclient_ok() throws VitamClientException {
-        VitamContext vitamContext = new VitamContext(0);
-        String id = "id_0";
-
-        when(
-            logbookService.findEventsByIdentifierAndCollectionNames(
-                any(String.class),
-                any(String.class),
-                any(VitamContext.class)
-            )
-        ).thenReturn(new RequestResponseOK<LogbookOperation>().setHttpCode(200));
-
-        assertThatCode(() -> contextService.findHistoryByIdentifier(vitamContext, id)).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void findHistoryByIdentifier_should_return_ok_when_vitamclient_400() throws VitamClientException {
-        VitamContext vitamContext = new VitamContext(0);
-        String id = "id_0";
-
-        when(
-            logbookService.findEventsByIdentifierAndCollectionNames(
-                any(String.class),
-                any(String.class),
-                any(VitamContext.class)
-            )
-        ).thenReturn(new RequestResponseOK<LogbookOperation>().setHttpCode(400));
-
-        assertThatCode(() -> contextService.findHistoryByIdentifier(vitamContext, id)).doesNotThrowAnyException();
-    }
-
-    @Test
     public void findHistoryByIdentifier_should_throw_VitamClientException_when_vitamclient_throws_VitamClientException()
         throws VitamClientException {
         VitamContext vitamContext = new VitamContext(0);
@@ -408,7 +376,8 @@ public class ContextServiceTest {
             logbookService.findEventsByIdentifierAndCollectionNames(
                 any(String.class),
                 any(String.class),
-                any(VitamContext.class)
+                any(VitamContext.class),
+                anyList()
             )
         ).thenThrow(new VitamClientException("Exception"));
 

--- a/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/FileFormatServiceTest.java
+++ b/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/FileFormatServiceTest.java
@@ -47,7 +47,6 @@ import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
 import fr.gouv.vitam.common.model.administration.FileFormatModel;
-import fr.gouv.vitam.common.model.logbook.LogbookOperation;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
@@ -76,6 +75,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -654,42 +654,6 @@ public class FileFormatServiceTest {
     }
 
     @Test
-    public void findHistoryByIdentifier_should_return_ok_when_vitamclient_ok() throws VitamClientException {
-        VitamContext vitamContext = new VitamContext(0);
-        String id = "identifier";
-
-        when(
-            logbookService.findEventsByIdentifierAndCollectionNames(
-                any(String.class),
-                any(String.class),
-                any(VitamContext.class)
-            )
-        ).thenReturn(new RequestResponseOK<LogbookOperation>().setHttpCode(200));
-
-        assertThatCode(() -> {
-            fileFormatService.findHistoryByIdentifier(vitamContext, id);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void findHistoryByIdentifier_should_return_ok_when_vitamclient_400() throws VitamClientException {
-        VitamContext vitamContext = new VitamContext(0);
-        String id = "identifier";
-
-        when(
-            logbookService.findEventsByIdentifierAndCollectionNames(
-                any(String.class),
-                any(String.class),
-                any(VitamContext.class)
-            )
-        ).thenReturn(new RequestResponseOK<LogbookOperation>().setHttpCode(400));
-
-        assertThatCode(() -> {
-            fileFormatService.findHistoryByIdentifier(vitamContext, id);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
     public void findHistoryByIdentifier_should_throw_VitamClientException_when_vitamclient_throws_VitamClientException()
         throws VitamClientException {
         VitamContext vitamContext = new VitamContext(0);
@@ -699,7 +663,8 @@ public class FileFormatServiceTest {
             logbookService.findEventsByIdentifierAndCollectionNames(
                 any(String.class),
                 any(String.class),
-                any(VitamContext.class)
+                any(VitamContext.class),
+                anyList()
             )
         ).thenThrow(new VitamClientException("Exception thrown by vitam"));
 

--- a/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/SecurityProfileServiceTest.java
+++ b/api/api-referential/referential/src/test/java/fr/gouv/vitamui/referential/server/service/SecurityProfileServiceTest.java
@@ -47,7 +47,6 @@ import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.RequestResponseOK;
 import fr.gouv.vitam.common.model.administration.SecurityProfileModel;
-import fr.gouv.vitam.common.model.logbook.LogbookOperation;
 import fr.gouv.vitamui.commons.api.exception.ConflictException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
@@ -70,6 +69,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -518,42 +518,6 @@ public class SecurityProfileServiceTest {
     }
 
     @Test
-    public void findHistoryByIdentifier_should_return_ok_when_vitamclient_ok() throws VitamClientException {
-        VitamContext vitamContext = new VitamContext(0);
-        String id = "identifier";
-
-        when(
-            logbookService.findEventsByIdentifierAndCollectionNames(
-                any(String.class),
-                any(String.class),
-                any(VitamContext.class)
-            )
-        ).thenReturn(new RequestResponseOK<LogbookOperation>().setHttpCode(200));
-
-        assertThatCode(() -> {
-            securityProfileService.findHistoryByIdentifier(vitamContext, id);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void findHistoryByIdentifier_should_return_ok_when_vitamclient_400() throws VitamClientException {
-        VitamContext vitamContext = new VitamContext(0);
-        String id = "identifier";
-
-        when(
-            logbookService.findEventsByIdentifierAndCollectionNames(
-                any(String.class),
-                any(String.class),
-                any(VitamContext.class)
-            )
-        ).thenReturn(new RequestResponseOK<LogbookOperation>().setHttpCode(400));
-
-        assertThatCode(() -> {
-            securityProfileService.findHistoryByIdentifier(vitamContext, id);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
     public void findHistoryByIdentifier_should_throw_VitamClientException_when_vitamclient_throws_VitamClientException()
         throws VitamClientException {
         VitamContext vitamContext = new VitamContext(0);
@@ -563,7 +527,8 @@ public class SecurityProfileServiceTest {
             logbookService.findEventsByIdentifierAndCollectionNames(
                 any(String.class),
                 any(String.class),
-                any(VitamContext.class)
+                any(VitamContext.class),
+                anyList()
             )
         ).thenThrow(new VitamClientException("Exception thrown by vitam"));
 

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/access/LogbookService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/access/LogbookService.java
@@ -36,6 +36,7 @@
  */
 package fr.gouv.vitamui.commons.vitam.api.access;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.gouv.vitam.access.external.client.AccessExternalClient;
@@ -56,19 +57,26 @@ import fr.gouv.vitam.common.model.logbook.LogbookLifecycle;
 import fr.gouv.vitam.common.model.logbook.LogbookOperation;
 import fr.gouv.vitam.ingest.external.client.IngestExternalClient;
 import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
+import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.rest.enums.ContentDispositionType;
+import fr.gouv.vitamui.commons.utils.JsonUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.HistoryEventDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
+import fr.gouv.vitamui.commons.vitam.api.util.EvIdAppSessionParser;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
+import jakarta.annotation.Nullable;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.hc.core5.http.HttpStatus;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils.responseMapping;
 
@@ -82,6 +90,8 @@ public class LogbookService {
     private static final String BATCH_REPORT = "batchreport";
     private static final String RULE_REPORT = "report";
     private static final String OBJECT_REPORT = "object";
+
+    private static final String CAS_CONTEXT = "Contexte CAS";
 
     private static final Set<String> INGEST_ALLOWED_TYPES_PROC = Set.of("MASTERDATA", "INGEST", "INGEST_TEST");
     private final AccessExternalClient accessExternalClient;
@@ -162,6 +172,7 @@ public class LogbookService {
 
     public RequestResponse<LogbookOperation> selectOperations(final JsonNode select, final VitamContext vitamContext)
         throws VitamClientException {
+        LOGGER.debug("selectOperations : select query {}, vitamContext {}", select, vitamContext);
         final RequestResponse<LogbookOperation> response = accessExternalClient.selectOperations(vitamContext, select);
         VitamRestUtils.checkResponse(response, HttpStatus.SC_OK, HttpStatus.SC_ACCEPTED);
         return response;
@@ -170,27 +181,64 @@ public class LogbookService {
     /**
      *
      * @param identifier
-     * @param collectionNames
+     * @param collectionName
      * @param vitamContext
      * @return
      * @throws VitamClientException
      */
-    public RequestResponse<LogbookOperation> findEventsByIdentifierAndCollectionNames(
+    public List<HistoryEventDto> findEventsByIdentifierAndCollectionNames(
         final String identifier,
-        final String collectionNames,
-        final VitamContext vitamContext
+        final String collectionName,
+        final VitamContext vitamContext,
+        @Nullable final List<String> eventTypesFilter
     ) throws VitamClientException {
         LOGGER.debug(
             "findEventsByIdentifierAndCollectionNames for : identifier {}, collection {}, vitamContext {}",
             identifier,
-            collectionNames,
+            collectionName,
             vitamContext
         );
-        final ObjectNode select = buildOperationQuery(buildQuery(identifier, collectionNames));
-        LOGGER.debug("selectOperations : select query {}, vitamContext {}", select, vitamContext);
-        final RequestResponse<LogbookOperation> response = accessExternalClient.selectOperations(vitamContext, select);
-        VitamRestUtils.checkResponse(response, HttpStatus.SC_OK, HttpStatus.SC_ACCEPTED);
-        return response;
+        final ObjectNode select = buildOperationQuery(buildQuery(identifier, collectionName));
+
+        final RequestResponse<LogbookOperation> response = selectOperations(select, vitamContext);
+
+        return toHistoryEvents(response, eventTypesFilter)
+            .stream()
+            // Only keep events matching collection name
+            .filter(e -> collectionName.equalsIgnoreCase(e.getObIdReq()))
+            .collect(Collectors.toList());
+    }
+
+    public @NonNull List<HistoryEventDto> toHistoryEvents(
+        RequestResponse<LogbookOperation> response,
+        @Nullable final List<String> eventTypesFilter
+    ) {
+        final JsonNode body = response.toJsonNode();
+        try {
+            return JsonUtils.treeToValue(body, LogbookOperationsCommonResponseDto.class, false)
+                .getResults()
+                .stream()
+                // Using flatMap to mix events from potentially several results in a unique list
+                .flatMap(logbookOperationDto -> {
+                    final String evIdAppSession = logbookOperationDto.getEvIdAppSession();
+                    final boolean isCAS = CAS_CONTEXT.equals(EvIdAppSessionParser.parseApiContextId(evIdAppSession));
+
+                    final String user = EvIdAppSessionParser.parseUserId(isCAS ? null : evIdAppSession);
+                    final String subrogator = EvIdAppSessionParser.parseSubrogatorId(isCAS ? null : evIdAppSession);
+
+                    return logbookOperationDto.getEvents().stream().map(e -> new HistoryEventDto(e, user, subrogator));
+                })
+                // Only keep events of the corresponding types (if set)
+                // FIXME: why are we filtering on outDetail and not type (N.B.: this is a port of some code that was previously in Angular)?
+                .filter(
+                    e ->
+                        CollectionUtils.isEmpty(eventTypesFilter) ||
+                        eventTypesFilter.stream().anyMatch(et -> e.getOutDetail().contains(et))
+                )
+                .collect(Collectors.toList());
+        } catch (final JsonProcessingException e) {
+            throw new InternalServerException(VitamRestUtils.PARSING_ERROR_MSG, e);
+        }
     }
 
     public RequestResponse<LogbookOperation> findEvents(
@@ -230,7 +278,7 @@ public class LogbookService {
             select.addOrderByDescFilter("events.evDateTime");
             return select.getFinalSelect();
         } catch (final InvalidCreateOperationException | InvalidParseOperationException e) {
-            throw new ApplicationServerException("An error occured while creating vitam query", e);
+            throw new ApplicationServerException("An error occurred while creating vitam query", e);
         }
     }
 
@@ -242,7 +290,7 @@ public class LogbookService {
             andQuery.add(obIdQuery, obIdReqQuery);
             return andQuery;
         } catch (InvalidCreateOperationException exception) {
-            throw new ApplicationServerException("An error occured while creating vitam query", exception);
+            throw new ApplicationServerException("An error occurred while creating vitam query", exception);
         }
     }
 
@@ -257,7 +305,7 @@ public class LogbookService {
             andQuery.add(obIdQuery, obIdReqQuery);
             return andQuery;
         } catch (InvalidCreateOperationException e) {
-            throw new ApplicationServerException("An error occured while creating vitam query", e);
+            throw new ApplicationServerException("An error occurred while creating vitam query", e);
         }
     }
 
@@ -304,12 +352,12 @@ public class LogbookService {
                 selectOperationbyId(id, vitamContext).toJsonNode(),
                 LogbookOperationsCommonResponseDto.class
             );
-            if (operation == null || operation.getResults() == null || operation.getResults().size() == 0) {
+            if (operation == null || operation.getResults() == null || operation.getResults().isEmpty()) {
                 throw new IllegalArgumentException(
                     "Unable to download object of operation " + id + ": the operation does not exist"
                 );
             }
-            if (!INGEST_ALLOWED_TYPES_PROC.contains(operation.getResults().get(0).getEvTypeProc())) {
+            if (!INGEST_ALLOWED_TYPES_PROC.contains(operation.getResults().getFirst().getEvTypeProc())) {
                 throw new IllegalArgumentException(
                     "Unable to download object of operation " +
                     id +
@@ -326,7 +374,7 @@ public class LogbookService {
             contentDispositionBuilder.filename(String.format(collection + "_%s.xml", id));
             response
                 .getHeaders()
-                .put(HttpHeaders.CONTENT_DISPOSITION, Arrays.asList(contentDispositionBuilder.build().toString()));
+                .put(HttpHeaders.CONTENT_DISPOSITION, List.of(contentDispositionBuilder.build().toString()));
 
             return response;
         } catch (final VitamClientException exception) {

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/dto/HistoryEventDto.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/dto/HistoryEventDto.java
@@ -1,5 +1,5 @@
-/*
- * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+/**
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2020)
  * and the signatories of the "VITAM - Accord du Contributeur" agreement.
  *
  * contact@programmevitam.fr
@@ -34,15 +34,56 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+package fr.gouv.vitamui.commons.vitam.api.dto;
 
-import { EventTypeLabelComponent } from './event-type-label.component';
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@NgModule({
-  declarations: [EventTypeLabelComponent],
-  exports: [EventTypeLabelComponent],
-  imports: [CommonModule, TranslateModule],
-})
-export class EventTypeLabelModule {}
+import java.io.Serializable;
+
+@Getter
+@Setter
+@ToString
+public class HistoryEventDto implements Serializable {
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("dateTime")
+    private String dateTime;
+
+    @JsonProperty("outcome")
+    private String outcome;
+
+    @JsonProperty("outDetail")
+    private String outDetail;
+
+    @JsonProperty("data")
+    private String data;
+
+    @JsonProperty("obId")
+    private String obId;
+
+    @JsonProperty("obIdReq")
+    private String obIdReq;
+
+    @JsonProperty("user")
+    private String userIdentifier;
+
+    @JsonProperty("subrogator")
+    private String subrogatorIdentifier;
+
+    public HistoryEventDto(final LogbookEventDto logbookEventDto, String user, String subrogator) {
+        this.type = logbookEventDto.getEvType();
+        this.dateTime = logbookEventDto.getEvDateTime();
+        this.outcome = logbookEventDto.getOutcome();
+        this.outDetail = logbookEventDto.getOutDetail();
+        this.data = logbookEventDto.getEvDetData();
+        this.obId = logbookEventDto.getObId();
+        this.obIdReq = logbookEventDto.getObIdReq();
+        this.userIdentifier = user;
+        this.subrogatorIdentifier = subrogator;
+    }
+}

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/util/EvIdAppSessionParser.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/util/EvIdAppSessionParser.java
@@ -1,0 +1,35 @@
+package fr.gouv.vitamui.commons.vitam.api.util;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class EvIdAppSessionParser {
+
+    private static final String UNKNOWN_VALUE = "-";
+    private static final Integer API_CONTEXT_INDEX = 2;
+    private static final Integer USER_INDEX = 3;
+    private static final Integer SUBROGATOR_INDEX = 4;
+
+    public static String parseApiContextId(String evIdAppSession) {
+        return parseEvIdAppSession(evIdAppSession, API_CONTEXT_INDEX);
+    }
+
+    public static String parseUserId(String evIdAppSession) {
+        return parseEvIdAppSession(evIdAppSession, USER_INDEX);
+    }
+
+    public static String parseSubrogatorId(String evIdAppSession) {
+        return parseEvIdAppSession(evIdAppSession, SUBROGATOR_INDEX);
+    }
+
+    private static String parseEvIdAppSession(String evIdAppSession, int index) {
+        return Optional.ofNullable(evIdAppSession)
+            .map(v -> v.split(":"))
+            .map(sessionData -> ArrayUtils.get(sessionData, index))
+            .filter(v -> !UNKNOWN_VALUE.equals(v))
+            .orElse(null);
+    }
+}

--- a/commons/commons-vitam/src/test/java/fr/gouv/vitamui/commons/vitam/api/access/LogbookServiceTest.java
+++ b/commons/commons-vitam/src/test/java/fr/gouv/vitamui/commons/vitam/api/access/LogbookServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.spy;
 
@@ -166,5 +167,19 @@ public class LogbookServiceTest {
 
         final Response response = logbookService.downloadAtr("vitamId", new VitamContext(10));
         VitamRestUtils.checkResponse(response, Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void toHistoryEvents_should_return_ok_when_vitamclient_ok() {
+        assertThatCode(
+            () -> logbookService.toHistoryEvents(new RequestResponseOK<LogbookOperation>().setHttpCode(200), null)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void toHistoryEvents_should_return_ok_when_vitamclient_400() {
+        assertThatCode(
+            () -> logbookService.toHistoryEvents(new RequestResponseOK<LogbookOperation>().setHttpCode(400), null)
+        ).doesNotThrowAnyException();
     }
 }

--- a/commons/commons-vitam/src/test/java/fr/gouv/vitamui/commons/vitam/api/util/EvIdAppSessionParserTest.java
+++ b/commons/commons-vitam/src/test/java/fr/gouv/vitamui/commons/vitam/api/util/EvIdAppSessionParserTest.java
@@ -1,0 +1,66 @@
+package fr.gouv.vitamui.commons.vitam.api.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EvIdAppSessionParserTest {
+
+    @ParameterizedTest
+    @MethodSource("parseUserIdParameters")
+    void should_parse_context(String evIdAppSession, String expectedContext) {
+        assertThat(EvIdAppSessionParser.parseApiContextId(evIdAppSession)).isEqualTo(expectedContext);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parseUserIdParameters")
+    void should_parse_user_id(String evIdAppSession, String ignoredExpectedContext, String expectedUserId) {
+        assertThat(EvIdAppSessionParser.parseUserId(evIdAppSession)).isEqualTo(expectedUserId);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parseUserIdParameters")
+    void should_parse_user_id(
+        String evIdAppSession,
+        String ignoredExpectedContext,
+        String ignoredExpectedUserId,
+        String expectedSubrogatorId
+    ) {
+        assertThat(EvIdAppSessionParser.parseSubrogatorId(evIdAppSession)).isEqualTo(expectedSubrogatorId);
+    }
+
+    private static Stream<Arguments> parseUserIdParameters() {
+        return Stream.of(
+            Arguments.of(
+                "CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity:101:-:1",
+                "Contexte UI Identity",
+                "101",
+                null
+            ),
+            Arguments.of(
+                "CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity:102:42:1",
+                "Contexte UI Identity",
+                "102",
+                "42"
+            ),
+            Arguments.of(
+                "CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity",
+                "Contexte UI Identity",
+                null,
+                null
+            ),
+            Arguments.of(
+                "CUSTOMERS_APP:02e97361-9ea0-403b-a208-ec7fc8672d73:Contexte UI Identity:101",
+                "Contexte UI Identity",
+                "101",
+                null
+            ),
+            Arguments.of("CUSTOMERS_APP", null, null, null),
+            Arguments.of(null, null, null, null)
+        );
+    }
+}

--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.html
@@ -28,12 +28,7 @@
     </mat-tab>
 
     <mat-tab [label]="'CUSTOMER.TAB.HISTORY' | translate">
-      <vitamui-common-operation-history-tab
-        [id]="customer?.id"
-        [identifier]="customer?.identifier"
-        collectionName="customers"
-        [filter]="filterEvents"
-      ></vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="customer?.id" [identifier]="customer?.identifier" collectionName="customers" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.ts
@@ -82,11 +82,4 @@ export class CustomerPreviewComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.customerUpdatedSub.unsubscribe();
   }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_CUSTOMER') || event.outDetail.includes('EXT_VITAMUI_CREATE_CUSTOMER'))
-    );
-  }
 }

--- a/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-operation-history-tab/owner-operation-history-tab.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-operation-history-tab/owner-operation-history-tab.component.ts
@@ -35,7 +35,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { AuthService, IEvent, LogbookService } from 'vitamui-library';
+import { AuthService, HistoryEvent, LogbookService } from 'vitamui-library';
 
 const EVENT_LIMIT = 100;
 @Component({
@@ -48,9 +48,8 @@ export class OwnerOperationHistoryTabComponent implements OnChanges {
   @Input() id: string;
   @Input() identifier: string;
   @Input() externalParamId: string;
-  @Input() filter: (event: any) => boolean;
 
-  events: IEvent[] = [];
+  events: HistoryEvent[] = [];
   loading = false;
 
   constructor(
@@ -75,7 +74,7 @@ export class OwnerOperationHistoryTabComponent implements OnChanges {
     this.logbookService.listHistoryForOwner(this.id, this.identifier, this.externalParamId, tenantIdentifier).subscribe(
       (results) => {
         this.loading = false;
-        this.events = results.filter((event) => (this.filter ? this.filter(event) : true)).slice(0, EVENT_LIMIT);
+        this.events = results.slice(0, EVENT_LIMIT);
       },
       () => (this.loading = false),
     );

--- a/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-preview.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-preview.component.html
@@ -17,12 +17,7 @@
     </mat-tab>
 
     <mat-tab [label]="'CUSTOMER.TAB.HISTORY' | translate">
-      <app-owner-operation-history-tab
-        [id]="owner?.id"
-        [identifier]="owner?.identifier"
-        [externalParamId]="tenant?.id"
-        [filter]="filterEvents"
-      ></app-owner-operation-history-tab>
+      <app-owner-operation-history-tab [id]="owner?.id" [identifier]="owner?.identifier" [externalParamId]="tenant?.id" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-preview.component.ts
@@ -36,7 +36,7 @@
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
-import { Owner, StartupService, Tenant } from 'vitamui-library';
+import { Owner, Tenant } from 'vitamui-library';
 
 @Component({
   selector: 'app-owner-preview',
@@ -50,29 +50,7 @@ export class OwnerPreviewComponent {
   @Input() isPopup: boolean;
   @Output() previewClose = new EventEmitter();
 
-  constructor(private startupService: StartupService) {}
-
-  openPopup() {
-    const url = this.tenant ? '/customer/tenant/' + this.tenant.id : '/customer/owner/' + this.owner.id;
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + url,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
-
   emitClose() {
     this.previewClose.emit();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_OWNER') ||
-        event.outDetail.includes('EXT_VITAMUI_CREATE_OWNER') ||
-        event.outDetail.includes('EXT_VITAMUI_CREATE_TENANT') ||
-        event.outDetail.includes('EXT_VITAMUI_UPDATE_TENANT'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/external-param-profile/external-param-profile-detail/external-param-profile-detail.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/external-param-profile/external-param-profile-detail/external-param-profile-detail.component.html
@@ -29,9 +29,7 @@
         [id]="externalParamProfile?.idProfile"
         [identifier]="externalParamProfile?.idProfile"
         collectionName="externalparamprofile"
-        [filter]="filterEvents"
-      >
-      </vitamui-common-operation-history-tab>
+      />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/identity/src/app/external-param-profile/external-param-profile-detail/external-param-profile-detail.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/external-param-profile/external-param-profile-detail/external-param-profile-detail.component.ts
@@ -36,7 +36,7 @@
  */
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { Event, ExternalParamProfile } from 'vitamui-library';
+import { ExternalParamProfile } from 'vitamui-library';
 import { ExternalParamProfileService } from '../external-param-profile.service';
 import { SharedService } from '../shared.service';
 
@@ -79,13 +79,5 @@ export class ExternalParamProfileDetailComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.externalParamProfileUpdateSub.unsubscribe();
-  }
-
-  filterEvents(event: Event): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_CREATE_EXTERNAL_PARAM_PROFILE') ||
-        event.outDetail.includes('EXT_VITAMUI_UPDATE_EXTERNAL_PARAM_PROFILE'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/group/group-preview/group-preview.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/group/group-preview/group-preview.component.html
@@ -17,12 +17,7 @@
     </mat-tab>
 
     <mat-tab [label]="'GROUP.TAB.HISTORY' | translate">
-      <vitamui-common-operation-history-tab
-        [id]="group?.id"
-        [identifier]="group?.identifier"
-        collectionName="groups"
-        [filter]="filterEvents"
-      ></vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="group?.id" [identifier]="group?.identifier" collectionName="groups" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/identity/src/app/group/group-preview/group-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/group/group-preview/group-preview.component.ts
@@ -36,7 +36,7 @@
  */
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { AuthService, Group, isLevelAllowed, StartupService } from 'vitamui-library';
+import { AuthService, Group, isLevelAllowed } from 'vitamui-library';
 
 import { GroupService } from '../group.service';
 
@@ -54,12 +54,10 @@ export class GroupPreviewComponent implements OnInit, OnDestroy, OnChanges {
   @Output() previewClose = new EventEmitter();
 
   private groupUpdateSub: Subscription;
-  public groupUsersCount: number;
 
   constructor(
     private groupService: GroupService,
     private authService: AuthService,
-    private startupService: StartupService,
   ) {}
 
   ngOnInit(): void {
@@ -87,14 +85,6 @@ export class GroupPreviewComponent implements OnInit, OnDestroy, OnChanges {
       }
     }
   }
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/group/' + this.group.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
 
   levelNotAllowed(): boolean {
     if (this.group) {
@@ -108,11 +98,5 @@ export class GroupPreviewComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy(): void {
     this.groupUpdateSub.unsubscribe();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_CREATE_GROUP') || event.outDetail.includes('EXT_VITAMUI_UPDATE_GROUP'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/hierarchy/hierarchy-detail/hierarchy-detail.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/hierarchy/hierarchy-detail/hierarchy-detail.component.html
@@ -17,7 +17,6 @@
         [id]="profile?.id"
         [identifier]="profile?.identifier"
         collectionName="profiles"
-        [filter]="filterEvents"
       ></vitamui-common-operation-history-tab>
     </mat-tab>
   </mat-tab-group>

--- a/ui/ui-frontend/projects/identity/src/app/hierarchy/hierarchy-detail/hierarchy-detail.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/hierarchy/hierarchy-detail/hierarchy-detail.component.ts
@@ -37,7 +37,7 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 
 import { Subscription } from 'rxjs';
-import { AuthService, Event, isLevelAllowed, Profile, StartupService } from 'vitamui-library';
+import { AuthService, isLevelAllowed, Profile } from 'vitamui-library';
 import { HierarchyService } from '../hierarchy.service';
 
 @Component({
@@ -61,7 +61,6 @@ export class HierarchyDetailComponent implements OnInit, OnDestroy {
   constructor(
     private hierarchyService: HierarchyService,
     private authService: AuthService,
-    private startupService: StartupService,
   ) {}
 
   ngOnInit() {
@@ -76,15 +75,6 @@ export class HierarchyDetailComponent implements OnInit, OnDestroy {
     this.profileUpdateSub.unsubscribe();
   }
 
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/profile-hierarchy/' + this.profile.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
-
   emitClose() {
     this.previewClose.emit();
   }
@@ -93,11 +83,5 @@ export class HierarchyDetailComponent implements OnInit, OnDestroy {
     if (this.profile) {
       return !isLevelAllowed(this.authService.user, this.profile.level);
     }
-  }
-
-  filterEvents(event: Event): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_CREATE_PROFILE') || event.outDetail.includes('EXT_VITAMUI_UPDATE_PROFILE'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/profile/profile-detail/profile-detail.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/profile/profile-detail/profile-detail.component.html
@@ -13,12 +13,7 @@
     </mat-tab>
 
     <mat-tab [label]="'USER_PROFILE.TAB.HISTORY' | translate">
-      <vitamui-common-operation-history-tab
-        [id]="profile?.id"
-        [identifier]="profile?.identifier"
-        collectionName="profiles"
-        [filter]="filterEvents"
-      ></vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="profile?.id" [identifier]="profile?.identifier" collectionName="profiles" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/identity/src/app/profile/profile-detail/profile-detail.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/profile/profile-detail/profile-detail.component.ts
@@ -36,7 +36,7 @@
  */
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { AuthService, Event, isLevelAllowed, Profile, StartupService } from 'vitamui-library';
+import { AuthService, isLevelAllowed, Profile } from 'vitamui-library';
 
 import { ProfileService } from '../profile.service';
 
@@ -61,7 +61,6 @@ export class ProfileDetailComponent implements OnInit, OnDestroy {
   constructor(
     private rngProfileService: ProfileService,
     private authService: AuthService,
-    private startupService: StartupService,
   ) {}
 
   ngOnInit(): void {
@@ -72,15 +71,6 @@ export class ProfileDetailComponent implements OnInit, OnDestroy {
         });
       }
     });
-  }
-
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/profile/' + this.profile.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
   }
 
   levelNotAllowed(): boolean {
@@ -95,11 +85,5 @@ export class ProfileDetailComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.profileUpdateSub.unsubscribe();
-  }
-
-  filterEvents(event: Event): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_CREATE_PROFILE') || event.outDetail.includes('EXT_VITAMUI_UPDATE_PROFILE'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-preview.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-preview.component.html
@@ -44,11 +44,7 @@
     </mat-tab>
 
     <mat-tab *ngIf="isVitamEnabled" [label]="'USER.TAB.HISTORY' | translate">
-      <vitamui-common-multi-operation-history-tab
-        [collectionsMap]="collectionsMap"
-        [identifiers]="identifiers"
-        [filter]="filterAuthenticationEvents"
-      ></vitamui-common-multi-operation-history-tab>
+      <vitamui-common-multi-operation-history-tab [collectionsMap]="collectionsMap" [identifiers]="identifiers" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-preview.component.ts
@@ -171,20 +171,6 @@ export class UserPreviewComponent implements OnDestroy, OnInit {
     this.previewClose.emit();
   }
 
-  filterAuthenticationEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_CREATE_USER') ||
-        event.outDetail.includes('EXT_VITAMUI_UPDATE_USER') ||
-        event.outDetail.includes('EXT_VITAMUI_BLOCK_USER') ||
-        event.outDetail.includes('EXT_VITAMUI_PASSWORD_REVOCATION') ||
-        event.outDetail.includes('EXT_VITAMUI_PASSWORD_INIT') ||
-        event.outDetail.includes('EXT_VITAMUI_PASSWORD_CHANGE') ||
-        event.outDetail.includes('EXT_VITAMUI_CREATE_USER_INFO') ||
-        event.outDetail.includes('EXT_VITAMUI_UPDATE_USER_INFO'))
-    );
-  }
-
   deleteUser(user: User, status: string) {
     const emailadress = user.email.split('@');
     const email = 'anonyme-' + user.identifier + '@' + emailadress[1];

--- a/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-preview.component.ts
+++ b/ui/ui-frontend/projects/ingest/src/app/ingest/ingest-preview/ingest-preview.component.ts
@@ -37,7 +37,7 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { first } from 'rxjs/operators';
 import { LogbookService } from 'vitamui-library';
-import { IngestStatus, LogbookOperation, ingestStatus, ingestStatusVisualColor } from '../../models/logbook-event.interface';
+import { IngestStatus, ingestStatus, ingestStatusVisualColor, LogbookOperation } from '../../models/logbook-event.interface';
 import { IngestService } from '../ingest.service';
 
 @Component({
@@ -97,12 +97,6 @@ export class IngestPreviewComponent implements OnInit, OnChanges {
 
   emitClose() {
     this.previewClose.emit();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_UPDATE_INGEST') || event.outDetail.includes('EXT_VITAMUI_CREATE_INGEST'))
-    );
   }
 
   getIngestStatus(ingest: any): IngestStatus {

--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-preview.component.html
@@ -33,10 +33,8 @@
         [id]="accessContract?.id"
         [identifier]="accessContract?.identifier"
         collectionName="accesscontracts"
-        [filter]="filterEvents"
         [filteringByIdentifier]="false"
-      >
-      </vitamui-common-operation-history-tab>
+      />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-preview/access-contract-preview.component.ts
@@ -38,7 +38,7 @@ import { AfterViewInit, Component, EventEmitter, HostListener, Input, Output, Vi
 import { MatDialog } from '@angular/material/dialog';
 import { MatTab, MatTabGroup, MatTabHeader } from '@angular/material/tabs';
 import { Observable } from 'rxjs';
-import { AccessContract, ConfirmActionComponent, AccessContractService } from 'vitamui-library';
+import { AccessContract, AccessContractService, ConfirmActionComponent } from 'vitamui-library';
 import { AccessContractInformationTabComponent } from './access-contract-information-tab/access-contract-information-tab.component';
 import { AccessContractAuthorizationsTabComponent } from './access-contract-authorizations-tab/access-contract-authorizations-tab.component';
 import { AccessContractWriteAccessTabComponent } from './access-contract-write-access-tab/access-contract-write-access-tab.component';
@@ -95,15 +95,6 @@ export class AccessContractPreviewComponent implements AfterViewInit {
     await this.checkBeforeExit();
 
     this.previewClose.emit();
-  }
-
-  public filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('STP_UPDATE_ACCESS_CONTRACT') ||
-        event.outDetail.includes('STP_IMPORT_ACCESS_CONTRACT') ||
-        event.outDetail.includes('STP_BACKUP_ACCESS_CONTRACT'))
-    );
   }
 
   private async checkBeforeExit() {

--- a/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.html
@@ -30,13 +30,7 @@
     </mat-tab>
 
     <mat-tab [label]="'AGENCY.TAB.HISTORY' | translate">
-      <vitamui-common-operation-history-tab
-        [id]="agency?.identifier"
-        [identifier]="agency?.identifier"
-        collectionName="agency"
-        [filter]="filterEvents"
-      >
-      </vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="agency?.identifier" [identifier]="agency?.identifier" collectionName="agency" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/agency/agency-preview/agency-preview.component.ts
@@ -139,13 +139,6 @@ export class AgencyPreviewComponent implements AfterViewInit {
     return await dialog.afterClosed().toPromise();
   }
 
-  public filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_ACCESS_CONTRACT') || event.outDetail.includes('EXT_VITAMUI_CREATE_ACCESS_CONTRACT'))
-    );
-  }
-
   public async emitClose() {
     if (this.tabUpdated[this.tabs.selectedIndex]) {
       await this.checkBeforeExit();

--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.html
@@ -24,12 +24,7 @@
     </mat-tab>
 
     <mat-tab label="{{ 'AUDIT.TAB.DETAILS.TITLE' | translate }}">
-      <vitamui-common-operation-history-tab
-        [id]="audit()?.id"
-        [identifier]="audit()?.id"
-        collectionName="operation"
-        [filter]="filterEvents"
-      >
+      <vitamui-common-operation-history-tab [id]="audit()?.id" [identifier]="audit()?.id" collectionName="operation">
       </vitamui-common-operation-history-tab>
     </mat-tab>
   </mat-tab-group>

--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.ts
@@ -39,9 +39,9 @@ import {
   Event,
   ExternalParameters,
   ExternalParametersService,
+  SnackBarService,
   VitamUICommonModule,
   VitamUILibraryModule,
-  SnackBarService,
 } from 'vitamui-library';
 import { AuditService } from '../audit.service';
 import { CommonModule } from '@angular/common';
@@ -124,12 +124,6 @@ export class AuditPreviewComponent implements OnInit {
 
   downloadReport() {
     this.auditService.download(this.audit().id, this.audit().type, this.accessContractId);
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_UPDATE_AUDIT') || event.outDetail.includes('EXT_VITAMUI_CREATE_AUDIT'))
-    );
   }
 
   private getLastStepStatus(audit: Event): string {

--- a/ui/ui-frontend/projects/referential/src/app/context/context-preview/context-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/context/context-preview/context-preview.component.html
@@ -17,13 +17,7 @@
     </mat-tab>
 
     <mat-tab [label]="'CONTEXTS_APP.TAB.HISTORY.TITLE' | translate">
-      <vitamui-common-operation-history-tab
-        [id]="context?.identifier"
-        [identifier]="context?.identifier"
-        collectionName="context"
-        [filter]="filterEvents"
-      >
-      </vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="context?.identifier" [identifier]="context?.identifier" collectionName="context" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/context/context-preview/context-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/context/context-preview/context-preview.component.ts
@@ -38,8 +38,7 @@ import { AfterViewInit, Component, EventEmitter, HostListener, Input, Output, Vi
 import { MatDialog } from '@angular/material/dialog';
 import { MatTab, MatTabGroup, MatTabHeader } from '@angular/material/tabs';
 import { Observable } from 'rxjs';
-import { Context } from 'vitamui-library';
-import { ConfirmActionComponent } from 'vitamui-library';
+import { ConfirmActionComponent, Context } from 'vitamui-library';
 import { ContextService } from '../context.service';
 import { ContextInformationTabComponent } from './context-information-tab/context-information-tab.component';
 import { ContextPermissionTabComponent } from './context-permission-tab/context-permission-tab.component';
@@ -111,13 +110,6 @@ export class ContextPreviewComponent implements AfterViewInit {
     const dialog = this.matDialog.open(ConfirmActionComponent, { panelClass: 'small' });
     dialog.componentInstance.dialogType = 'changeTab';
     return await dialog.afterClosed().toPromise();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_ACCESS_CONTRACT') || event.outDetail.includes('EXT_VITAMUI_CREATE_ACCESS_CONTRACT'))
-    );
   }
 
   async emitClose() {

--- a/ui/ui-frontend/projects/referential/src/app/file-format/file-format-preview/file-format-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/file-format/file-format-preview/file-format-preview.component.html
@@ -9,13 +9,7 @@
     </mat-tab>
 
     <mat-tab [label]="'FILE_FORMATS.TAB.HISTORY.TITLE' | translate">
-      <vitamui-common-operation-history-tab
-        [id]="fileFormat?.puid"
-        [identifier]="fileFormat?.puid"
-        collectionName="fileformat"
-        [filter]="filterEvents"
-      >
-      </vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="fileFormat?.puid" [identifier]="fileFormat?.puid" collectionName="fileformat" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/file-format/file-format-preview/file-format-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/file-format/file-format-preview/file-format-preview.component.ts
@@ -110,13 +110,6 @@ export class FileFormatPreviewComponent implements AfterViewInit {
     return await dialog.afterClosed().toPromise();
   }
 
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_FILE_FORMAT') || event.outDetail.includes('EXT_VITAMUI_CREATE_FILE_FORMAT'))
-    );
-  }
-
   async emitClose() {
     if (this.tabUpdated[this.tabs.selectedIndex]) {
       await this.checkBeforeExit();

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-preview.component.html
@@ -74,9 +74,7 @@
         [id]="ingestContract?.id"
         [identifier]="ingestContract?.identifier"
         collectionName="ingestcontract"
-        [filter]="filterEvents"
-      >
-      </vitamui-common-operation-history-tab>
+      />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-preview/ingest-contract-preview.component.ts
@@ -38,8 +38,7 @@ import { AfterViewInit, Component, EventEmitter, HostListener, Input, OnChanges,
 import { MatDialog } from '@angular/material/dialog';
 import { MatTab, MatTabGroup, MatTabHeader } from '@angular/material/tabs';
 import { Observable } from 'rxjs';
-import { IngestContract } from 'vitamui-library';
-import { ConfirmActionComponent } from 'vitamui-library';
+import { ConfirmActionComponent, IngestContract } from 'vitamui-library';
 import { IngestContractService } from '../ingest-contract.service';
 import { IngestContractFormatTabComponent } from './ingest-contract-format-tab/ingest-contract-format-tab.component';
 import { IngestContractHeritageTabComponent } from './ingest-contract-heritage-tab/ingest-contract-heritage-tab.component';
@@ -158,13 +157,6 @@ export class IngestContractPreviewComponent implements OnChanges, AfterViewInit 
     const dialog = this.matDialog.open(ConfirmActionComponent, { panelClass: 'small' });
     dialog.componentInstance.dialogType = 'changeTab';
     return await dialog.afterClosed().toPromise();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_INGEST_CONTRACT') || event.outDetail.includes('EXT_VITAMUI_CREATE_INGEST_CONTRACT'))
-    );
   }
 
   async emitClose() {

--- a/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-preview/management-contract-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-preview/management-contract-preview.component.html
@@ -36,7 +36,8 @@
       <vitamui-common-operation-history-tab
         [id]="inputManagementContract?.id"
         [identifier]="inputManagementContract?.identifier"
-        [filter]="filterEvents"
+        collectionName="management-contract"
+        [filteringByIdentifier]="false"
       >
       </vitamui-common-operation-history-tab>
     </mat-tab>

--- a/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-preview/management-contract-preview.component.spec.ts
+++ b/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-preview/management-contract-preview.component.spec.ts
@@ -84,47 +84,6 @@ describe('ManagementContractPreviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should return false', () => {
-    // Given
-    const event = { id: 'id', eventDetails: 'test test' };
-
-    // When
-    const respone = component.filterEvents(event);
-
-    // Then
-    expect(respone).toBeFalsy();
-  });
-
-  it('should return true', () => {
-    // Given
-    const event = {
-      id: 'aeeaaaaaaghjmgheaax42amfo3qv6jyaaaaq',
-      evId: 'aeeaaaaaaghjmgheaax42amfo3qv6jyaaaaq',
-      evIdReq: 'aeeaaaaaaghjmgheaax42amfo3qv6jyaaaaq',
-      evType: 'PROCESS_SIP_UNITARY',
-      evTypeProc: 'INGEST',
-      evDateTime: '2023-01-03T09:05:59.803',
-      outcome: 'STARTED',
-      outDetail: 'STP_IMPORT_MANAGEMENT_CONTRACT.STARTED',
-      outMessg: 'Début du processus du SIP : aeeaaaaaaghjmgheaax42amfo3qv6jyaaaaq',
-      evDetData:
-        '{\n  "EvDetailReq" : "Versement",\n  "EvDateTimeReq" : "2023-01-03T09:05:57",\n  "ArchivalAgreement" : "ArchivalAgreement0",\n  "ServiceLevel" : null,\n  "_up" : [ "aeaqaaaaaehffa3qaavjkamfop2tqpyaaada" ]\n}',
-      obId: 'aeeaaaaaaghjmgheaax42amfo3qv6jyaaaaq',
-      agId: '{"Name":"vitam-env-itrec-vm-2","Role":"ingest-external","ServerId":1050024164,"SiteId":1,"GlobalPlatformId":244717796}',
-      agIdApp: 'CT-000001',
-      agIdExt: '{"originatingAgency":"Identifier0","TransferringAgency":"Vitam","ArchivalAgency":"Vitam","submissionAgency":"Identifier0"}',
-      rightsStatementIdentifier: '{"ArchivalAgreement":"ArchivalAgreement0"}',
-
-      obIdIn: 'Versement',
-    };
-
-    // When
-    const respone = component.filterEvents(event);
-
-    // Then
-    expect(respone).toBeTruthy();
-  });
-
   it('should return the exact array ', () => {
     // Given
     component.tabUpdated = [false, false];

--- a/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-preview/management-contract-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/management-contract/management-contract-preview/management-contract-preview.component.ts
@@ -39,11 +39,11 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatTab, MatTabGroup, MatTabHeader } from '@angular/material/tabs';
 import { Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { ManagementContract } from 'vitamui-library';
-import { ConfirmActionComponent } from 'vitamui-library';
+import { ConfirmActionComponent, ManagementContract } from 'vitamui-library';
 import { ManagementContractIdentificationTabComponent } from './management-contract-identification-tab/management-contract-identification-tab.component';
 import { ManagementContractInformationTabComponent } from './management-contract-information-tab/management-contract-information-tab.component';
 import { ManagementContractStorageTabComponent } from './management-contract-storage-tab/management-contract-storage-tab.component';
+
 @Component({
   selector: 'app-management-contract-preview',
   templateUrl: './management-contract-preview.component.html',
@@ -92,14 +92,6 @@ export class ManagementContractPreviewComponent implements OnChanges, AfterViewI
 
   updatedChange(updated: boolean, index: number) {
     this.tabUpdated[index] = updated;
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.toString().includes('STP_UPDATE_MANAGEMENT_CONTRACT') ||
-        event.outDetail.toString().includes('STP_IMPORT_MANAGEMENT_CONTRACT'))
-    );
   }
 
   async emitClose() {

--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-preview.component.html
@@ -12,8 +12,7 @@
     </mat-tab>
 
     <mat-tab [label]="'ONTOLOGY.TAB.HISTORY.TITLE' | translate">
-      <vitamui-common-operation-history-tab [id]="identifier" [identifier]="identifier" collectionName="ontology" [filter]="filterEvents">
-      </vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="identifier" [identifier]="identifier" collectionName="ontology" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology-preview/ontology-preview.component.ts
@@ -77,10 +77,6 @@ export class OntologyPreviewComponent implements AfterViewInit, OnChanges {
   tabLinks: Array<OntologyInformationTabComponent> = [];
   @ViewChild('infoTab', { static: false }) infoTab: OntologyInformationTabComponent;
 
-  filterEvents(event: any): boolean {
-    return event.outDetail && (event.outDetail.includes('STP_UPDATE_ONTOLOGY') || event.outDetail.includes('STP_IMPORT_ONTOLOGY'));
-  }
-
   @HostListener('window:beforeunload', ['$event'])
   beforeunloadHandler(event: BeforeUnloadEvent): string | void {
     if (this.tabUpdated?.[this.tabs?.selectedIndex] && this.isOntology(this.selectedElement)) {

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.html
@@ -9,8 +9,7 @@
     </mat-tab>
 
     <mat-tab [label]="'RULES_APP.TAB.HISTORY.TITLE' | translate">
-      <vitamui-common-operation-history-tab [id]="rule?.id" [identifier]="rule?.id" collectionName="rules" [filter]="filterEvents">
-      </vitamui-common-operation-history-tab>
+      <vitamui-common-operation-history-tab [id]="rule?.id" [identifier]="rule?.id" collectionName="rules" />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/rule/rule-preview/rule-preview.component.ts
@@ -109,13 +109,6 @@ export class RulePreviewComponent implements AfterViewInit {
     return await dialog.afterClosed().toPromise();
   }
 
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_FILE_FORMAT') || event.outDetail.includes('EXT_VITAMUI_CREATE_FILE_FORMAT'))
-    );
-  }
-
   async emitClose() {
     if (this.tabUpdated[this.tabs.selectedIndex]) {
       await this.checkBeforeExit();

--- a/ui/ui-frontend/projects/referential/src/app/security-profile/security-profile-preview/security-profile-preview.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/security-profile/security-profile-preview/security-profile-preview.component.html
@@ -29,9 +29,7 @@
         [id]="securityProfile?.identifier"
         [identifier]="securityProfile?.identifier"
         collectionName="security-profile"
-        [filter]="filterEvents"
-      >
-      </vitamui-common-operation-history-tab>
+      />
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/referential/src/app/security-profile/security-profile-preview/security-profile-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/security-profile/security-profile-preview/security-profile-preview.component.ts
@@ -38,8 +38,7 @@ import { AfterViewInit, Component, EventEmitter, HostListener, Input, Output, Vi
 import { MatDialog } from '@angular/material/dialog';
 import { MatTab, MatTabGroup, MatTabHeader } from '@angular/material/tabs';
 import { Observable } from 'rxjs';
-import { SecurityProfile } from 'vitamui-library';
-import { ConfirmActionComponent } from 'vitamui-library';
+import { ConfirmActionComponent, SecurityProfile } from 'vitamui-library';
 import { SecurityProfileService } from '../security-profile.service';
 import { SecurityProfileInformationTabComponent } from './security-profile-information-tab/security-profile-information-tab.component';
 import { SecurityProfilePermissionsTabComponent } from './security-profile-permissions-tab/security-profile-permissions-tab.component';
@@ -118,13 +117,6 @@ export class SecurityProfilePreviewComponent implements AfterViewInit {
   updateFullAccess(newValue: boolean) {
     this.securityProfile.fullAccess = newValue;
     this.permsTab.SecurityProfile = this.securityProfile;
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_ACCESS_CONTRACT') || event.outDetail.includes('EXT_VITAMUI_CREATE_ACCESS_CONTRACT'))
-    );
   }
 
   async emitClose() {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/logbook-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/logbook-api.service.ts
@@ -39,7 +39,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { BASE_URL } from '../injection-tokens';
-import { ApiEvent, IEvent, VitamSelectQuery } from '../models';
+import { ApiEvent, HistoryEvent, IEvent } from '../models';
 import { VitamResponse } from '../models/vitam/vitam-response.interface';
 import { PaginatedApi } from '../paginated-api.interface';
 import { PageRequest, PaginatedResponse } from '../vitamui-table';
@@ -143,26 +143,10 @@ export class LogbookApiService implements PaginatedApi<IEvent> {
       .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
   }
 
-  findOperationByIdAndCollectionName(id: string, resourcePath: string, headers?: HttpHeaders): Observable<{ $results: IEvent[] }> {
+  findOperationByIdAndCollectionName(id: string, resourcePath: string, headers?: HttpHeaders): Observable<HistoryEvent[]> {
     return this.http
-      .get<{ $results: ApiEvent[] }>(this.baseUrl + '/' + resourcePath + '/' + id + '/history', { headers })
-      .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
-  }
-
-  findOperationsBySelectQuery(
-    selectQuery: VitamSelectQuery,
-    vitamTenantIdentifier?: number,
-    headers?: HttpHeaders,
-  ): Observable<{ $results: IEvent[] }> {
-    let params = new HttpParams();
-
-    if (vitamTenantIdentifier) {
-      params = params.append('vitamTenantIdentifier', vitamTenantIdentifier.toString());
-    }
-
-    return this.http
-      .post<{ $results: ApiEvent[] }>(this.apiUrl + '/operations', selectQuery, { headers, params })
-      .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
+      .get<HistoryEvent[]>(this.baseUrl + '/' + resourcePath + '/' + id + '/history', { headers })
+      .pipe(map((event) => event.map((event) => ({ ...event, parsedData: JSON.parse(event.data) }))));
   }
 
   downloadManifest(id: string, headers?: HttpHeaders): Observable<HttpResponse<Blob>> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/base-http-client.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/base-http-client.ts
@@ -38,9 +38,6 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { LogbookApiService } from './api/logbook-api.service';
-import { ApiEvent, IEvent } from './models';
-
 const HTTP_STATUS_OK = 200;
 
 export abstract class BaseHttpClient<T extends { id: string }> {
@@ -94,11 +91,5 @@ export abstract class BaseHttpClient<T extends { id: string }> {
 
   protected patch(data: { id: string; [key: string]: any }, headers?: HttpHeaders): Observable<T> {
     return this.http.patch<T>(this.apiUrl + '/' + data.id, data, { headers });
-  }
-
-  public logbook(id: string, headers?: HttpHeaders): Observable<{ $results: IEvent[] }> {
-    return this.http
-      .get<{ $results: ApiEvent[] }>(this.apiUrl + '/' + id + '/logbook', { headers })
-      .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/event-type-label/event-type-label.component.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/event-type-label/event-type-label.component.spec.ts
@@ -38,6 +38,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VitamUICommonTestModule } from '../../../../../testing/src';
 
 import { EventTypeLabelComponent } from './event-type-label.component';
+import { TranslateModule } from '@ngx-translate/core';
 
 describe('EventTypeLabelComponent', () => {
   let component: EventTypeLabelComponent;
@@ -45,8 +46,7 @@ describe('EventTypeLabelComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VitamUICommonTestModule],
-      declarations: [EventTypeLabelComponent],
+      imports: [EventTypeLabelComponent, VitamUICommonTestModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/event-type-label/event-type-label.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/event-type-label/event-type-label.component.ts
@@ -35,12 +35,13 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, Input } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'vitamui-common-event-type-label',
   templateUrl: './event-type-label.component.html',
   styleUrls: ['./event-type-label.component.scss'],
-  standalone: false,
+  imports: [TranslatePipe],
 })
 export class EventTypeLabelComponent {
   @Input() key: string;

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.html
@@ -1,16 +1,15 @@
-<ng-container *ngFor="let event of events">
+@for (event of events; track event) {
   <div
     class="history-event-item"
     [class.event-error]="event.outcome === 'KO' || event.outcome === 'FATAL'"
     [class.event-warning]="event.outcome === 'WARNING'"
   >
     <div class="history-event-date">
-      <ng-container *ngIf="event.parsedData && event.parsedData['Date d\'opération']">
+      @if (event.parsedData && event.parsedData["Date d'opération"]) {
         {{ event.parsedData["Date d'opération"] | dateTime: 'dd/MM/yyyy | HH:mm:ss' }}
-      </ng-container>
-      <ng-container *ngIf="!event.parsedData || !event.parsedData['Date d\'opération']">
+      } @else {
         {{ event.dateTime | dateTime: 'dd/MM/yyyy | HH:mm:ss' }}
-      </ng-container>
+      }
     </div>
     <div class="history-event-title">
       <vitamui-common-event-type-label [key]="event.type"></vitamui-common-event-type-label> -
@@ -18,11 +17,16 @@
     </div>
     <div class="history-event-outmessage">
       <vitamui-common-event-type-label [key]="event.outDetail"></vitamui-common-event-type-label>
-      <span *ngIf="event.userIdentifier"> {{ 'COMMON.BY_USER' | translate: { userIdentifier: event.userIdentifier } }}</span>
-      <span *ngIf="event.subrogatorIdentifier">
-        ({{ 'COMMON.SUBROGATED_BY' | translate: { subrogatorIdentifier: event.subrogatorIdentifier } }})</span
-      >.
+      @if (event.userIdentifier) {
+        <span> {{ 'COMMON.BY_USER' | translate: { userIdentifier: event.userIdentifier } }}</span>
+      }
+      @if (event.subrogatorIdentifier) {
+        <span>({{ 'COMMON.SUBROGATED_BY' | translate: { subrogatorIdentifier: event.subrogatorIdentifier } }})</span>
+      }
+      .
     </div>
-    <div class="history-event-details" *ngIf="checkEventData(event)">{{ getEventData(event) }}</div>
+    @if (checkEventData(event)) {
+      <pre class="history-event-details">{{ getEventData(event) }}</pre>
+    }
   </div>
-</ng-container>
+}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.scss
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.scss
@@ -35,6 +35,7 @@
   .history-event-details {
     color: var(--vitamui-grey-900);
     word-break: break-word;
+    text-wrap: auto;
     padding-right: 8px;
   }
 

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.spec.ts
@@ -42,7 +42,6 @@ import { HistoryEventsComponent } from './history-events.component';
 @Component({
   selector: 'vitamui-common-event-type-label',
   template: '',
-  standalone: false,
 })
 class EventTypeLabelStubComponent {
   @Input() key: string;
@@ -54,7 +53,7 @@ describe('HistoryEventsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [HistoryEventsComponent, EventTypeLabelStubComponent],
+      imports: [HistoryEventsComponent, EventTypeLabelStubComponent],
     }).compileComponents();
   });
 

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history-events/history-events.component.ts
@@ -36,25 +36,32 @@
  */
 import { Component, Input } from '@angular/core';
 
-import { IEvent } from '../../../models';
+import { HistoryEvent } from '../../../models';
+import { EventTypeLabelComponent } from '../../event-type-label/event-type-label.component';
+import { PipesModule } from '../../../pipes/pipes.module';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'vitamui-common-history-events',
   templateUrl: './history-events.component.html',
   styleUrls: ['./history-events.component.scss'],
-  standalone: false,
+  imports: [EventTypeLabelComponent, PipesModule, TranslatePipe],
 })
 export class HistoryEventsComponent {
-  @Input() events: IEvent[];
+  @Input() events: HistoryEvent[];
 
-  checkEventData(event: IEvent): boolean {
-    if (event) {
-      return event.data !== '{}';
-    }
+  checkEventData(event: HistoryEvent): boolean {
+    return event?.data && event.data !== '{}';
   }
-  getEventData(event: IEvent) {
+  getEventData(event: HistoryEvent) {
     if (event) {
-      return event.data;
+      try {
+        // Pretty printing the data
+        return JSON.stringify(JSON.parse(event.data), null, 2);
+      } catch {
+        // In case the data is not a valid JSON
+        return event.data;
+      }
     }
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history.module.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/history.module.ts
@@ -41,14 +41,21 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { CollapseModule } from '../../components/collapse/collapse.module';
 import { PipesModule } from '../../pipes/pipes.module';
-import { EventTypeLabelModule } from '../event-type-label/event-type-label.module';
-import { HistoryEventsComponent } from './history-events/history-events.component';
 import { MultiOperationHistoryTabComponent } from './multi-operation-history-tab/multi-operation-history-tab.component';
 import { OperationHistoryTabComponent } from './operation-history-tab/operation-history-tab.component';
+import { EventTypeLabelComponent } from '../event-type-label/event-type-label.component';
 
 @NgModule({
-  imports: [CommonModule, CollapseModule, MatProgressSpinnerModule, EventTypeLabelModule, TranslateModule, PipesModule],
-  declarations: [HistoryEventsComponent, OperationHistoryTabComponent, MultiOperationHistoryTabComponent],
-  exports: [HistoryEventsComponent, OperationHistoryTabComponent, MultiOperationHistoryTabComponent],
+  imports: [
+    CommonModule,
+    CollapseModule,
+    MatProgressSpinnerModule,
+    EventTypeLabelComponent,
+    TranslateModule,
+    PipesModule,
+    OperationHistoryTabComponent,
+    MultiOperationHistoryTabComponent,
+  ],
+  exports: [OperationHistoryTabComponent, MultiOperationHistoryTabComponent],
 })
 export class HistoryModule {}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/multi-operation-history-tab/multi-operation-history-tab.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/multi-operation-history-tab/multi-operation-history-tab.component.html
@@ -1,9 +1,11 @@
-<div *ngIf="loading; else elseBlock" class="loading-spinner"><mat-spinner diameter="50" color="accent"></mat-spinner></div>
-<ng-template #elseBlock>
-  <div *ngIf="!events?.length; else elseBlock" class="no-result">{{ 'COMMON.HISTORY.NO_HISTORY' | translate }}</div>
-  <ng-template #elseBlock>
+@if (loading) {
+  <div class="loading-spinner"><mat-spinner diameter="50" color="accent"></mat-spinner></div>
+} @else {
+  @if (!events?.length) {
+    <div class="no-result">{{ 'COMMON.HISTORY.NO_HISTORY' | translate }}</div>
+  } @else {
     <vitamui-common-collapse [collapseTitle]="'COMMON.HISTORY.OPERATIONS' | translate">
       <vitamui-common-history-events [events]="events"></vitamui-common-history-events>
     </vitamui-common-collapse>
-  </ng-template>
-</ng-template>
+  }
+}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/multi-operation-history-tab/multi-operation-history-tab.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/multi-operation-history-tab/multi-operation-history-tab.component.ts
@@ -40,8 +40,12 @@ import { Subject } from 'rxjs';
 import { map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { AuthService } from '../../../auth.service';
-import { IEvent } from '../../../models';
+import { HistoryEvent } from '../../../models';
 import { LogbookService } from '../../logbook.service';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { TranslatePipe } from '@ngx-translate/core';
+import { CollapseModule } from '../../../components/collapse/collapse.module';
+import { HistoryEventsComponent } from '../history-events/history-events.component';
 
 const EVENT_LIMIT = 100;
 
@@ -49,15 +53,14 @@ const EVENT_LIMIT = 100;
   selector: 'vitamui-common-multi-operation-history-tab',
   templateUrl: './multi-operation-history-tab.component.html',
   styleUrls: ['./multi-operation-history-tab.component.scss'],
-  standalone: false,
+  imports: [MatProgressSpinner, TranslatePipe, CollapseModule, HistoryEventsComponent],
 })
 export class MultiOperationHistoryTabComponent implements OnChanges, OnDestroy {
   @Input() collectionsMap: Map<string, string>;
   @Input() identifiers: string[];
-  @Input() filter: (event: any) => boolean;
   @Input() filteringByIdentifier = true;
 
-  events: IEvent[] = [];
+  events: HistoryEvent[] = [];
   loading = false;
 
   private isDestroyed$ = new Subject<void>();
@@ -91,18 +94,14 @@ export class MultiOperationHistoryTabComponent implements OnChanges, OnDestroy {
         map((paramMap) =>
           paramMap.get('tenantIdentifier') ? +paramMap.get('tenantIdentifier') : Number(this.authService.user.proofTenantIdentifier),
         ),
-        switchMap((tenantIdentifier) => {
-          const result = this.logbookService.listHistoryOperations(this.collectionsMap, tenantIdentifier);
-          return result;
-        }),
+        switchMap((tenantIdentifier) => this.logbookService.listHistoryOperations(this.collectionsMap, tenantIdentifier)),
         takeUntil(this.isDestroyed$),
       )
       .subscribe(
         (results) => {
           this.events = results
-            .filter((event) => {
-              return this.filter ? this.filter(event) && (!this.filteringByIdentifier || this.filterByIdentifier(event)) : true;
-            })
+            // FIXME: shouldn't we filter on API side?
+            .filter((event) => (this.filteringByIdentifier ? this.filterByIdentifier(event) : true))
             .slice(0, EVENT_LIMIT);
           this.loading = false;
         },
@@ -110,7 +109,7 @@ export class MultiOperationHistoryTabComponent implements OnChanges, OnDestroy {
       );
   }
 
-  filterByIdentifier(event: any): boolean {
-    return event.objectId && this.identifiers.includes(event.objectId);
+  private filterByIdentifier(event: HistoryEvent): boolean {
+    return event.obId && this.identifiers.includes(event.obId);
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/operation-history-tab/operation-history-tab.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/operation-history-tab/operation-history-tab.component.html
@@ -1,9 +1,11 @@
-<div *ngIf="loading; else elseBlock" class="loading-spinner"><mat-spinner diameter="50" color="accent"></mat-spinner></div>
-<ng-template #elseBlock>
-  <div *ngIf="!events?.length; else elseBlock" class="no-result">{{ 'COMMON.HISTORY.NO_HISTORY' | translate }}</div>
-  <ng-template #elseBlock>
+@if (loading) {
+  <div class="loading-spinner"><mat-spinner diameter="50" color="accent"></mat-spinner></div>
+} @else {
+  @if (!events?.length) {
+    <div class="no-result">{{ 'COMMON.HISTORY.NO_HISTORY' | translate }}</div>
+  } @else {
     <vitamui-common-collapse [collapseTitle]="'COMMON.HISTORY.OPERATIONS' | translate">
       <vitamui-common-history-events [events]="events"></vitamui-common-history-events>
     </vitamui-common-collapse>
-  </ng-template>
-</ng-template>
+  }
+}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/operation-history-tab/operation-history-tab.component.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/operation-history-tab/operation-history-tab.component.spec.ts
@@ -39,28 +39,19 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { VitamUICommonTestModule } from '../../../../../../testing/src';
 import { AuthService } from '../../../auth.service';
-import { IEvent } from '../../../models';
+import { HistoryEvent } from '../../../models';
 import { LogbookService } from '../../logbook.service';
 import { OperationHistoryTabComponent } from './operation-history-tab.component';
+import { TranslateModule } from '@ngx-translate/core';
 
-const logbookEvent: IEvent = {
-  id: 'eventObjectId',
-  idRequest: 'aedqaaaaaghc5pzqaayl2amc3mdleuiaaaaq',
-  parentId: null,
+const logbookEvent: HistoryEvent = {
   type: 'STORAGE_SECURISATION_TIMESTAMP',
-  typeProc: 'TRACEABILITY',
   dateTime: new Date(),
   outcome: 'OK',
   outDetail: 'STORAGE_SECURISATION_TIMESTAMP.OK',
-  outMessage: "Succès de la création du tampon d'horodatage de l'ensemble des journaux d'écriture",
   data: null,
   parsedData: {},
-  objectId: 'eventId',
-  collectionName: 'LogbookOperations',
-  agId: null,
-  agIdApp: 'agIdApp',
-  agIdExt: null,
-  rightsStatementIdentifier: null,
+  obId: 'eventId',
   obIdReq: null,
 };
 
@@ -70,8 +61,7 @@ describe('OperationHistoryTabComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VitamUICommonTestModule],
-      declarations: [OperationHistoryTabComponent],
+      imports: [OperationHistoryTabComponent, VitamUICommonTestModule, TranslateModule.forRoot()],
       providers: [
         { provide: AuthService, useValue: {} },
         { provide: LogbookService, useValue: {} },
@@ -103,7 +93,7 @@ describe('OperationHistoryTabComponent', () => {
     expect(component.filterByIdentifier(event)).toBeTruthy();
   });
 
-  it('Component should return fakse when all conditions are not respected', () => {
+  it('Component should return false when all conditions are not respected', () => {
     // Given
     const event = logbookEvent;
 
@@ -115,26 +105,16 @@ describe('OperationHistoryTabComponent', () => {
     expect(component.filterByIdentifier(event)).toBeFalsy();
   });
 
-  it('Component should return false when objectId is null', () => {
+  it('Component should return false when obId is null', () => {
     // Given
-    const event: IEvent = {
-      id: 'eventObjectId',
-      idRequest: 'aeeaaaaaaghkyonpaa3fsamcys3raeiaaaaq',
-      parentId: null,
+    const event: HistoryEvent = {
       type: 'STP_SANITY_CHECK_SIP.STARTED',
-      typeProc: 'INGEST',
       dateTime: new Date(),
       outcome: 'OK',
       outDetail: 'STP_SANITY_CHECK_SIP.STARTED.OK',
-      outMessage: "Succès du début du processus des contrôles préalables à l'entrée",
       data: null,
       parsedData: {},
-      objectId: null,
-      collectionName: 'IngestCollection',
-      agId: null,
-      agIdApp: 'agIdApp',
-      agIdExt: null,
-      rightsStatementIdentifier: null,
+      obId: null,
       obIdReq: null,
     };
 

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/operation-history-tab/operation-history-tab.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/history/operation-history-tab/operation-history-tab.component.ts
@@ -40,8 +40,12 @@ import { Subject } from 'rxjs';
 import { map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { AuthService } from '../../../auth.service';
-import { IEvent } from '../../../models';
+import { HistoryEvent } from '../../../models';
 import { LogbookService } from '../../logbook.service';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { CollapseModule } from '../../../components/collapse/collapse.module';
+import { TranslatePipe } from '@ngx-translate/core';
+import { HistoryEventsComponent } from '../history-events/history-events.component';
 
 const EVENT_LIMIT = 100;
 
@@ -49,16 +53,15 @@ const EVENT_LIMIT = 100;
   selector: 'vitamui-common-operation-history-tab',
   templateUrl: './operation-history-tab.component.html',
   styleUrls: ['./operation-history-tab.component.scss'],
-  standalone: false,
+  imports: [MatProgressSpinner, CollapseModule, HistoryEventsComponent, TranslatePipe],
 })
 export class OperationHistoryTabComponent implements OnChanges, OnDestroy {
   @Input() id: string;
   @Input() identifier: string;
   @Input() collectionName: string;
-  @Input() filter: (event: any) => boolean;
   @Input() filteringByIdentifier = true;
 
-  events: IEvent[] = [];
+  events: HistoryEvent[] = [];
   loading = false;
 
   private isDestroyed$ = new Subject<void>();
@@ -89,25 +92,26 @@ export class OperationHistoryTabComponent implements OnChanges, OnDestroy {
         map((paramMap) =>
           paramMap.get('tenantIdentifier') ? +paramMap.get('tenantIdentifier') : Number(this.authService.user.proofTenantIdentifier),
         ),
-        switchMap((tenantIdentifier) => {
-          return this.logbookService.listOperationByIdAndCollectionName(this.id, this.collectionName, tenantIdentifier);
-        }),
+        switchMap((tenantIdentifier) =>
+          this.logbookService.listOperationByIdAndCollectionName(this.id, this.collectionName, tenantIdentifier),
+        ),
         takeUntil(this.isDestroyed$),
       )
-      .subscribe(
-        (results) => {
+      .subscribe({
+        next: (results) => {
           this.events = results
             .filter((event) => {
-              return this.filter ? this.filter(event) && (!this.filteringByIdentifier || this.filterByIdentifier(event)) : true;
+              // FIXME: shouldn't we filter on API side?
+              return this.filteringByIdentifier ? this.filterByIdentifier(event) : true;
             })
             .slice(0, EVENT_LIMIT);
           this.loading = false;
         },
-        () => (this.loading = false),
-      );
+        error: () => (this.loading = false),
+      });
   }
 
-  filterByIdentifier(event: any): boolean {
-    return event.objectId && event.objectId === this.identifier;
+  filterByIdentifier(event: HistoryEvent): boolean {
+    return event.obId && event.obId === this.identifier;
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/logbook.module.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/logbook.module.ts
@@ -37,13 +37,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-
-import { EventTypeLabelModule } from './event-type-label/event-type-label.module';
 import { HistoryModule } from './history/history.module';
+import { EventTypeLabelComponent } from './event-type-label/event-type-label.component';
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, HistoryModule, EventTypeLabelModule, TranslateModule],
-  exports: [HistoryModule, EventTypeLabelModule],
+  imports: [CommonModule, HistoryModule, EventTypeLabelComponent, TranslateModule],
+  exports: [HistoryModule],
 })
 export class LogbookModule {}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/logbook.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/logbook.service.ts
@@ -39,128 +39,35 @@ import { Injectable } from '@angular/core';
 import { forkJoin, Observable, of, throwError } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { LogbookApiService } from '../api/logbook-api.service';
-import { Logger } from '../logger/logger';
-import { IEvent } from '../models';
-import { VitamSelectQuery } from '../models/vitam/vitam-select-query.interface';
+import { HistoryEvent, IEvent } from '../models';
 import { VitamuiHttpHeaders } from '../vitamui-http-headers.enum';
 
 @Injectable({
   providedIn: 'root',
 })
 export class LogbookService {
-  constructor(
-    private logger: Logger,
-    private logbookApi: LogbookApiService,
-  ) {}
+  constructor(private logbookApi: LogbookApiService) {}
 
-  protected extractEvents(response: { $results: IEvent[] }): IEvent[] {
-    if (response && response.$results) {
-      if (response.$results.length > 1) {
-        this.logger.warn(this, 'WARN: multiple results in history');
-      }
-      if (response.$results.length > 0) {
-        return response.$results[0].events;
-      }
-    }
-
-    return [];
-  }
-
-  listOperationsEvents(identifier: string, obIdReq: string, tenantIdentifier: number, accessContract: string): Observable<IEvent[]> {
-    const headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
-      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-
-    return this.logbookApi.findOperations(identifier, obIdReq, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) => response.$results.reduce(flattenChildEvents, []).sort(sortEventByDate)),
-    );
-  }
-
-  listUnitEvents(unitId: string, accessContract: string, tenantIdentifier: number): Observable<IEvent[]> {
-    const headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
-      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-
-    return this.logbookApi.findUnitLifeCyclesByUnitId(unitId, headers).pipe(
-      catchError(() => of({ $hits: null, $results: [] })),
-      map((response) => this.extractEvents(response).sort(sortEventByDate)),
-    );
-  }
-
-  listObjectEvents(objectId: string, accessContract: string, tenantIdentifier: number): Observable<IEvent[]> {
-    const headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
-      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-    return this.logbookApi.findObjectGroupLifeCyclesByUnitId(objectId, headers).pipe(
-      catchError(() => of({ $hits: null, $results: [] })),
-      map((response) => this.extractEvents(response).sort(sortEventByDate)),
-    );
-  }
-
-  listOperationByIdAndCollectionName(identifier: string, collectionName: string, tenantIdentifier: number): Observable<IEvent[]> {
+  listOperationByIdAndCollectionName(id: string, collectionName: string, tenantIdentifier: number): Observable<HistoryEvent[]> {
     const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(identifier, collectionName, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) =>
-        response.$results
-          .reduce(flattenChildEvents, [])
-          .filter((e) => e.obIdReq.toLowerCase() === collectionName.toLowerCase())
-          .sort(sortEventByDate),
-      ),
+    return this.logbookApi.findOperationByIdAndCollectionName(id, collectionName, headers).pipe(
+      catchError(() => of([] as HistoryEvent[])),
+      map((response) => response.sort(sortEventByDate)),
     );
   }
 
-  listOperationByResourcePathIdAndCollectionName(
-    resourcePath: string,
-    identifier: string,
-    collectionName: string,
-    tenantIdentifier: number,
-  ): Observable<IEvent[]> {
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(identifier, resourcePath, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) =>
-        response.$results
-          .reduce(flattenChildEvents, [])
-          .filter((e) => e.obIdReq === collectionName)
-          .sort(sortEventByDate),
-      ),
-    );
-  }
-
-  listOperationByResourcePathIdAndCollectionNameWithCustomFilter(
-    resourcePath: string,
-    identifier: string,
-    tenantIdentifier: number,
-    filterPredicate: (event: IEvent) => boolean,
-  ): Observable<IEvent[]> {
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(identifier, resourcePath, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) => response.$results.reduce(flattenChildEvents, []).filter(filterPredicate).sort(sortEventByDate)),
-    );
-  }
-
-  listOperationByIdentifierAndCollectionName(
+  private listOperationByIdentifierAndCollectionName(
     id: string,
     identifier: string,
     collectionName: string,
     tenantIdentifier: number,
-  ): Observable<IEvent[]> {
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(id, collectionName, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) =>
-        response.$results
-          .reduce(flattenChildEvents, [])
-          .filter((e) => e.obIdReq === collectionName && e.obId === identifier)
-          .sort(sortEventByDate),
-      ),
+  ): Observable<HistoryEvent[]> {
+    return this.listOperationByIdAndCollectionName(id, collectionName, tenantIdentifier).pipe(
+      map((response) => response.filter((e) => e.obId === identifier)),
     );
   }
 
-  listHistoryForOwner(id: string, identifier: string, externalParamId: string, tenantIdentifier: number): Observable<IEvent[]> {
+  listHistoryForOwner(id: string, identifier: string, externalParamId: string, tenantIdentifier: number): Observable<HistoryEvent[]> {
     const ownerEventsObservable = this.listOperationByIdentifierAndCollectionName(id, identifier, 'owners', tenantIdentifier);
     const tenantEventsObservable = this.listOperationByIdAndCollectionName(externalParamId, 'tenants', tenantIdentifier);
 
@@ -171,19 +78,8 @@ export class LogbookService {
     );
   }
 
-  listHistoryForProfileArchive(id: string, externalParamId: string, tenantIdentifier: number): Observable<IEvent[]> {
-    const profileEventsObservable = this.listOperationByIdAndCollectionName(id, 'profiles', tenantIdentifier);
-    const archiveParamEventsObservable = this.listOperationByIdAndCollectionName(externalParamId, 'archiveparams', tenantIdentifier);
-
-    return forkJoin([profileEventsObservable, archiveParamEventsObservable]).pipe(
-      map((results) => {
-        return results[0].concat(results[1]).sort(sortEventByDate);
-      }),
-    );
-  }
-
-  listHistoryOperations(collectionsMap: Map<string, string>, tenantIdentifier: number): Observable<IEvent[]> {
-    const observables: Observable<IEvent[]>[] = [];
+  listHistoryOperations(collectionsMap: Map<string, string>, tenantIdentifier: number): Observable<HistoryEvent[]> {
+    const observables: Observable<HistoryEvent[]>[] = [];
     collectionsMap.forEach((value, key) => {
       const result = this.listOperationByIdAndCollectionName(key, value, tenantIdentifier);
       observables.push(result);
@@ -191,31 +87,12 @@ export class LogbookService {
 
     return forkJoin(observables).pipe(
       map((results) => {
-        let events: IEvent[] = [];
+        let events: HistoryEvent[] = [];
 
         results.forEach((event) => {
           events = events.concat(event);
         });
         return events.sort(sortEventByDate);
-      }),
-    );
-  }
-
-  listOperationsBySelectQuery(
-    query: VitamSelectQuery,
-    tenantIdentifier: number,
-    accessContract?: string,
-    vitamTenantIdentifier?: number,
-  ): Observable<IEvent[]> {
-    let headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    if (accessContract) {
-      headers = headers.set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-    }
-
-    return this.logbookApi.findOperationsBySelectQuery(query, vitamTenantIdentifier, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) => {
-        return response.$results.reduce(flattenChildEvents, []).sort(sortEventByDate);
       }),
     );
   }
@@ -259,10 +136,6 @@ export class LogbookService {
       document.body.removeChild(element);
     });
   }
-}
-
-function flattenChildEvents(acc: IEvent[], current: IEvent): IEvent[] {
-  return acc.concat(current.events);
 }
 
 export function sortEventByDate(ev1: IEvent, ev2: IEvent): number {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/logbook/event.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/logbook/event.interface.ts
@@ -36,27 +36,30 @@
  */
 import { Id } from '../id.interface';
 
-export interface IEvent extends Id {
-  obIdIn?: string;
-  idRequest: string;
-  parentId: string;
+export interface HistoryEvent {
   type: string;
-  typeProc: string;
   dateTime: Date;
   outcome: string;
   outDetail: string;
-  outMessage: string;
   data: string;
   parsedData: { [key: string]: any };
+  obId?: string;
+  obIdReq: string;
+  userIdentifier?: string;
+  subrogatorIdentifier?: string;
+}
+
+export interface IEvent extends Id, HistoryEvent {
+  obIdIn?: string;
+  idRequest: string;
+  parentId: string;
+  typeProc: string;
+  outMessage: string;
   objectId: string;
   collectionName: string;
   agId: string;
   agIdApp: string;
   agIdExt: string;
   rightsStatementIdentifier: string;
-  obIdReq: string;
-  obId?: string;
-  userIdentifier?: string;
-  subrogatorIdentifier?: string;
   events?: IEvent[];
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/vitamui-common.module.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/vitamui-common.module.ts
@@ -108,6 +108,8 @@ import { VitamuiTreeNodeComponent } from './components/vitamui-tree-node/vitamui
 import { InputComponent } from '../../lib/components/input/input.component';
 import { VitamUIFieldErrorComponent } from './components/vitamui-field-error/vitamui-field-error.component';
 import { ElementsComponent } from './components/elements/elements.component';
+import { EventTypeLabelComponent } from './logbook';
+import { HistoryEventsComponent } from './logbook/history/history-events/history-events.component';
 
 export function loadConfigFactory(configService: ConfigService, environment: any) {
   const p = () => configService.load(environment.configUrls).toPromise();
@@ -157,9 +159,11 @@ export function startupServiceFactory(startupService: StartupService, authServic
     DragAndDropDirective,
     EditableFieldModule,
     EllipsisDirectiveModule,
+    EventTypeLabelComponent,
     FileSelectorComponent,
     FooterComponent,
     HeaderModule,
+    HistoryEventsComponent,
     InfiniteScrollModule,
     InputComponent,
     LogbookModule,
@@ -219,9 +223,11 @@ export function startupServiceFactory(startupService: StartupService, authServic
     DragAndDropDirective,
     EditableFieldModule,
     EllipsisDirectiveModule,
+    EventTypeLabelComponent,
     FileSelectorComponent,
     FooterComponent,
     HeaderModule,
+    HistoryEventsComponent,
     InfiniteScrollModule,
     InputComponent,
     LogbookModule,

--- a/ui/ui-frontend/projects/vitamui-library/src/public-api.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/public-api.ts
@@ -163,7 +163,7 @@ export * from './app/modules/directives/resize-sidebar/resize-sidebar.directive'
 export * from './app/modules/directives/resize-sidebar/resize-sidebar.module';
 export * from './app/modules/directives/resize-sidebar/resize-vertical.directive';
 export * from './app/modules/directives/row-collapse/row-collapse.module';
-export * from './app/modules/logbook/event-type-label/event-type-label.module';
+export * from './app/modules/logbook/event-type-label/event-type-label.component';
 export * from './app/modules/logbook/history/history-events/history-events.component';
 export * from './app/modules/logbook/history/multi-operation-history-tab/multi-operation-history-tab.component';
 export * from './app/modules/logbook/history/operation-history-tab/operation-history-tab.component';


### PR DESCRIPTION
- Ajout de `@Secured` sur les points d'API `findHistoryById`
- Déplacement de la logique (`filter`) du front (Angular) vers le back Java
- Création d'un POJO `HistoryEventDto` dédié, ne contenant que les données utiles au front. Ce POJO est utilisé dans le return des `findHistoryById`
- Utilisation de la balise `<pre>` et formatage du JSON dans l'affichage des historiques


N.B. :
- il reste de la logique côté front (LogbookApiService) notamment pour la page "Dépôt et suivi des versements". À voir s'il faut refactor la page pour utiliser un POJO dédié.
- j'ai laissé `filterByIdentifier` dans `operation-history-tab.component.ts` et `multi-operation-history-tab.component.ts` car cela semble toujours utile. Je ne sais pas si l'on peut facilement déplacer cette logique côté backend