### PR TITLE
CP V9.0 - Bug #16465 [Search & Collect] Incorrect display of the letters “p” and “q” in some labels in VITAM UI.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/sass/_input.scss
+++ b/ui/ui-frontend/projects/vitamui-library/src/sass/_input.scss
@@ -167,4 +167,5 @@ app-simple-criteria-search .vitamui-input label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 1.4;
 }


### PR DESCRIPTION
see: https://github.com/ProgrammeVitam/vitam-ui/pull/3727