### PR TITLE
Bug #14438: Apply custom overlay style to keep the tooltip below the header layer (z-index < 100).

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/header.component.scss
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/header.component.scss
@@ -4,7 +4,7 @@ $header-height: 72px !default;
 
 mat-toolbar {
   @include elevation.shadow-128dp-dark;
-  z-index: 10;
+  z-index: 1001; // Make sure the header is over default overlays (tooltips, menus, ...)
 }
 
 .header {

--- a/ui/ui-frontend/projects/vitamui-library/src/sass/material/_dialog.scss
+++ b/ui/ui-frontend/projects/vitamui-library/src/sass/material/_dialog.scss
@@ -3,6 +3,14 @@
 @use '../bootstrap';
 
 :root {
+  .cdk-overlay-container {
+    z-index: 1000; // Should be the Angular Material default value for overlays, but we make sure it'll stay the same in the future
+
+    &:has(.mat-mdc-dialog-container) {
+      z-index: 1002; // Make sure the overlay for a dialog is over the header
+    }
+  }
+
   .cdk-overlay-pane.small .mat-mdc-dialog-container {
     width: 500px;
   }


### PR DESCRIPTION
Corriger le fait que la tooltip passe au dessus le header.