### PR TITLE
Bug #16496: limit customers generic admin profiles

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/ApiIamConstants.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/ApiIamConstants.java
@@ -40,6 +40,7 @@ import fr.gouv.vitamui.commons.api.domain.ServicesData;
 import fr.gouv.vitamui.commons.utils.VitamUIUtils;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Constants for API IAM.
@@ -47,6 +48,7 @@ import java.util.List;
 public final class ApiIamConstants {
 
     public static final String ADMIN_CLIENT_ROOT = "ADMIN_CLIENT_ROOT";
+    public static final String FULL_ADMIN_CLIENT_ROOT = "FULL_ADMIN_CLIENT_ROOT";
 
     private static final List<String> ACCOUNT_ROLES = VitamUIUtils.listOf(ServicesData.ROLE_UPDATE_ME_USERS);
 
@@ -115,6 +117,19 @@ public final class ApiIamConstants {
         "Profil de l'application de gestion des hiérarchies de profils";
 
     public static final String PHONE_NUMBER_VALID_REGEXP = "^[+]{1}[0-9]{11,12}$";
+
+    public static final String RESTRICTED_ADMIN_GROUP_NAME = "RESTRICTED_ADMIN_GROUP";
+
+    public static final String USERS_APP_RESTRICT_PROFILE_NAME = "Profil restreint pour la gestion des utilisateurs";
+    public static final String USERS_APP_NAME = "USERS_APP";
+
+    public static final String RESTRICTED_ADMIN_GROUP_DESCRIPTION = "Groupe de profils pour l'administrateur générique";
+    public static final Set<String> GENERIC_ADMIN_ALLOWED_APPS = Set.of(
+        "PROFILES_APP",
+        "HIERARCHY_PROFILE_APP",
+        "GROUPS_APP",
+        "ACCOUNTS_APP"
+    );
 
     private ApiIamConstants() {
         // do nothing

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/utils/EntityFactory.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/utils/EntityFactory.java
@@ -114,6 +114,7 @@ public final class EntityFactory {
         group.setName(name);
         group.setDescription(description);
         group.setLevel(level);
+        group.setReadonly(isReadonly);
         group.setEnabled(true);
         group.setProfileIds(profiles.stream().map(Profile::getId).collect(Collectors.toList()));
         return group;

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfig.java
@@ -171,6 +171,7 @@ public class CustomerInitConfig implements InitializingBean {
 
         private String name;
         private String description;
+        private boolean readOnly;
         private String level;
         private List<String> profiles;
 
@@ -180,10 +181,12 @@ public class CustomerInitConfig implements InitializingBean {
             final String name,
             final String description,
             final String level,
+            final boolean readOnly,
             final List<String> profiles
         ) {
             this.name = name;
             this.description = description;
+            this.readOnly = readOnly;
             this.level = level;
             this.profiles = profiles;
         }

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerService.java
@@ -205,13 +205,62 @@ public class InitCustomerService {
         LOGGER.debug("External Parameter added into DataBase {}", fullAccessContract);
         externalParametersService.update(fullAccessContract);
 
-        final Group createdAdminGroup = createAdminGroup(customerDto, createdAdminProfiles);
-        createAdminUser(customerDto, createdAdminGroup);
+        createAdminGroup(customerDto, createdAdminProfiles);
 
         List<Profile> customProfiles = createCustomProfiles(customerDto, proofTenantDto);
 
         List<Group> customGroups = createCustomGroups(customerDto, proofTenantDto, customProfiles);
+
+        Group limitedGroup = createLimitedAdminGroup(customerDto, createdAdminProfiles, customProfiles);
+
+        createAdminUser(customerDto, limitedGroup);
+
         createCustomUsers(customerDto, customGroups);
+    }
+
+    private Group createLimitedAdminGroup(
+        CustomerDto customerDto,
+        List<Profile> adminProfiles,
+        List<Profile> customProfiles
+    ) {
+        final List<Profile> filteredProfiles = new ArrayList<>(
+            adminProfiles
+                .stream()
+                .filter(profile -> ApiIamConstants.GENERIC_ADMIN_ALLOWED_APPS.contains(profile.getApplicationName()))
+                .collect(
+                    Collectors.groupingBy(
+                        profile -> Pair.of(profile.getApplicationName(), profile.getTenantIdentifier()),
+                        Collectors.collectingAndThen(Collectors.toList(), List::getFirst)
+                    )
+                )
+                .values()
+        );
+
+        final Profile userAppRestrictedProfile = customProfiles
+            .stream()
+            .filter(profile -> ApiIamConstants.USERS_APP_NAME.equals(profile.getApplicationName()))
+            .filter(profile -> profile.getName().startsWith(ApiIamConstants.USERS_APP_RESTRICT_PROFILE_NAME))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Unable to find profile with name " + ApiIamConstants.USERS_APP_RESTRICT_PROFILE_NAME
+                    )
+            );
+
+        filteredProfiles.add(userAppRestrictedProfile);
+
+        final Group group = EntityFactory.buildGroup(
+            ApiIamConstants.RESTRICTED_ADMIN_GROUP_NAME + " " + customerDto.getCode(),
+            generateIdentifier(SequencesConstants.GROUP_IDENTIFIER),
+            ApiIamConstants.RESTRICTED_ADMIN_GROUP_DESCRIPTION,
+            true,
+            ApiIamConstants.ADMIN_LEVEL,
+            filteredProfiles,
+            customerDto.getId()
+        );
+
+        return saveGroup(group);
     }
 
     private ExternalParametersDto initFullAccessContractExternalParameter(
@@ -512,7 +561,7 @@ public class InitCustomerService {
         return profiles;
     }
 
-    private Group createAdminGroup(final CustomerDto customerDto, final List<Profile> profiles) {
+    private void createAdminGroup(final CustomerDto customerDto, final List<Profile> profiles) {
         // Cannot affect to a group 2 profiles on the same application name for the same tenant
         // So take the first found by applicationName/Tenant pair
         final List<Profile> filteredProfiles = new ArrayList<>(
@@ -529,13 +578,13 @@ public class InitCustomerService {
         final Group group = EntityFactory.buildGroup(
             getAdminClientRootName(customerDto),
             generateIdentifier(SequencesConstants.GROUP_IDENTIFIER),
-            ApiIamConstants.ADMIN_CLIENT_ROOT,
+            ApiIamConstants.FULL_ADMIN_CLIENT_ROOT,
             true,
             ApiIamConstants.ADMIN_LEVEL,
             filteredProfiles,
             customerDto.getId()
         );
-        return saveGroup(group);
+        saveGroup(group);
     }
 
     private UserDto createAdminUser(final CustomerDto customerDto, final Group group) {
@@ -543,6 +592,7 @@ public class InitCustomerService {
         userDto.setOtp(false);
         userDto.setType(UserTypeEnum.GENERIC);
         userDto.setSubrogeable(true);
+        userDto.setReadonly(true);
         userDto.setLastname(ApiIamConstants.ADMIN_CLIENT_LASTNAME);
         userDto.setFirstname(ApiIamConstants.ADMIN_CLIENT_FIRSTNAME);
         userDto.setUserInfoId(saveUserInfo(getLanguage(customerDto)).getId());

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
@@ -277,7 +277,10 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
     protected void beforeCreate(final UserDto dto) {
         final String message = "Unable to create user " + dto.getEmail() + " (" + dto.getCustomerId() + ")";
 
-        checkSetReadonly(dto.isReadonly(), message);
+        if (UserTypeEnum.GENERIC != dto.getType()) {
+            //allow making generic users read Only
+            checkSetReadonly(dto.isReadonly(), message);
+        }
         checkCustomer(dto.getCustomerId(), message);
         checkEmail(dto.getEmail(), dto.getCustomerId(), message);
         checkGroupId(dto.getGroupId(), message);
@@ -452,11 +455,13 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
         checkCustomer(user.getCustomerId(), message);
         checkLevel(user.getLevel(), message);
 
-        checkSetReadonly(dto.isReadonly(), message);
+        if (UserTypeEnum.GENERIC != dto.getType()) {
+            //allow making generic users read Only
+            checkSetReadonly(dto.isReadonly(), message);
+        }
         if (!StringUtils.equalsIgnoreCase(user.getEmail(), dto.getEmail())) {
             checkEmail(dto.getEmail(), user.getCustomerId(), message);
         }
-        checkSetReadonly(dto.isReadonly(), message);
 
         final GroupDto groupDto = getGroupDtoById(dto.getGroupId(), message);
         checkGroup(groupDto, user.getCustomerId(), message);

--- a/api/api-iam/iam/src/main/resources/dev/customer-init.yml
+++ b/api/api-iam/iam/src/main/resources/dev/customer-init.yml
@@ -43,16 +43,33 @@ customer-init:
         - ROLE_UPDATE_MANAGEMENT_CONTRACT
         - ROLE_DELETE_MANAGEMENT_CONTRACT
 
-  #- name: profileName
-  #  description: desc
-  #  level: 1
-  #  app-name: app
-  #  roles:
-  #    - role_1
-  #    - role_2
-  #    - role_3
-  #  ...
-  # Default profiles groups for each customer created
+    # Mandatory: The profile bellow is a specific profile for each customer's generic administrator created, this profile is added to disable generic accounts creation role
+    - name: Profil restreint pour la gestion des utilisateurs
+      description: Profil de l'application de gestion restreinte des utilisateurs
+      level:
+      app-name: USERS_APP
+      roles:
+        - ROLE_GET_USERS
+        - ROLE_CREATE_USERS
+        - ROLE_UPDATE_USERS
+        - ROLE_UPDATE_STANDARD_USERS
+        - ROLE_MFA_USERS
+        - ROLE_ANONYMIZATION_USERS
+        - ROLE_GET_GROUPS
+        - ROLE_GET_USER_INFOS
+        - ROLE_CREATE_USER_INFOS
+        - ROLE_UPDATE_USER_INFOS
+
+        #- name: profileName
+        #  description: desc
+        #  level: 1
+        #  app-name: app
+        #  roles:
+        #    - role_1
+        #    - role_2
+        #    - role_3
+        #  ...
+        # Default profiles groups for each customer created
   profiles-groups:
   #- name: group1
   #   description: desc

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfigTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfigTest.java
@@ -224,7 +224,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
     public void testAfterPropertiesWithEmptyProfileNameForGroup() {
         setValidProfiles();
         customerInitConfig.setProfilesGroups(
-            List.of(new CustomerInitConfig.ProfilesGroupInitConfig("", null, null, null))
+            List.of(new CustomerInitConfig.ProfilesGroupInitConfig("", null, null, false, null))
         );
         assertThatThrownBy(customerInitConfig::afterPropertiesSet)
             .isInstanceOf(IllegalArgumentException.class)
@@ -235,7 +235,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
     public void testAfterPropertiesWithEmptyProfilesForGroup() {
         setValidProfiles();
         customerInitConfig.setProfilesGroups(
-            List.of(new CustomerInitConfig.ProfilesGroupInitConfig(GROUP_NAME_1, DESCRIPTION_2, LEVEL_2, null))
+            List.of(new CustomerInitConfig.ProfilesGroupInitConfig(GROUP_NAME_1, DESCRIPTION_2, LEVEL_2, false, null))
         );
         assertThatThrownBy(customerInitConfig::afterPropertiesSet)
             .isInstanceOf(IllegalArgumentException.class)
@@ -251,6 +251,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_3)
                 )
             )
@@ -269,6 +270,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     Arrays.asList(PROFILE_NAME_1, PROFILE_NAME_1)
                 )
             )
@@ -287,12 +289,14 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_1)
                 ),
                 new CustomerInitConfig.ProfilesGroupInitConfig(
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_1)
                 )
             )
@@ -446,6 +450,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_1)
                 )
             )

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceIntegrationTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceIntegrationTest.java
@@ -212,7 +212,7 @@ public class InitCustomerServiceIntegrationTest {
             .is(EventType.EXT_VITAMUI_CREATE_PROFILE);
         ev = eventRepository.findAll(Query.query(criteria));
         assertThat(ev).isNotEmpty();
-        assertThat(ev).hasSize(10);
+        assertThat(ev).hasSize(11);
 
         criteria = Criteria.where("obIdReq")
             .is(MongoDbCollections.GROUPS)
@@ -220,7 +220,7 @@ public class InitCustomerServiceIntegrationTest {
             .is(EventType.EXT_VITAMUI_CREATE_GROUP);
         ev = eventRepository.findAll(Query.query(criteria));
         assertThat(ev).isNotEmpty();
-        assertThat(ev).hasSize(2);
+        assertThat(ev).hasSize(3);
 
         criteria = Criteria.where("obIdReq")
             .is(MongoDbCollections.USERS)

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceTest.java
@@ -46,6 +46,8 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class InitCustomerServiceTest {
@@ -130,7 +132,8 @@ public class InitCustomerServiceTest {
         // Given
         CustomerDto customer = IamDtoBuilder.buildCustomerDto("id", "name", "code", "emailDomain");
         OwnerDto owner = IamDtoBuilder.buildOwnerDto("id", "name", "id");
-
+        CustomerInitConfig.ProfileInitConfig restrictedProfile = createRestrictedProfile();
+        when(customerInitConfig.getProfiles()).thenReturn(List.of(restrictedProfile));
         Profile profileCustomerInit1 = new Profile();
         profileCustomerInit1.setApplicationName(APP_NAME);
         profileCustomerInit1.setName(FIRST_PROFILE_ID);
@@ -161,6 +164,8 @@ public class InitCustomerServiceTest {
 
         given(groupRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0, Group.class));
 
+        ArgumentCaptor<Group> groupCaptor = ArgumentCaptor.forClass(Group.class);
+
         given(userInfoService.create(any())).willReturn(new UserInfoDto());
 
         // When
@@ -168,16 +173,48 @@ public class InitCustomerServiceTest {
 
         // Then
         ArgumentCaptor<Profile> profileCaptor = ArgumentCaptor.forClass(Profile.class);
-        Mockito.verify(profileRepository, times(7)).save(profileCaptor.capture());
+        Mockito.verify(profileRepository, times(8)).save(profileCaptor.capture());
         // Two profiles created on the same app
         Assertions.assertThat(profileCaptor.getAllValues())
             .filteredOn(profile -> profile.getApplicationName().equals(APP_NAME))
             .hasSize(2);
 
         // Only the first profile of the app in customer-init is affected to admin group
-        ArgumentCaptor<Group> groupCaptor = ArgumentCaptor.forClass(Group.class);
-        Mockito.verify(groupRepository, times(1)).save(groupCaptor.capture());
-        Assertions.assertThat(groupCaptor.getValue().getProfileIds()).contains(FIRST_PROFILE_ID);
-        Assertions.assertThat(groupCaptor.getValue().getProfileIds()).doesNotContain(SECOND_PROFILE_ID);
+
+        verify(groupRepository, times(2)).save(groupCaptor.capture());
+
+        List<Group> savedGroups = groupCaptor.getAllValues();
+
+        Group firstSavedGroup = savedGroups.get(0);
+        Group secondSavedGroup = savedGroups.get(1);
+
+        Assertions.assertThat(firstSavedGroup.getName()).startsWith("ADMIN_CLIENT_ROOT");
+        Assertions.assertThat(secondSavedGroup.getName()).startsWith("RESTRICTED_ADMIN_GROUP");
+
+        Assertions.assertThat(firstSavedGroup.getProfileIds())
+            .contains(FIRST_PROFILE_ID)
+            .doesNotContain(SECOND_PROFILE_ID);
+    }
+
+    private CustomerInitConfig.ProfileInitConfig createRestrictedProfile() {
+        CustomerInitConfig.ProfileInitConfig profile = new CustomerInitConfig.ProfileInitConfig();
+        profile.setAppName("USERS_APP");
+        profile.setName("Profil restreint pour la gestion des utilisateurs");
+        profile.setDescription("Profil restreint pour la gestion des utilisateurs");
+        profile.setRoles(
+            List.of(
+                "ROLE_GET_USERS",
+                "ROLE_CREATE_USERS",
+                "ROLE_UPDATE_USERS",
+                "ROLE_UPDATE_STANDARD_USERS",
+                "ROLE_MFA_USERS",
+                "ROLE_ANONYMIZATION_USERS",
+                "ROLE_GET_GROUPS",
+                "ROLE_GET_USER_INFOS",
+                "ROLE_CREATE_USER_INFOS",
+                "ROLE_UPDATE_USER_INFOS"
+            )
+        );
+        return profile;
     }
 }

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/CustomerCrudControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/CustomerCrudControllerTest.java
@@ -66,10 +66,13 @@ import org.springframework.http.ResponseEntity;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -233,7 +236,7 @@ public final class CustomerCrudControllerTest {
         when(tenantRepository.save(any())).thenReturn(buildTenant());
         when(userService.create(any())).thenReturn(buildUserDto());
 
-        when(groupRepository.save(any())).thenReturn(buildGroup());
+        when(groupRepository.save(any())).thenAnswer(AdditionalAnswers.returnsFirstArg());
 
         when(profileRepository.save(any())).thenAnswer(invocation -> {
             final Object[] args = invocation.getArguments();
@@ -242,6 +245,9 @@ public final class CustomerCrudControllerTest {
         when(identityProviderRepository.save(any())).thenReturn(buildIdp());
         when(profileService.getAll(any(QueryDto.class))).thenReturn(Arrays.asList(buildProfileDto()));
         when(tenantService.getDefaultProfiles(any(), any())).thenReturn(new ArrayList<>());
+        CustomerInitConfig.ProfileInitConfig restrictedProfile = createRestrictedProfile();
+
+        when(customerInitConfig.getProfiles()).thenReturn(List.of(restrictedProfile));
     }
 
     @Test
@@ -595,5 +601,27 @@ public final class CustomerCrudControllerTest {
     @AfterEach
     void tearDown() throws Exception {
         mocks.close();
+    }
+
+    private CustomerInitConfig.ProfileInitConfig createRestrictedProfile() {
+        CustomerInitConfig.ProfileInitConfig profile = new CustomerInitConfig.ProfileInitConfig();
+        profile.setAppName("USERS_APP");
+        profile.setName("Profil restreint pour la gestion des utilisateurs");
+        profile.setDescription("Profil restreint pour la gestion des utilisateurs");
+        profile.setRoles(
+            List.of(
+                "ROLE_GET_USERS",
+                "ROLE_CREATE_USERS",
+                "ROLE_UPDATE_USERS",
+                "ROLE_UPDATE_STANDARD_USERS",
+                "ROLE_MFA_USERS",
+                "ROLE_ANONYMIZATION_USERS",
+                "ROLE_GET_GROUPS",
+                "ROLE_GET_USER_INFOS",
+                "ROLE_CREATE_USER_INFOS",
+                "ROLE_UPDATE_USER_INFOS"
+            )
+        );
+        return profile;
     }
 }

--- a/api/api-iam/iam/src/test/resources/customer-init.yml
+++ b/api/api-iam/iam/src/test/resources/customer-init.yml
@@ -1,21 +1,36 @@
-
 customer-init:
   profiles:
+    # Mandatory: The profile bellow is a specific profile for each customer's generic administrator created, this profile is added to disable generic accounts creation role
+    - name: Profil restreint pour la gestion des utilisateurs
+      description: Profil restreint pour la gestion des utilisateurs
+      level:
+      app-name: USERS_APP
+      roles:
+        - ROLE_GET_USERS
+        - ROLE_CREATE_USERS
+        - ROLE_UPDATE_USERS
+        - ROLE_UPDATE_STANDARD_USERS
+        - ROLE_MFA_USERS
+        - ROLE_ANONYMIZATION_USERS
+        - ROLE_GET_GROUPS
+        - ROLE_GET_USER_INFOS
+        - ROLE_CREATE_USER_INFOS
+        - ROLE_UPDATE_USER_INFOS
     - name: profile1
       description: desc1
       level: 1
       app-name: app1
       roles:
-       - role_1
-       - role_2
-       - role_3
+        - role_1
+        - role_2
+        - role_3
     - name: profile2
       description: desc2
       level: 2
       app-name: app2
       roles:
-       - role_2
-       - role_3
+        - role_2
+        - role_3
 
   profiles-groups:
     - name: group1
@@ -37,9 +52,9 @@ customer-init:
       level: 1
       app-name: app2
       roles:
-       - role_1
-       - role_2
-       - role_3
+        - role_1
+        - role_2
+        - role_3
 
   admin-profiles:
     - name: profile4

--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -3,6 +3,23 @@
 customer-init:
   # Default profiles for each customer created
   profiles:
+    # Mandatory: The profile bellow is a specific profile for each customer's generic administrator created, this profile is added to disable generic accounts creation role
+    - name: Profil restreint pour la gestion des utilisateurs
+      description: Profil restreint pour la gestion des utilisateurs
+      level:
+      app-name: USERS_APP
+      roles:
+        - ROLE_GET_USERS
+        - ROLE_CREATE_USERS
+        - ROLE_UPDATE_USERS
+        - ROLE_UPDATE_STANDARD_USERS
+        - ROLE_MFA_USERS
+        - ROLE_ANONYMIZATION_USERS
+        - ROLE_GET_GROUPS
+        - ROLE_GET_USER_INFOS
+        - ROLE_CREATE_USER_INFOS
+        - ROLE_UPDATE_USER_INFOS
+
   #- name: profileName
   #  description: desc
   #  level: 1

--- a/deployment/scripts/mongod/v8.1/3-00_reduce_generic_admins_roles.js.j2
+++ b/deployment/scripts/mongod/v8.1/3-00_reduce_generic_admins_roles.js.j2
@@ -1,0 +1,178 @@
+print("START v8.1.3-00_reduce_generic_admins_roles.js");
+
+db = db.getSiblingDB('{{ mongodb.iam.db | default('iam') }}');
+
+// For each customer (except system_customer)
+db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (customer) {
+
+    var genericAdmin = db.getCollection('users').findOne({
+        type: 'GENERIC',
+        email: {
+            $regex: '^admin@',
+            $options: 'i'
+        },
+        customerId: customer._id
+    });
+
+    if (!genericAdmin) {
+        throw new Error(
+            "No generic admin found for customer: " + customer._id
+        );
+    }
+
+    var currentGroupForGenericAdmin = db.getCollection('groups').findOne({
+        _id: genericAdmin.groupId
+    });
+
+    if (!currentGroupForGenericAdmin) {
+        throw new Error(
+            "No group found for generic admin of customer: " + customer._id
+        );
+    }
+
+    if (
+        currentGroupForGenericAdmin?.name &&
+        !currentGroupForGenericAdmin.name.startsWith("RESTRICTED_ADMIN_GROUP") &&
+        !currentGroupForGenericAdmin.name.startsWith("ADMIN_CLIENT_ROOT")
+    ) {
+        throw new Error(
+            "Generic admin is affected to a different group than RESTRICTED_ADMIN_GROUP or ADMIN_CLIENT_ROOT"
+        );
+    }
+
+    // Update full admin group to make it read-only
+    db.groups.updateOne(
+        {
+            _id: currentGroupForGenericAdmin._id
+        },
+        {
+            $set: {
+                readonly: true
+            }
+        }
+    );
+
+    if (
+        currentGroupForGenericAdmin?.name &&
+        currentGroupForGenericAdmin.name.startsWith("ADMIN_CLIENT_ROOT")
+    ) {
+
+        // Not yet updated for this customer
+
+        // Get current sequence for profiles
+        var maxIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;
+
+        // Find the proof tenant (created by default with the customer)
+        var proofTenant = db.getCollection('tenants').findOne({
+            customerId: customer._id,
+            proof: true
+        });
+
+        // CREATE NEW PROFILES FOR APPLICATIONS:
+        // USERS_APP, ACCOUNTS_APP, GROUPS_APP, PROFILES_APP, HIERARCHY_PROFILE_APP
+
+        db.profiles.insertOne({
+            "_id": "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN",
+            "identifier": NumberInt(++maxIdProfile),
+            "name": "Profil restreint pour la gestion des utilisateurs " + proofTenant.identifier,
+            "description": "Profil de l'application de gestion restreinte des utilisateurs",
+            "tenantIdentifier": NumberInt(proofTenant.identifier),
+            "applicationName": "USERS_APP",
+            "level": "",
+            "enabled": true,
+            "readonly": false,
+            "customerId": customer._id,
+            "roles": [
+                { "name": "ROLE_GET_USERS" },
+                { "name": "ROLE_CREATE_USERS" },
+                { "name": "ROLE_UPDATE_USERS" },
+                { "name": "ROLE_UPDATE_STANDARD_USERS" },
+                { "name": "ROLE_MFA_USERS" },
+                { "name": "ROLE_ANONYMIZATION_USERS" },
+                { "name": "ROLE_GET_GROUPS" },
+                { "name": "ROLE_GET_USER_INFOS" },
+                { "name": "ROLE_CREATE_USER_INFOS" },
+                { "name": "ROLE_UPDATE_USER_INFOS" }
+            ]
+        });
+
+        // Find existing profiles in admin group for applications:
+        // ACCOUNTS_APP, GROUPS_APP, PROFILES_APP, HIERARCHY_PROFILE_APP
+        var matchingProfileIds = db.profiles.find(
+            {
+                _id: {
+                    $in: currentGroupForGenericAdmin.profileIds
+                },
+                applicationName: {
+                    $in: [
+                        "PROFILES_APP",
+                        "HIERARCHY_PROFILE_APP",
+                        "ACCOUNTS_APP",
+                        "GROUPS_APP"
+                    ]
+                }
+            },
+            {
+                _id: 1
+            }
+        ).toArray().map(function (profile) {
+            return profile._id;
+        });
+
+        //Add custom USERS_APP profile to the matchingProfileIds list
+        matchingProfileIds.push(
+            "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN"
+        );
+
+        // Get current sequence for groups
+        var maxIdGroup = db.getCollection('sequences').findOne({
+            _id: 'group_identifier'
+        }).sequence;
+
+        db.groups.insertOne({
+            _id: "RESTRICTED_ADMIN_GROUP_" + proofTenant.identifier,
+            name: "RESTRICTED_ADMIN_GROUP " + customer.code,
+            readonly: true,
+            identifier: NumberInt(++maxIdGroup),
+            description: "Groupe de profils pour l'administrateur générique",
+            profileIds: matchingProfileIds,
+            customerId: customer._id
+        });
+
+        // Update generic admin group
+        db.users.updateOne(
+            {
+                _id: genericAdmin._id
+            },
+            {
+                $set: {
+                    groupId: "RESTRICTED_ADMIN_GROUP_" + proofTenant.identifier
+                }
+            }
+        );
+
+        // Update sequences
+        db.sequences.updateOne(
+            {
+                _id: "group_identifier"
+            },
+            {
+                $set: {
+                    sequence: NumberInt(maxIdGroup)
+                }
+            }
+        );
+         db.sequences.updateOne(
+                    {
+                        _id: "profile_identifier"
+                    },
+                    {
+                        $set: {
+                            sequence: NumberInt(maxIdProfile)
+                        }
+                    }
+                );
+    }
+});
+
+print("END v8.1.3-00_reduce_generic_admins_roles.js");


### PR DESCRIPTION
## Description

L'objectif de cette PR est de créer un nouveau groupe de profiles readOnly **GENERIC_ADMIN_ROOT_GROUP** limité affecté à l'administrateur générique de chaque organisation.



## Contributeur


* VAS (Vitam Accessible en Service)