### PR TITLE
Bug #16506: Set Filebeat's default timezone to Europe/Paris for logs without timezone.

### DIFF
--- a/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
+++ b/deployment/roles/filebeat/templates/inputs/vitamui_services.yml.j2
@@ -25,6 +25,7 @@
         trim_values: all
     - timestamp:
         field: date_time
+        timezone: {{ filebeat.timezone | default('Europe/Paris') }}
         layouts:
           - '2006-01-02 15:04:05,000'
         test:
@@ -113,6 +114,7 @@
         trim_values: all
     - timestamp:
         field: date_time
+        timezone: {{ filebeat.timezone | default('Europe/Paris') }}
         layouts:
           - '2006-01-02 15:04:05,000'
         test:

--- a/deployment/roles/filebeat/templates/modules/logstash.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/logstash.yml.j2
@@ -22,6 +22,7 @@
             trim_values: all
         - timestamp:
             field: date_time
+            timezone: {{ filebeat.timezone | default('Europe/Paris') }}
             layouts:
               - '2006-01-02T15:04:05,000'
             test:


### PR DESCRIPTION
## Description

*Description des modifications*

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam