### PR TITLE
CP V8.1 - Bug #16496: limit customers generic admin profiles

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/ApiIamExternalConstants.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/ApiIamExternalConstants.java
@@ -47,6 +47,7 @@ import java.util.List;
 public final class ApiIamExternalConstants {
 
     public static final String ADMIN_CLIENT_ROOT = "ADMIN_CLIENT_ROOT";
+    public static final String FULL_ADMIN_CLIENT_ROOT = "FULL_ADMIN_CLIENT_ROOT";
 
     private static final List<String> ACCOUNT_ROLES = VitamUIUtils.listOf(ServicesData.ROLE_UPDATE_ME_USERS);
 

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/utils/EntityFactory.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/common/utils/EntityFactory.java
@@ -114,6 +114,7 @@ public final class EntityFactory {
         group.setName(name);
         group.setDescription(description);
         group.setLevel(level);
+        group.setReadonly(isReadonly);
         group.setEnabled(true);
         group.setProfileIds(profiles.stream().map(Profile::getId).collect(Collectors.toList()));
         return group;

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfig.java
@@ -169,6 +169,7 @@ public class CustomerInitConfig implements InitializingBean {
 
         private String name;
         private String description;
+        private boolean readOnly;
         private String level;
         private List<String> profiles;
 
@@ -178,10 +179,12 @@ public class CustomerInitConfig implements InitializingBean {
             final String name,
             final String description,
             final String level,
+            final boolean readOnly,
             final List<String> profiles
         ) {
             this.name = name;
             this.description = description;
+            this.readOnly = readOnly;
             this.level = level;
             this.profiles = profiles;
         }

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerService.java
@@ -99,6 +99,8 @@ import java.util.stream.Collectors;
 @Setter
 public class InitCustomerService {
 
+    public static final String GENERIC_ADMIN_ROOT_GROUP_NAME = "GENERIC_ADMIN_ROOT_GROUP";
+
     @Autowired
     private CustomerRepository customerRepository;
 
@@ -205,12 +207,27 @@ public class InitCustomerService {
         LOGGER.debug("External Parameter added into DataBase {}", fullAccessContract);
         externalParametersService.update(fullAccessContract);
 
-        final Group createdAdminGroup = createAdminGroup(customerDto, createdAdminProfiles);
-        createAdminUser(customerDto, createdAdminGroup);
+        createAdminGroup(customerDto, createdAdminProfiles);
 
         List<Profile> customProfiles = createCustomProfiles(customerDto, proofTenantDto);
 
         List<Group> customGroups = createCustomGroups(customerDto, proofTenantDto, customProfiles);
+
+        List<Group> limitedGroups = customGroups
+            .stream()
+            .filter(group -> GENERIC_ADMIN_ROOT_GROUP_NAME.equals(group.getName()))
+            .toList();
+
+        if (limitedGroups.size() != 1) {
+            throw new IllegalArgumentException(
+                "Expected exactly one group with name GENERIC_ADMIN_ROOT_GROUP, found: " + limitedGroups.size()
+            );
+        }
+
+        Group limitedGroup = limitedGroups.get(0);
+
+        createAdminUser(customerDto, limitedGroup);
+
         createCustomUsers(customerDto, customGroups);
     }
 
@@ -529,7 +546,7 @@ public class InitCustomerService {
         final Group group = EntityFactory.buildGroup(
             getAdminClientRootName(customerDto),
             generateIdentifier(SequencesConstants.GROUP_IDENTIFIER),
-            ApiIamExternalConstants.ADMIN_CLIENT_ROOT,
+            ApiIamExternalConstants.FULL_ADMIN_CLIENT_ROOT,
             true,
             ApiIamExternalConstants.ADMIN_LEVEL,
             filteredProfiles,
@@ -543,6 +560,9 @@ public class InitCustomerService {
         userDto.setOtp(false);
         userDto.setType(UserTypeEnum.GENERIC);
         userDto.setSubrogeable(true);
+        userDto.setLastname(ApiIamExternalConstants.ADMIN_CLIENT_LASTNAME);
+        userDto.setFirstname(ApiIamExternalConstants.ADMIN_CLIENT_FIRSTNAME);
+        userDto.setReadonly(true);
         userDto.setLastname(ApiIamExternalConstants.ADMIN_CLIENT_LASTNAME);
         userDto.setFirstname(ApiIamExternalConstants.ADMIN_CLIENT_FIRSTNAME);
         userDto.setUserInfoId(saveUserInfo(getLanguage(customerDto)).getId());

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
@@ -279,7 +279,10 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
     protected void beforeCreate(final UserDto dto) {
         final String message = "Unable to create user " + dto.getEmail() + " (" + dto.getCustomerId() + ")";
 
-        checkSetReadonly(dto.isReadonly(), message);
+        if (UserTypeEnum.GENERIC != dto.getType()) {
+            //allow making generic users read Only
+            checkSetReadonly(dto.isReadonly(), message);
+        }
         checkCustomer(dto.getCustomerId(), message);
         checkEmail(dto.getEmail(), dto.getCustomerId(), message);
         checkGroupId(dto.getGroupId(), message);
@@ -454,11 +457,13 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
         checkCustomer(user.getCustomerId(), message);
         checkLevel(user.getLevel(), message);
 
-        checkSetReadonly(dto.isReadonly(), message);
+        if (UserTypeEnum.GENERIC != dto.getType()) {
+            //allow making generic users read Only
+            checkSetReadonly(dto.isReadonly(), message);
+        }
         if (!StringUtils.equalsIgnoreCase(user.getEmail(), dto.getEmail())) {
             checkEmail(dto.getEmail(), user.getCustomerId(), message);
         }
-        checkSetReadonly(dto.isReadonly(), message);
 
         final GroupDto groupDto = getGroupDtoById(dto.getGroupId(), message);
         checkGroup(groupDto, user.getCustomerId(), message);

--- a/api/api-iam/iam/src/main/resources/dev/customer-init.yml
+++ b/api/api-iam/iam/src/main/resources/dev/customer-init.yml
@@ -4,6 +4,66 @@
 customer-init:
   # Default profiles for each customer created
   profiles:
+    # Mandatory: The profiles list of the generic administrator default group for each customer created
+    - name: USERS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des utilisateurs pour l'admin générique
+      app-name: USERS_APP
+      level:
+      roles:
+        - ROLE_GET_USERS
+        - ROLE_CREATE_USERS
+        - ROLE_UPDATE_USERS
+        - ROLE_UPDATE_STANDARD_USERS
+        - ROLE_MFA_USERS
+        - ROLE_ANONYMIZATION_USERS
+        - ROLE_GENERIC_USERS
+        - ROLE_GET_GROUPS
+        - ROLE_GET_USER_INFOS
+        - ROLE_CREATE_USER_INFOS
+        - ROLE_UPDATE_USER_INFOS
+
+    - name: ACCOUNTS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application Mon Compte pour l'admin générique
+      app-name: ACCOUNTS_APP
+      level:
+      roles:
+        - ROLE_UPDATE_ME_USERS
+
+    - name: GROUPS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des groupes pour l'admin générique
+      app-name: GROUPS_APP
+      level:
+      roles:
+        - ROLE_GET_GROUPS
+        - ROLE_UPDATE_GROUPS
+        - ROLE_DELETE_GROUPS
+        - ROLE_CREATE_GROUPS
+        - ROLE_GET_PROFILES_ALL_TENANTS
+        - ROLE_GET_PROFILES
+
+    - name: HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des hiérarchies de profils pour l'admin générique
+      app-name: HIERARCHY_PROFILE_APP
+      level:
+      roles:
+        - ROLE_GET_PROFILES
+        - ROLE_CREATE_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_UPDATE_ME_USERS
+        - ROLE_DELETE_PROFILES
+
+    - name: PROFILES_APP_PROFILE_GENERIC_ADMIN
+      description: APP Profil de l'application de gestion des profils utilisateurs pour l'admin générique
+      app-name: PROFILES_APP
+      level:
+      roles:
+        - ROLE_GET_PROFILES
+        - ROLE_CREATE_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_GET_GROUPS
+        - ROLE_DELETE_PROFILES
+
+    # Other profiles
     - name: Profil pour la gestion des profiles de sécurité
       description: Gestion des profiles de sécurité dans Vitam
       app-name: SECURITY_PROFILES_APP
@@ -43,23 +103,37 @@ customer-init:
         - ROLE_UPDATE_MANAGEMENT_CONTRACT
         - ROLE_DELETE_MANAGEMENT_CONTRACT
 
-  #- name: profileName
-  #  description: desc
-  #  level: 1
-  #  app-name: app
-  #  roles:
-  #    - role_1
-  #    - role_2
-  #    - role_3
-  #  ...
-  # Default profiles groups for each customer created
+        #- name: profileName
+        #  description: desc
+        #  level: 1
+        #  app-name: app
+        #  roles:
+        #    - role_1
+        #    - role_2
+        #    - role_3
+        #  ...
+        # Default profiles groups for each customer created
   profiles-groups:
-  #- name: group1
-  #   description: desc
-  #   level: 2
-  #   profiles:
-  #     - profileName
-  #  ...
+    #- name: group1
+    #   description: desc
+    #   readOnly: true
+    #   level: 2
+    #   profiles:
+    #     - profileName
+    #  ...
+
+    # Mandatory: The default group configuration of generic administrator for each customer created, it should be named GENERIC_ADMIN_ROOT_GROUP
+    - name: GENERIC_ADMIN_ROOT_GROUP
+      description: desc
+      level:
+      readOnly: true
+      profiles:
+        - PROFILES_APP_PROFILE_GENERIC_ADMIN
+        - HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN
+        - GROUPS_APP_PROFILE_GENERIC_ADMIN
+        - ACCOUNTS_APP_PROFILE_GENERIC_ADMIN
+        - USERS_APP_PROFILE_GENERIC_ADMIN
+
   # Default users for each customer created
   users:
   #- last-name: lastName

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfigTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/config/CustomerInitConfigTest.java
@@ -227,7 +227,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
     public void testAfterPropertiesWithEmptyProfileNameForGroup() {
         setValidProfiles();
         customerInitConfig.setProfilesGroups(
-            List.of(new CustomerInitConfig.ProfilesGroupInitConfig("", null, null, null))
+            List.of(new CustomerInitConfig.ProfilesGroupInitConfig("", null, null, false, null))
         );
         assertThatThrownBy(customerInitConfig::afterPropertiesSet)
             .isInstanceOf(IllegalArgumentException.class)
@@ -238,7 +238,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
     public void testAfterPropertiesWithEmptyProfilesForGroup() {
         setValidProfiles();
         customerInitConfig.setProfilesGroups(
-            List.of(new CustomerInitConfig.ProfilesGroupInitConfig(GROUP_NAME_1, DESCRIPTION_2, LEVEL_2, null))
+            List.of(new CustomerInitConfig.ProfilesGroupInitConfig(GROUP_NAME_1, DESCRIPTION_2, LEVEL_2, false, null))
         );
         assertThatThrownBy(customerInitConfig::afterPropertiesSet)
             .isInstanceOf(IllegalArgumentException.class)
@@ -254,6 +254,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_3)
                 )
             )
@@ -272,6 +273,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     Arrays.asList(PROFILE_NAME_1, PROFILE_NAME_1)
                 )
             )
@@ -290,12 +292,14 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_1)
                 ),
                 new CustomerInitConfig.ProfilesGroupInitConfig(
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_1)
                 )
             )
@@ -449,6 +453,7 @@ public class CustomerInitConfigTest extends AbstractMongoTests {
                     GROUP_NAME_1,
                     DESCRIPTION_2,
                     LEVEL_2,
+                    false,
                     List.of(PROFILE_NAME_1)
                 )
             )

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceIntegrationTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceIntegrationTest.java
@@ -215,7 +215,7 @@ public class InitCustomerServiceIntegrationTest {
             .is(EventType.EXT_VITAMUI_CREATE_PROFILE);
         ev = eventRepository.findAll(Query.query(criteria));
         assertThat(ev).isNotEmpty();
-        assertThat(ev).hasSize(10);
+        assertThat(ev).hasSize(15);
 
         criteria = Criteria.where("obIdReq")
             .is(MongoDbCollections.GROUPS)
@@ -223,7 +223,7 @@ public class InitCustomerServiceIntegrationTest {
             .is(EventType.EXT_VITAMUI_CREATE_GROUP);
         ev = eventRepository.findAll(Query.query(criteria));
         assertThat(ev).isNotEmpty();
-        assertThat(ev).hasSize(2);
+        assertThat(ev).hasSize(3);
 
         criteria = Criteria.where("obIdReq")
             .is(MongoDbCollections.USERS)

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/customer/service/InitCustomerServiceTest.java
@@ -161,6 +161,12 @@ public class InitCustomerServiceTest {
 
         given(groupRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0, Group.class));
 
+        CustomerInitConfig.ProfilesGroupInitConfig profileGroup = new CustomerInitConfig.ProfilesGroupInitConfig();
+        profileGroup.setName(InitCustomerService.GENERIC_ADMIN_ROOT_GROUP_NAME);
+        profileGroup.setProfiles(List.of(FIRST_PROFILE_ID));
+        given(customerInitConfig.getProfilesGroups()).willReturn(List.of(profileGroup));
+        given(customerInitConfig.getUsers()).willReturn(new ArrayList<>());
+
         given(userInfoService.create(any())).willReturn(new UserInfoDto());
 
         // When
@@ -176,8 +182,14 @@ public class InitCustomerServiceTest {
 
         // Only the first profile of the app in customer-init is affected to admin group
         ArgumentCaptor<Group> groupCaptor = ArgumentCaptor.forClass(Group.class);
-        Mockito.verify(groupRepository, times(1)).save(groupCaptor.capture());
-        Assertions.assertThat(groupCaptor.getValue().getProfileIds()).contains(FIRST_PROFILE_ID);
-        Assertions.assertThat(groupCaptor.getValue().getProfileIds()).doesNotContain(SECOND_PROFILE_ID);
+        Mockito.verify(groupRepository, times(2)).save(groupCaptor.capture());
+        Group adminGroup = groupCaptor
+            .getAllValues()
+            .stream()
+            .filter(g -> g.getName().equals(initCustomerService.getAdminClientRootName(customer)))
+            .findFirst()
+            .get();
+        Assertions.assertThat(adminGroup.getProfileIds()).contains(FIRST_PROFILE_ID);
+        Assertions.assertThat(adminGroup.getProfileIds()).doesNotContain(SECOND_PROFILE_ID);
     }
 }

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/CustomerCrudControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/CustomerCrudControllerTest.java
@@ -65,6 +65,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -231,7 +232,7 @@ public final class CustomerCrudControllerTest {
         when(tenantRepository.save(any())).thenReturn(buildTenant());
         when(userService.create(any())).thenReturn(buildUserDto());
 
-        when(groupRepository.save(any())).thenReturn(buildGroup());
+        when(groupRepository.save(any())).thenAnswer(AdditionalAnswers.returnsFirstArg());
 
         when(profileRepository.save(any())).thenAnswer(invocation -> {
             final Object[] args = invocation.getArguments();
@@ -240,6 +241,12 @@ public final class CustomerCrudControllerTest {
         when(identityProviderRepository.save(any())).thenReturn(buildIdp());
         when(profileService.getAll(any(QueryDto.class))).thenReturn(Arrays.asList(buildProfileDto()));
         when(tenantService.getDefaultProfiles(any(), any())).thenReturn(new ArrayList<>());
+
+        CustomerInitConfig.ProfilesGroupInitConfig profileGroup = new CustomerInitConfig.ProfilesGroupInitConfig();
+        profileGroup.setName(InitCustomerService.GENERIC_ADMIN_ROOT_GROUP_NAME);
+        profileGroup.setProfiles(List.of("profileName"));
+        when(customerInitConfig.getProfilesGroups()).thenReturn(List.of(profileGroup));
+        when(customerInitConfig.getUsers()).thenReturn(new ArrayList<>());
     }
 
     @Test
@@ -386,6 +393,7 @@ public final class CustomerCrudControllerTest {
         when(groupRepository.save(any())).thenThrow(new InternalServerException("Group Creation error"));
 
         customerController.create(buildCustomerData(customerDto));
+        fail("should fail");
         fail("should fail");
     }
 

--- a/api/api-iam/iam/src/test/resources/customer-init.yml
+++ b/api/api-iam/iam/src/test/resources/customer-init.yml
@@ -1,4 +1,3 @@
-
 customer-init:
   profiles:
     - name: profile1
@@ -6,16 +5,74 @@ customer-init:
       level: 1
       app-name: app1
       roles:
-       - role_1
-       - role_2
-       - role_3
+        - role_1
+        - role_2
+        - role_3
     - name: profile2
       description: desc2
       level: 2
       app-name: app2
       roles:
-       - role_2
-       - role_3
+        - role_2
+        - role_3
+    - name: USERS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des utilisateurs pour l'admin générique
+      app-name: USERS_APP
+      level:
+      roles:
+        - ROLE_GET_USERS
+        - ROLE_CREATE_USERS
+        - ROLE_UPDATE_USERS
+        - ROLE_UPDATE_STANDARD_USERS
+        - ROLE_MFA_USERS
+        - ROLE_ANONYMIZATION_USERS
+        - ROLE_GENERIC_USERS
+        - ROLE_GET_GROUPS
+        - ROLE_GET_USER_INFOS
+        - ROLE_CREATE_USER_INFOS
+        - ROLE_UPDATE_USER_INFOS
+
+
+    - name: ACCOUNTS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application Mon Compte pour l'admin générique
+      app-name: ACCOUNTS_APP
+      level:
+      roles:
+        - ROLE_UPDATE_ME_USERS
+
+    - name: GROUPS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des groupes pour l'admin générique
+      app-name: GROUPS_APP
+      level:
+      roles:
+        - ROLE_GET_GROUPS
+        - ROLE_UPDATE_GROUPS
+        - ROLE_DELETE_GROUPS
+        - ROLE_CREATE_GROUPS
+        - ROLE_GET_PROFILES_ALL_TENANTS
+        - ROLE_GET_PROFILES
+
+    - name: HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des hiérarchies de profils pour l'admin générique
+      app-name: HIERARCHY_PROFILE_APP
+      level:
+      roles:
+        - ROLE_GET_PROFILES
+        - ROLE_CREATE_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_UPDATE_ME_USERS
+        - ROLE_DELETE_PROFILES
+
+    - name: PROFILES_APP_PROFILE_GENERIC_ADMIN
+      description: APP Profil de l'application de gestion des profils utilisateurs pour l'admin générique
+      app-name: PROFILES_APP
+      level:
+      roles:
+        - ROLE_GET_PROFILES
+        - ROLE_CREATE_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_GET_GROUPS
+        - ROLE_DELETE_PROFILES
 
   profiles-groups:
     - name: group1
@@ -24,6 +81,16 @@ customer-init:
       profiles:
         - profile1
 
+    - name: GENERIC_ADMIN_ROOT_GROUP  # default group to create for customers generic admin
+      description: desc
+      level:
+      readOnly: true
+      profiles:
+        - PROFILES_APP_PROFILE_GENERIC_ADMIN
+        - HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN
+        - GROUPS_APP_PROFILE_GENERIC_ADMIN
+        - ACCOUNTS_APP_PROFILE_GENERIC_ADMIN
+        - USERS_APP_PROFILE_GENERIC_ADMIN
   users:
     - last-name: lastName
       first-name: firstName
@@ -37,9 +104,9 @@ customer-init:
       level: 1
       app-name: app2
       roles:
-       - role_1
-       - role_2
-       - role_3
+        - role_1
+        - role_2
+        - role_3
 
   admin-profiles:
     - name: profile4

--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -3,6 +3,64 @@
 customer-init:
   # Default profiles for each customer created
   profiles:
+    # Mandatory: The profiles list of the generic administrator default group for each customer created
+    - name: USERS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des utilisateurs pour l'admin générique
+      app-name: USERS_APP
+      level:
+      roles:
+        - ROLE_GET_USERS
+        - ROLE_CREATE_USERS
+        - ROLE_UPDATE_USERS
+        - ROLE_UPDATE_STANDARD_USERS
+        - ROLE_MFA_USERS
+        - ROLE_ANONYMIZATION_USERS
+        - ROLE_GENERIC_USERS
+        - ROLE_GET_GROUPS
+        - ROLE_GET_USER_INFOS
+        - ROLE_CREATE_USER_INFOS
+        - ROLE_UPDATE_USER_INFOS
+
+    - name: ACCOUNTS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application Mon Compte pour l'admin générique
+      app-name: ACCOUNTS_APP
+      level:
+      roles:
+        - ROLE_UPDATE_ME_USERS
+
+    - name: GROUPS_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des groupes pour l'admin générique
+      app-name: GROUPS_APP
+      level:
+      roles:
+        - ROLE_GET_GROUPS
+        - ROLE_UPDATE_GROUPS
+        - ROLE_DELETE_GROUPS
+        - ROLE_CREATE_GROUPS
+        - ROLE_GET_PROFILES_ALL_TENANTS
+        - ROLE_GET_PROFILES
+
+    - name: HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN
+      description: Profil de l'application de gestion des hiérarchies de profils pour l'admin générique
+      app-name: HIERARCHY_PROFILE_APP
+      level:
+      roles:
+        - ROLE_GET_PROFILES
+        - ROLE_CREATE_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_UPDATE_ME_USERS
+        - ROLE_DELETE_PROFILES
+
+    - name: PROFILES_APP_PROFILE_GENERIC_ADMIN
+      description: APP Profil de l'application de gestion des profils utilisateurs pour l'admin générique
+      app-name: PROFILES_APP
+      level:
+      roles:
+        - ROLE_GET_PROFILES
+        - ROLE_CREATE_PROFILES
+        - ROLE_UPDATE_PROFILES
+        - ROLE_GET_GROUPS
+        - ROLE_DELETE_PROFILES
   #- name: profileName
   #  description: desc
   #  level: 1
@@ -14,9 +72,21 @@ customer-init:
   #  ...
   # Default profiles groups for each customer created
   profiles-groups:
+    # Mandatory: The default group configuration of generic administrator for each customer created, it should be named GENERIC_ADMIN_ROOT_GROUP
+    - name: GENERIC_ADMIN_ROOT_GROUP
+      description: Profil par défaut de l'administrateur générique de l'organisation
+      level:
+      readOnly: true
+      profiles:
+        - PROFILES_APP_PROFILE_GENERIC_ADMIN
+        - HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN
+        - GROUPS_APP_PROFILE_GENERIC_ADMIN
+        - ACCOUNTS_APP_PROFILE_GENERIC_ADMIN
+        - USERS_APP_PROFILE_GENERIC_ADMIN
   #- name: group1
   #   description: desc
   #   level: 2
+  #   readOnly: true
   #   profiles:
   #     - profileName
   #  ...

--- a/deployment/scripts/mongod/v8.1/3-00_reduce_generic_admins_roles.js.j2
+++ b/deployment/scripts/mongod/v8.1/3-00_reduce_generic_admins_roles.js.j2
@@ -1,0 +1,181 @@
+print("START v8.1.3-00_reduce_generic_admins_roles.js");
+
+db = db.getSiblingDB('{{ mongodb.iam.db | default('iam') }}');
+
+// For each customer (except system_customer)
+db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (customer) {
+
+    var genericAdmin = db.getCollection('users').findOne({
+        'firstname': 'Admin',
+        'lastname': 'ADMIN',
+        'type': 'GENERIC',
+        'customerId': customer._id
+    });
+
+    if (!genericAdmin) {
+        print("No generic admin found for customer: " + customer._id);
+        return;
+    }
+
+    var currentGroupForGenericAdmin = db.getCollection('groups').findOne({ '_id': genericAdmin.groupId });
+
+    if (!currentGroupForGenericAdmin) {
+        print("No group found for generic admin of customer: " + customer._id);
+        return;
+    }
+
+    if (currentGroupForGenericAdmin.name != "GENERIC_ADMIN_ROOT_GROUP") {
+        // Not yet updated for this customer
+
+        // Find the proof tenant, by default is the first tenant on creating customer
+        var proofTenant = db.getCollection('tenants').findOne({
+            "customerId": customer._id,
+            "proof": true
+        });
+
+        // Get current sequence for profiles
+        var maxIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;
+
+        // CREATE NEW PROFILES FOR APPLICATIONS:
+        // USERS_APP, ACCOUNTS_APP, GROUPS_APP, PROFILES_APP, HIERARCHY_PROFILE_APP
+
+        db.profiles.insertOne({
+            "_id": "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN",
+            "identifier": NumberInt(maxIdProfile++),
+            "name": "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN",
+            "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
+            "tenantIdentifier": NumberInt(proofTenant.identifier),
+            "applicationName": "USERS_APP",
+            "level": "",
+            "enabled": true,
+            "readonly": false,
+            "customerId": customer._id,
+            "roles": [
+                { "name": "ROLE_GET_USERS" },
+                { "name": "ROLE_CREATE_USERS" },
+                { "name": "ROLE_UPDATE_USERS" },
+                { "name": "ROLE_UPDATE_STANDARD_USERS" },
+                { "name": "ROLE_MFA_USERS" },
+                { "name": "ROLE_ANONYMIZATION_USERS" },
+                { "name": "ROLE_GENERIC_USERS" },
+                { "name": "ROLE_GET_GROUPS" },
+                { "name": "ROLE_GET_USER_INFOS" },
+                { "name": "ROLE_CREATE_USER_INFOS" },
+                { "name": "ROLE_UPDATE_USER_INFOS" }
+            ]
+        });
+
+        db.profiles.insertOne({
+            "_id": "PROFIL_" + proofTenant.identifier + "-ACCOUNTS_APP_PROFILE_GENERIC_ADMIN",
+            "identifier": NumberInt(maxIdProfile++),
+            "name": "PROFIL_" + proofTenant.identifier + "-ACCOUNTS_APP_PROFILE_GENERIC_ADMIN",
+            "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
+            "tenantIdentifier": NumberInt(proofTenant.identifier),
+            "applicationName": "ACCOUNTS_APP",
+            "level": "",
+            "enabled": true,
+            "readonly": false,
+            "customerId": customer._id,
+            "roles": [
+                { "name": "ROLE_UPDATE_ME_USERS" }
+            ]
+        });
+
+        db.profiles.insertOne({
+            "_id": "PROFIL_" + proofTenant.identifier + "-GROUPS_APP_PROFILE_GENERIC_ADMIN",
+            "identifier": NumberInt(maxIdProfile++),
+            "name": "PROFIL_" + proofTenant.identifier + "-GROUPS_APP_PROFILE_GENERIC_ADMIN",
+            "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
+            "tenantIdentifier": NumberInt(proofTenant.identifier),
+            "applicationName": "GROUPS_APP",
+            "level": "",
+            "enabled": true,
+            "readonly": false,
+            "customerId": customer._id,
+            "roles": [
+                { "name": "ROLE_GET_GROUPS" },
+                { "name": "ROLE_UPDATE_GROUPS" },
+                { "name": "ROLE_DELETE_GROUPS" },
+                { "name": "ROLE_CREATE_GROUPS" },
+                { "name": "ROLE_GET_PROFILES_ALL_TENANTS" },
+                { "name": "ROLE_GET_PROFILES" }
+            ]
+        });
+
+        db.profiles.insertOne({
+            "_id": "PROFIL_" + proofTenant.identifier + "-HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN",
+            "identifier": NumberInt(maxIdProfile++),
+            "name": "PROFIL_" + proofTenant.identifier + "-HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN",
+            "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
+            "tenantIdentifier": NumberInt(proofTenant.identifier),
+            "applicationName": "HIERARCHY_PROFILE_APP",
+            "level": "",
+            "enabled": true,
+            "readonly": false,
+            "customerId": customer._id,
+            "roles": [
+                { "name": "ROLE_GET_PROFILES" },
+                { "name": "ROLE_CREATE_PROFILES" },
+                { "name": "ROLE_UPDATE_PROFILES" },
+                { "name": "ROLE_UPDATE_ME_USERS" },
+                { "name": "ROLE_DELETE_PROFILES" }
+            ]
+        });
+
+        db.profiles.insertOne({
+            "_id": "PROFIL_" + proofTenant.identifier + "-PROFILES_APP_PROFILE_GENERIC_ADMIN",
+            "identifier": NumberInt(maxIdProfile++),
+            "name": "PROFIL_" + proofTenant.identifier + "-PROFILES_APP_PROFILE_GENERIC_ADMIN",
+            "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
+            "tenantIdentifier": NumberInt(proofTenant.identifier),
+            "applicationName": "PROFILES_APP",
+            "level": "",
+            "enabled": true,
+            "readonly": false,
+            "customerId": customer._id,
+            "roles": [
+                { "name": "ROLE_GET_PROFILES" },
+                { "name": "ROLE_CREATE_PROFILES" },
+                { "name": "ROLE_UPDATE_PROFILES" },
+                { "name": "ROLE_GET_GROUPS" },
+                { "name": "ROLE_DELETE_PROFILES" }
+            ]
+        });
+
+        db.groups.insertOne({
+            "_id": "GENERIC_ADMIN_ROOT_GROUP_" + proofTenant.identifier,
+            "name": "GENERIC_ADMIN_ROOT_GROUP",
+            "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
+            "profileIds": [
+                "PROFIL_" + proofTenant.identifier + "-PROFILES_APP_PROFILE_GENERIC_ADMIN",
+                "PROFIL_" + proofTenant.identifier + "-HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN",
+                "PROFIL_" + proofTenant.identifier + "-GROUPS_APP_PROFILE_GENERIC_ADMIN",
+                "PROFIL_" + proofTenant.identifier + "-ACCOUNTS_APP_PROFILE_GENERIC_ADMIN",
+                "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN"
+            ],
+            "customerId": customer._id
+        });
+
+        // Update genericAdmin's group
+        db.users.updateOne(
+            { "_id": genericAdmin._id },
+            {
+                $set: {
+                    "groupId": "GENERIC_ADMIN_ROOT_GROUP_" + proofTenant.identifier
+                }
+            }
+        );
+
+        // Update sequence
+        db.sequences.updateOne(
+            { "_id": "profile_identifier" },
+            {
+                $set: {
+                    "sequence": NumberInt(maxIdProfile)
+                }
+            }
+        );
+    }
+});
+
+print("END v8.1.3-00_reduce_generic_admins_roles.js");

--- a/deployment/scripts/mongod/v8.1/3-00_reduce_generic_admins_roles.js.j2
+++ b/deployment/scripts/mongod/v8.1/3-00_reduce_generic_admins_roles.js.j2
@@ -4,25 +4,36 @@ db = db.getSiblingDB('{{ mongodb.iam.db | default('iam') }}');
 
 // For each customer (except system_customer)
 db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (customer) {
-
     var genericAdmin = db.getCollection('users').findOne({
-        'firstname': 'Admin',
-        'lastname': 'ADMIN',
         'type': 'GENERIC',
+        'email': {
+            '$regex': '^admin@',
+            '$options': 'i'
+        },
         'customerId': customer._id
     });
 
     if (!genericAdmin) {
-        print("No generic admin found for customer: " + customer._id);
-        return;
+        throw new Error("No generic admin found for customer: " + customer._id);
     }
 
-    var currentGroupForGenericAdmin = db.getCollection('groups').findOne({ '_id': genericAdmin.groupId });
+    var currentGroupForGenericAdmin = db.getCollection('groups').findOne({
+        '_id': genericAdmin.groupId
+    });
 
     if (!currentGroupForGenericAdmin) {
-        print("No group found for generic admin of customer: " + customer._id);
-        return;
+        throw new Error("No group found for generic admin of customer: " + customer._id);
     }
+
+    //Update full admin group to make it readOnly
+    db.groups.updateOne(
+        { "_id": currentGroupForGenericAdmin._id },
+        {
+            $set: {
+                "readonly": true
+            }
+        }
+    );
 
     if (currentGroupForGenericAdmin.name != "GENERIC_ADMIN_ROOT_GROUP") {
         // Not yet updated for this customer
@@ -34,14 +45,21 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
         });
 
         // Get current sequence for profiles
-        var maxIdProfile = db.getCollection('sequences').findOne({ '_id': 'profile_identifier' }).sequence;
+        var maxIdProfile = db.getCollection('sequences').findOne({
+            '_id': 'profile_identifier'
+        }).sequence;
+
+        // Get current sequence for groups
+        var maxIdGroup = db.getCollection('sequences').findOne({
+            '_id': 'group_identifier'
+        }).sequence;
 
         // CREATE NEW PROFILES FOR APPLICATIONS:
         // USERS_APP, ACCOUNTS_APP, GROUPS_APP, PROFILES_APP, HIERARCHY_PROFILE_APP
 
         db.profiles.insertOne({
             "_id": "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN",
-            "identifier": NumberInt(maxIdProfile++),
+            "identifier": NumberInt(++maxIdProfile),
             "name": "PROFIL_" + proofTenant.identifier + "-USERS_APP_PROFILE_GENERIC_ADMIN",
             "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
             "tenantIdentifier": NumberInt(proofTenant.identifier),
@@ -67,7 +85,7 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
 
         db.profiles.insertOne({
             "_id": "PROFIL_" + proofTenant.identifier + "-ACCOUNTS_APP_PROFILE_GENERIC_ADMIN",
-            "identifier": NumberInt(maxIdProfile++),
+            "identifier": NumberInt(++maxIdProfile),
             "name": "PROFIL_" + proofTenant.identifier + "-ACCOUNTS_APP_PROFILE_GENERIC_ADMIN",
             "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
             "tenantIdentifier": NumberInt(proofTenant.identifier),
@@ -83,7 +101,7 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
 
         db.profiles.insertOne({
             "_id": "PROFIL_" + proofTenant.identifier + "-GROUPS_APP_PROFILE_GENERIC_ADMIN",
-            "identifier": NumberInt(maxIdProfile++),
+            "identifier": NumberInt(++maxIdProfile),
             "name": "PROFIL_" + proofTenant.identifier + "-GROUPS_APP_PROFILE_GENERIC_ADMIN",
             "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
             "tenantIdentifier": NumberInt(proofTenant.identifier),
@@ -104,7 +122,7 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
 
         db.profiles.insertOne({
             "_id": "PROFIL_" + proofTenant.identifier + "-HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN",
-            "identifier": NumberInt(maxIdProfile++),
+            "identifier": NumberInt(++maxIdProfile),
             "name": "PROFIL_" + proofTenant.identifier + "-HIERARCHY_PROFILE_APP_PROFILE_GENERIC_ADMIN",
             "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
             "tenantIdentifier": NumberInt(proofTenant.identifier),
@@ -124,7 +142,7 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
 
         db.profiles.insertOne({
             "_id": "PROFIL_" + proofTenant.identifier + "-PROFILES_APP_PROFILE_GENERIC_ADMIN",
-            "identifier": NumberInt(maxIdProfile++),
+            "identifier": NumberInt(++maxIdProfile),
             "name": "PROFIL_" + proofTenant.identifier + "-PROFILES_APP_PROFILE_GENERIC_ADMIN",
             "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
             "tenantIdentifier": NumberInt(proofTenant.identifier),
@@ -145,6 +163,8 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
         db.groups.insertOne({
             "_id": "GENERIC_ADMIN_ROOT_GROUP_" + proofTenant.identifier,
             "name": "GENERIC_ADMIN_ROOT_GROUP",
+            "readonly": true,
+            "identifier": NumberInt(++maxIdGroup),
             "description": "Profil de l'application de gestion des utilisateurs pour l'admin générique",
             "profileIds": [
                 "PROFIL_" + proofTenant.identifier + "-PROFILES_APP_PROFILE_GENERIC_ADMIN",
@@ -166,12 +186,21 @@ db.customers.find({ "_id": { $ne: "system_customer" } }).forEach(function (custo
             }
         );
 
-        // Update sequence
+        // Update sequences
         db.sequences.updateOne(
             { "_id": "profile_identifier" },
             {
                 $set: {
                     "sequence": NumberInt(maxIdProfile)
+                }
+            }
+        );
+
+        db.sequences.updateOne(
+            { "_id": "group_identifier" },
+            {
+                $set: {
+                    "sequence": NumberInt(maxIdGroup)
                 }
             }
         );


### PR DESCRIPTION
## Description

L'objectif de cette PR est de créer un nouveau groupe de profiles readOnly **GENERIC_ADMIN_ROOT_GROUP** limité affecté à l'administrateur générique de chaque organisation.



## Contributeur


* VAS (Vitam Accessible en Service)