### PR TITLE
Bug #16506: Updating filebeat's timezone for nginx error logs.

### DIFF
--- a/deployment/roles/filebeat/templates/modules/apache.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/apache.yml.j2
@@ -83,6 +83,7 @@
               }
         - timestamp:
             field: date_time
+            timezone: {{ filebeat.timezone | default('Europe/Paris') }}
             layouts:
               - 'Mon Jan 02 15:04:05.000000 2006'
             test:

--- a/deployment/roles/filebeat/templates/modules/nginx.yml.j2
+++ b/deployment/roles/filebeat/templates/modules/nginx.yml.j2
@@ -85,6 +85,7 @@
               }
         - timestamp:
             field: date_time
+            timezone: {{ filebeat.timezone | default('Europe/Paris') }}
             layouts:
               - '2006/01/02 15:04:05'
             test:


### PR DESCRIPTION
## Description

Missing timezone for nginx's error logs.

## Type de changement

* Ansiblerie
* Correction

## Contributeur

* Programme Vitam