### PR TITLE
Bug #15010: Secure ApplicationController.getApplicationsFromUi

### DIFF
--- a/api/api-iam/iam-client/src/main/resources/swagger.yaml
+++ b/api/api-iam/iam-client/src/main/resources/swagger.yaml
@@ -2634,12 +2634,6 @@ paths:
                   schema:
                       type: string
                       example: null
-                - name: embedded
-                  in: query
-                  required: false
-                  schema:
-                      type: string
-                      example: null
             responses:
                 "200":
                     description: OK
@@ -2650,6 +2644,23 @@ paths:
                                 example: null
                                 items:
                                     $ref: "#/components/schemas/ApplicationDto"
+                            example: null
+    /iam/v1/applications/listNames:
+        get:
+            tags:
+                - Applications
+            summary: Return all application names
+            operationId: applications_listNames
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*':
+                            schema:
+                                type: array
+                                example: null
+                                items:
+                                    $ref: "#/components/schemas/IdentifierNameDto"
                             example: null
     /iam/v1/applications/{identifier}/externalid:
         get:
@@ -2671,34 +2682,6 @@ paths:
                         '*/*':
                             schema:
                                 type: boolean
-                                example: null
-                            example: null
-    /iam/v1/applications/filtered:
-        get:
-            tags:
-                - Applications
-            summary: Return config about applications and categories
-            operationId: applications_getApplicationsFromUi
-            parameters:
-                - name: filterApp
-                  in: query
-                  required: false
-                  schema:
-                      type: boolean
-                      example: null
-                      default: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        '*/*':
-                            schema:
-                                type: object
-                                additionalProperties:
-                                    type: array
-                                    example: null
-                                    items:
-                                        $ref: "#/components/schemas/ApplicationDto"
                                 example: null
                             example: null
     /autotest:
@@ -4314,6 +4297,23 @@ components:
                     example: null
                 target:
                     maxLength: 25
+                    minLength: 0
+                    type: string
+                    example: null
+            example: null
+        IdentifierNameDto:
+            required:
+                - identifier
+                - name
+            type: object
+            properties:
+                identifier:
+                    maxLength: 100
+                    minLength: 1
+                    type: string
+                    example: null
+                name:
+                    maxLength: 50
                     minLength: 0
                     type: string
                     example: null

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/application/service/ApplicationService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/application/service/ApplicationService.java
@@ -36,16 +36,11 @@
  */
 package fr.gouv.vitamui.iam.server.application.service;
 
-import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.converter.Converter;
 import fr.gouv.vitamui.commons.api.domain.ApplicationDto;
-import fr.gouv.vitamui.commons.api.domain.Criterion;
-import fr.gouv.vitamui.commons.api.domain.CriterionOperator;
-import fr.gouv.vitamui.commons.api.domain.QueryDto;
-import fr.gouv.vitamui.commons.api.domain.QueryOperator;
+import fr.gouv.vitamui.commons.api.domain.IdentifierNameDto;
 import fr.gouv.vitamui.commons.api.domain.TenantInformationDto;
 import fr.gouv.vitamui.commons.api.exception.UnAuthorizedException;
-import fr.gouv.vitamui.commons.api.utils.CriteriaUtils;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.security.client.dto.AuthUserDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
@@ -55,7 +50,6 @@ import fr.gouv.vitamui.iam.server.application.domain.Application;
 import fr.gouv.vitamui.iam.server.security.AbstractResourceClientService;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +59,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -108,41 +101,20 @@ public class ApplicationService extends AbstractResourceClientService<Applicatio
     /**
      * {@inheritDoc}
      */
-    @Override
-    public List<ApplicationDto> getAll(Optional<String> criteria, Optional<String> embedded) {
-        Boolean filterApp = true;
-
-        if (criteria.isPresent()) {
-            final QueryDto queryDto = QueryDto.fromJson(criteria);
-            List<Criterion> criterions = queryDto.getCriterionList();
-            Optional<Criterion> findFilterApp = criterions
-                .stream()
-                .filter(criterion -> "filterApp".equals(criterion.getKey()))
-                .findFirst();
-
-            if (findFilterApp.isPresent()) {
-                Criterion filterAppCriterion = findFilterApp.get();
-                filterApp = (Boolean) filterAppCriterion.getValue();
-
-                criterions.remove(filterAppCriterion);
-                criteria = Optional.of(CriteriaUtils.toJson(queryDto));
-            }
-        }
-
-        List<ApplicationDto> apps = super.getAll(criteria, embedded);
-        if (filterApp) {
-            filterApp(apps);
-        }
-        return apps;
+    public List<ApplicationDto> getAllFilteredByUser(Optional<String> criteria) {
+        List<ApplicationDto> apps = super.getAll(criteria);
+        return filterApp(apps); // Apps are filtered depending on user permissions
     }
 
-    public Map<String, List<ApplicationDto>> getApplications(final boolean filterApp) {
-        QueryDto query = new QueryDto(QueryOperator.AND);
-        query.addCriterion(new Criterion("filterApp", filterApp, CriterionOperator.EQUALS));
-        List<ApplicationDto> applications = getAll(Optional.of(query.toJson()), Optional.empty());
-        Map<String, List<ApplicationDto>> portalConfig = new HashMap<>();
-        portalConfig.put(CommonConstants.APPLICATION_CONFIGURATION, applications);
-        return portalConfig;
+    /**
+     * Returns all applications names and identifiers, without filtering on user permissions (useful to have a list of all applications without leaking secured information)
+     * @return unfiltered application list, but only with their identifier and name
+     */
+    public List<IdentifierNameDto> listNames() {
+        return super.getAll(Optional.empty())
+            .stream()
+            .map(app -> new IdentifierNameDto(app.getIdentifier(), app.getName()))
+            .toList();
     }
 
     public boolean isApplicationExternalIdentifierEnabled(String applicationId) {
@@ -157,20 +129,21 @@ public class ApplicationService extends AbstractResourceClientService<Applicatio
 
     /**
      * Filter application for logger user permission
+     *
      * @param apps initial app list
+     * @return filtered application list
      */
-    private void filterApp(final Collection<ApplicationDto> apps) {
-        final AuthUserDto user = securityService.getUser();
-        if (user == null) {
-            throw new UnAuthorizedException("No authenticated user");
-        }
-        List<TenantInformationDto> tenantsByApp = user.getTenantsByApp();
-        if (CollectionUtils.isEmpty(user.getTenantsByApp())) {
-            tenantsByApp = new ArrayList<>();
-        }
-        final Collection<String> filter = tenantsByApp.stream().map(p -> p.getName()).collect(Collectors.toList());
-        final Predicate<ApplicationDto> predicate = a -> !filter.contains(a.getIdentifier());
-        apps.removeIf(predicate);
+    private List<ApplicationDto> filterApp(final Collection<ApplicationDto> apps) {
+        final AuthUserDto user = Optional.ofNullable(securityService.getUser()).orElseThrow(
+            () -> new UnAuthorizedException("No authenticated user")
+        );
+        final List<TenantInformationDto> tenantsByApp = Optional.ofNullable(user.getTenantsByApp()).orElse(
+            new ArrayList<>()
+        );
+        final Collection<String> filter = tenantsByApp.stream().map(TenantInformationDto::getName).toList();
+        final Predicate<ApplicationDto> predicate = app -> filter.contains(app.getIdentifier());
+
+        return apps.stream().filter(predicate).toList();
     }
 
     /**
@@ -201,7 +174,7 @@ public class ApplicationService extends AbstractResourceClientService<Applicatio
 
     @Override
     protected Collection<String> getAllowedKeys() {
-        return Arrays.asList("identifier", "url", "_id", "category", "filterApp");
+        return Arrays.asList("identifier", "url", "_id", "category");
     }
 
     @Override

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ApplicationController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/ApplicationController.java
@@ -40,8 +40,7 @@ package fr.gouv.vitamui.iam.server.rest;
 import fr.gouv.vitamui.common.security.SanityChecker;
 import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.domain.ApplicationDto;
-import fr.gouv.vitamui.commons.api.utils.EnumUtils;
-import fr.gouv.vitamui.iam.common.dto.common.EmbeddedOptions;
+import fr.gouv.vitamui.commons.api.domain.IdentifierNameDto;
 import fr.gouv.vitamui.iam.common.rest.RestApi;
 import fr.gouv.vitamui.iam.server.application.service.ApplicationService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -60,7 +59,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -90,31 +88,27 @@ public class ApplicationController {
      * Get All applications filtered by user privileges
      *
      * @param criteria
-     * @param embedded
      * @return all Applications matching user privileges
      */
     @GetMapping
     @Operation(operationId = "applications_getAll", summary = "Return all applications matching user privileges")
     public List<ApplicationDto> getAll(
-        @Parameter(description = "Criteria to filter the applications") final Optional<String> criteria,
-        @RequestParam final Optional<String> embedded
+        @Parameter(description = "Criteria to filter the applications") final Optional<String> criteria
     ) {
         SanityChecker.sanitizeCriteria(criteria);
-        EnumUtils.checkValidEnum(EmbeddedOptions.class, embedded);
-        LOGGER.debug("Get all with criteria={}, embedded={}", criteria, embedded);
-        return applicationService.getAll(criteria, embedded);
+        LOGGER.debug("Get all with criteria={}", criteria);
+        return applicationService.getAllFilteredByUser(criteria);
     }
 
-    @GetMapping("/filtered")
-    @Operation(
-        operationId = "applications_getApplicationsFromUi",
-        summary = "Return config about applications and categories"
-    )
-    public Map<String, List<ApplicationDto>> getApplicationsFromUi(
-        @RequestParam(defaultValue = "true") final boolean filterApp
-    ) {
-        LOGGER.debug("getApplications");
-        return applicationService.getApplications(filterApp);
+    /**
+     * Get All application names
+     *
+     * @return all application names
+     */
+    @GetMapping(path = "/listNames")
+    @Operation(operationId = "applications_listNames", summary = "Return all application names")
+    public List<IdentifierNameDto> listNames() {
+        return applicationService.listNames();
     }
 
     /**

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/application/service/ApplicationServiceTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/application/service/ApplicationServiceTest.java
@@ -2,8 +2,7 @@ package fr.gouv.vitamui.iam.server.application.service;
 
 import fr.gouv.vitamui.commons.api.CommonConstants;
 import fr.gouv.vitamui.commons.api.domain.ApplicationDto;
-import fr.gouv.vitamui.commons.api.domain.CriterionOperator;
-import fr.gouv.vitamui.commons.api.domain.QueryDto;
+import fr.gouv.vitamui.commons.api.domain.IdentifierNameDto;
 import fr.gouv.vitamui.commons.api.domain.TenantInformationDto;
 import fr.gouv.vitamui.commons.api.exception.UnAuthorizedException;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
@@ -61,22 +60,20 @@ public class ApplicationServiceTest {
     }
 
     @Test
-    public void testGetAll() {
+    public void testGetAllFilteredByUser() {
         final Application app = IamServerUtilsTest.buildApplication();
         final List<Application> apps = Arrays.asList(app);
         when(applicationRepository.findAll(any(Query.class))).thenReturn(apps);
 
         wireInternalSecurityServerCalls(true);
 
-        final QueryDto criteria = QueryDto.criteria("identifier", "cont", CriterionOperator.CONTAINSIGNORECASE);
-
-        final List<ApplicationDto> result = applicationService.getAll(Optional.of(criteria.toJson()), Optional.empty());
+        final List<ApplicationDto> result = applicationService.getAllFilteredByUser(Optional.empty());
         Assertions.assertNotNull(result, "Applications should be returned.");
         Assertions.assertEquals(apps.size(), result.size(), "Applications size should be returned.");
     }
 
     @Test
-    public void testGetAllFilteredForUser() {
+    public void testGetAllFilteredByUserShouldFilteredForUser() {
         final Application app = IamServerUtilsTest.buildApplication();
         final Application app2 = IamServerUtilsTest.buildApplication("id2", "url2");
         final List<Application> apps = Arrays.asList(app, app2);
@@ -84,57 +81,50 @@ public class ApplicationServiceTest {
 
         wireInternalSecurityServerCalls(true);
 
-        final QueryDto criteria = QueryDto.criteria("identifier", "cont", CriterionOperator.CONTAINSIGNORECASE);
-
-        final List<ApplicationDto> result = applicationService.getAll(Optional.of(criteria.toJson()), Optional.empty());
+        final List<ApplicationDto> result = applicationService.getAllFilteredByUser(Optional.empty());
         Assertions.assertNotNull(result, "Applications should be returned.");
         Assertions.assertEquals(1, result.size(), "Applications size should be returned.");
     }
 
     @Test
-    public void testGetAllWithoutFilter() {
-        final Application app = IamServerUtilsTest.buildApplication();
-        final Application app2 = IamServerUtilsTest.buildApplication("id2", "url2");
-        final List<Application> apps = Arrays.asList(app, app2);
-        when(applicationRepository.findAll(any(Query.class))).thenReturn(apps);
-
-        wireInternalSecurityServerCalls(true);
-
-        final QueryDto criteria = QueryDto.criteria("filterApp", false, CriterionOperator.EQUALS);
-
-        final List<ApplicationDto> result = applicationService.getAll(Optional.of(criteria.toJson()), Optional.empty());
-        Assertions.assertNotNull(result, "Applications should be returned.");
-        Assertions.assertEquals(2, result.size(), "Applications size should be returned.");
-    }
-
-    @Test
-    public void testGetAllForNullUserThenThrowException() {
+    public void testGetAllFilteredByUserForNullUserThenThrowException() {
         final Application app = IamServerUtilsTest.buildApplication();
         final List<Application> apps = List.of(app);
         when(applicationRepository.findAll(any(Query.class))).thenReturn(apps);
 
         Mockito.when(securityService.getUser()).thenReturn(null);
 
-        final QueryDto criteria = QueryDto.criteria("identifier", "cont", CriterionOperator.CONTAINSIGNORECASE);
         try {
-            applicationService.getAll(Optional.of(criteria.toJson()), Optional.empty());
+            applicationService.getAllFilteredByUser(Optional.empty());
             Assertions.fail("Should Throw Exception");
         } catch (UnAuthorizedException ignored) {}
     }
 
     @Test
-    public void testGetAllForUserWithoutPermission() {
+    public void testGetAllFilteredByUserForUserWithoutPermission() {
         final Application app = IamServerUtilsTest.buildApplication();
-        final List<Application> apps = Arrays.asList(app);
+        final List<Application> apps = List.of(app);
         when(applicationRepository.findAll(any(Query.class))).thenReturn(apps);
 
         wireInternalSecurityServerCalls(false);
 
-        final QueryDto criteria = QueryDto.criteria("identifier", "cont", CriterionOperator.CONTAINSIGNORECASE);
-
-        final List<ApplicationDto> result = applicationService.getAll(Optional.of(criteria.toJson()), Optional.empty());
+        final List<ApplicationDto> result = applicationService.getAllFilteredByUser(Optional.empty());
         Assertions.assertNotNull(result, "Applications should be returned.");
         Assertions.assertEquals(0, result.size(), "Applications size should be returned.");
+    }
+
+    @Test
+    public void testListNamesShouldReturnAllApps() {
+        final Application app = IamServerUtilsTest.buildApplication();
+        final Application app2 = IamServerUtilsTest.buildApplication("id2", "url2");
+        final List<Application> apps = Arrays.asList(app, app2);
+        when(applicationRepository.findAll(any(Query.class))).thenReturn(apps);
+
+        wireInternalSecurityServerCalls(false);
+
+        final List<IdentifierNameDto> result = applicationService.listNames();
+        Assertions.assertNotNull(result, "Applications should be returned.");
+        Assertions.assertEquals(2, result.size(), "Applications size should be returned.");
     }
 
     private void wireInternalSecurityServerCalls(boolean withApplications) {

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/ApplicationControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/ApplicationControllerTest.java
@@ -53,7 +53,7 @@ public final class ApplicationControllerTest extends ApiIamControllerTest<Applic
         when(applicationService.getAll(any(), any())).thenReturn(apps);
 
         try {
-            applicationController.getAll(Optional.empty(), Optional.empty());
+            applicationController.getAll(Optional.empty());
         } catch (final IllegalArgumentException e) {
             assertEquals("The DTO identifier must match the path identifier for update.", e.getMessage());
         }

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/CommonConstants.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/CommonConstants.java
@@ -189,11 +189,6 @@ public class CommonConstants {
 
     public static final String USER_INFO_ID = "userInfoId";
 
-    /**
-     * Constant contains application list for portal/header applications display
-     */
-    public static final String APPLICATION_CONFIGURATION = "APPLICATION_CONFIGURATION";
-
     public static final String CAS_IDP_PARAMETER = "cas_idp";
 
     public static final String IDP_PARAMETER = "idp";

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/domain/IdentifierNameDto.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/domain/IdentifierNameDto.java
@@ -1,5 +1,5 @@
-/*
- * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+/**
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2020)
  * and the signatories of the "VITAM - Accord du Contributeur" agreement.
  *
  * contact@programmevitam.fr
@@ -34,8 +34,23 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-export * from './application.interface';
-export * from './category.interface';
-export * from './identifier-name.interface';
-export * from './ui.interface';
-export * from './vitam-configuration.interface';
+package fr.gouv.vitamui.commons.api.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@AllArgsConstructor
+public class IdentifierNameDto implements Serializable {
+
+    private String identifier;
+    private String name;
+}

--- a/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.spec.ts
+++ b/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.spec.ts
@@ -104,41 +104,38 @@ const expectedProfiles = [
   },
 ];
 
-const expectedApp = {
-  APPLICATION_CONFIGURATION: [
-    {
-      id: 'CUSTOMERS_APP',
-      identifier: 'CUSTOMERS_APP',
-      name: 'Organisations',
-      url: '',
-    },
-    {
-      id: 'ARCHIVE_APP',
-      identifier: 'ARCHIVE_APP',
-      name: 'Archives',
-      url: '',
-    },
-    {
-      id: 'USERS_APP',
-      identifier: 'USERS_APP',
-      name: 'Utilisateurs',
-      url: '',
-    },
-    {
-      id: 'GROUPS_APP',
-      identifier: 'GROUPS_APP',
-      name: 'Groupes de profils',
-      url: '',
-    },
-    {
-      id: 'PROFILES_APP',
-      identifier: 'PROFILES_APP',
-      name: 'Profils APP Utilisateurs',
-      url: '',
-    },
-  ],
-  CATEGORY_CONFIGURATION: {},
-};
+const expectedApp = [
+  {
+    id: 'CUSTOMERS_APP',
+    identifier: 'CUSTOMERS_APP',
+    name: 'Organisations',
+    url: '',
+  },
+  {
+    id: 'ARCHIVE_APP',
+    identifier: 'ARCHIVE_APP',
+    name: 'Archives',
+    url: '',
+  },
+  {
+    id: 'USERS_APP',
+    identifier: 'USERS_APP',
+    name: 'Utilisateurs',
+    url: '',
+  },
+  {
+    id: 'GROUPS_APP',
+    identifier: 'GROUPS_APP',
+    name: 'Groupes de profils',
+    url: '',
+  },
+  {
+    id: 'PROFILES_APP',
+    identifier: 'PROFILES_APP',
+    name: 'Profils APP Utilisateurs',
+    url: '',
+  },
+];
 
 @Component({
   template: ` <app-profiles-form [(ngModel)]="profiles" level=""></app-profiles-form> `,
@@ -173,7 +170,7 @@ describe('ProfilesFormComponent', () => {
       declarations: [ProfilesFormComponent, TesthostComponent],
       providers: [
         { provide: ProfileService, useValue: { list: () => of(expectedProfiles) } },
-        { provide: ApplicationApiService, useValue: { getAllByParams: () => of(expectedApp) } },
+        { provide: ApplicationApiService, useValue: { listNames: () => of(expectedApp) } },
         { provide: ApplicationService, useValue: { list: () => of(expectedApp), buildApplications: () => expectedApp } },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/shared/profiles-form/profiles-form.component.ts
@@ -36,10 +36,8 @@
  */
 import { Component, ElementRef, forwardRef, Input, OnInit, SimpleChanges, ViewChild, OnChanges, inject } from '@angular/core';
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
-import { map, shareReplay } from 'rxjs/operators';
-import { Application, ApplicationApiService, Option, Profile, ProfileService, SelectComponent } from 'vitamui-library';
-
-import { HttpParams } from '@angular/common/http';
+import { shareReplay } from 'rxjs/operators';
+import { ApplicationApiService, IdentifierName, Option, Profile, ProfileService, SelectComponent } from 'vitamui-library';
 import { OptionTree } from './option-tree.interface';
 import { zip } from 'rxjs';
 
@@ -62,7 +60,7 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit, OnCh
 
   profiles: Profile[] = [];
   profileIds: string[] = [];
-  applicationsDetails: Application[] = [];
+  private applicationsDetails: IdentifierName[] = [];
 
   public loading = true;
 
@@ -83,10 +81,7 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit, OnCh
   @ViewChild('profileInput', { static: false }) profileInput: SelectComponent;
   @ViewChild('addButton', { static: false }) addButton: ElementRef;
 
-  private applicationsDetails$ = this.appApiService.getAllByParams(new HttpParams().set('filterApp', 'false')).pipe(
-    map((applications) => applications.APPLICATION_CONFIGURATION),
-    shareReplay(1),
-  );
+  private applicationsDetails$ = this.appApiService.listNames().pipe(shareReplay(1));
 
   ngOnInit(): void {
     this.applicationsDetails$.subscribe((applicationsDetails) => (this.applicationsDetails = applicationsDetails));
@@ -243,8 +238,7 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit, OnCh
   }
 
   private buildApplicationOption(profile: Profile): OptionTree {
-    const application = this.applicationsDetails.find((app) => app.identifier === profile.applicationName);
-    let appLabel = this.applicationsDetails.find((app) => app.identifier === application.identifier).name;
+    const appLabel = this.applicationsDetails.find((app) => app.identifier === profile.applicationName).name;
 
     return {
       key: profile.applicationName,
@@ -290,7 +284,7 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit, OnCh
     this.appSelect.reset();
   }
 
-  private filterProfileIds(profileIds: string[], profiles: Profile[], applicationsDetails: Application[]): string[] {
+  private filterProfileIds(profileIds: string[], profiles: Profile[], applicationsDetails: IdentifierName[]): string[] {
     return profiles
       .filter((profile) => applicationsDetails.some((app) => app.identifier === profile.applicationName))
       .map((profile) => profile.id)
@@ -298,7 +292,7 @@ export class ProfilesFormComponent implements ControlValueAccessor, OnInit, OnCh
   }
 }
 
-function byApplicationName(profiles: Profile[], applications: Application[]): (idA: string, idB: string) => number {
+function byApplicationName(profiles: Profile[], applications: IdentifierName[]): (idA: string, idB: string) => number {
   return (idA, idB) => {
     const nameA = getApplicationName(profiles, idA, applications);
     const nameB = getApplicationName(profiles, idB, applications);
@@ -314,7 +308,7 @@ function byApplicationName(profiles: Profile[], applications: Application[]): (i
   };
 }
 
-function getApplicationName(profiles: Profile[], profileId: string, applications: Application[]): string {
+function getApplicationName(profiles: Profile[], profileId: string, applications: IdentifierName[]): string {
   const profile = profiles.find((p) => p.id === profileId);
 
   if (!profile) {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/application-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/application-api.service.ts
@@ -34,13 +34,14 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
 import { BASE_URL } from '../injection-tokens';
-import { AppConfiguration, ApplicationInfo, AttachmentType } from '../models';
+import { AppConfiguration, Application, AttachmentType } from '../models';
+import { IdentifierName } from '../models/application/identifier-name.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -56,8 +57,12 @@ export class ApplicationApiService {
     this.apiUrl = baseUrl + '/ui/applications';
   }
 
-  getAllByParams(params: HttpParams, headers?: HttpHeaders): Observable<ApplicationInfo> {
-    return this.http.get<ApplicationInfo>(`${this.apiUrl}/filtered`, { params, headers });
+  getAll(headers?: HttpHeaders): Observable<Application[]> {
+    return this.http.get<Application[]>(`${this.apiUrl}`, { headers });
+  }
+
+  listNames(): Observable<IdentifierName[]> {
+    return this.http.get<IdentifierName[]>(`${this.apiUrl}/listNames`);
   }
 
   isApplicationExternalIdentifierEnabled(id: string): Observable<boolean> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/application.service.spec.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/application.service.spec.ts
@@ -46,6 +46,7 @@ import { BASE_URL } from './injection-tokens';
 import { Application } from './models/application/application.interface';
 import { StartupService } from './startup.service';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { Category } from './models';
 
 describe('ApplicationService', () => {
   let httpTestingController: HttpTestingController;
@@ -63,7 +64,7 @@ describe('ApplicationService', () => {
       customerId: 'fakeCustomerId',
     };
     const configServiceStub = {
-      config: { GATEWAY_ENABLED: false },
+      config: { CATEGORY_CONFIGURATION: [] as Category[] },
     };
 
     TestBed.configureTestingModule({
@@ -89,10 +90,10 @@ describe('ApplicationService', () => {
     expect(service).toBeTruthy();
   }));
 
-  it('should call /fake-api/ui/applications/filtered?filterApp=true', () => {
+  it('should call /fake-api/ui/applications', () => {
     appService.list().subscribe(
       (response) => {
-        expect(response.APPLICATION_CONFIGURATION).toEqual([
+        expect(response).toEqual([
           {
             id: 'account',
             identifier: ApplicationId.ACCOUNTS_APP,
@@ -112,32 +113,29 @@ describe('ApplicationService', () => {
         throw e;
       },
     );
-    const req = httpTestingController.expectOne('/fake-api/ui/applications/filtered?filterApp=true');
+    const req = httpTestingController.expectOne('/fake-api/ui/applications');
     expect(req.request.method).toEqual('GET');
-    req.flush({
-      APPLICATION_CONFIGURATION: [
-        {
-          id: 'account',
-          identifier: ApplicationId.ACCOUNTS_APP,
-          url: 'http://app-test-2.vitamui.com',
-          icon: 'vitamui-icon vitamui-icon-user',
-          name: 'Mon compte',
-          category: 'users',
-          position: 7,
-          hasCustomerList: false,
-          hasTenantList: false,
-          hasHighlight: false,
-          target: '',
-        },
-      ],
-      CATEGORY_CONFIGURATION: [{ identifier: 'users', title: '', displayTitle: false, order: 1 }],
-    });
+    req.flush([
+      {
+        id: 'account',
+        identifier: ApplicationId.ACCOUNTS_APP,
+        url: 'http://app-test-2.vitamui.com',
+        icon: 'vitamui-icon vitamui-icon-user',
+        name: 'Mon compte',
+        category: 'users',
+        position: 7,
+        hasCustomerList: false,
+        hasTenantList: false,
+        hasHighlight: false,
+        target: '',
+      },
+    ]);
   });
 
   it('should return an empty list if the API returns an error', () => {
     appService.list().subscribe(
       (response) => {
-        expect(response).toEqual({ APPLICATION_CONFIGURATION: [], CATEGORY_CONFIGURATION: [] });
+        expect(response).toEqual([]);
       },
       (e: unknown) => {
         throw e;

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/application.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/application.service.ts
@@ -34,7 +34,6 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -44,12 +43,11 @@ import { ApplicationId } from './application-id.enum';
 import { AuthService } from './auth.service';
 import { ConfigService } from './config.service';
 import { GlobalEventService } from './global-event.service';
-import { Application, ApplicationInfo } from './models/application/application.interface';
+import { Application } from './models/application/application.interface';
 import { Category } from './models/application/category.interface';
 import { Tenant } from './models/customer/tenant.interface';
 import { ApplicationAnalytics } from './models/user/application-analytics.interface';
 import { TenantSelectionService } from './tenant-selection.service';
-import { VitamuiHttpHeaders } from './vitamui-http-headers.enum';
 
 @Injectable({
   providedIn: 'root',
@@ -91,20 +89,14 @@ export class ApplicationService {
   /**
    * Get and init applications list for the current auth user.
    */
-  public list(): Observable<ApplicationInfo> {
-    const params = new HttpParams().set('filterApp', 'true');
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, this.authService.getAnyTenantIdentifier());
-    return this.applicationApi.getAllByParams(params, headers).pipe(
-      catchError(() => of({ APPLICATION_CONFIGURATION: [], CATEGORY_CONFIGURATION: {} })),
-      map((applicationInfo: ApplicationInfo) => {
-        this._applications = applicationInfo.APPLICATION_CONFIGURATION;
-        if (this.configService.config.GATEWAY_ENABLED) {
-          this._categories = this.sortCategories(this.configService.config.CATEGORY_CONFIGURATION);
-        } else {
-          this._categories = this.sortCategories(applicationInfo.CATEGORY_CONFIGURATION);
-        }
+  public list(): Observable<Application[]> {
+    return this.applicationApi.getAll().pipe(
+      catchError(() => of([])),
+      map((applications: Application[]) => {
+        this._applications = applications;
+        this._categories = this.sortCategories(this.configService.config.CATEGORY_CONFIGURATION);
         this._applications$.next(this._applications);
-        return applicationInfo;
+        return applications;
       }),
     );
   }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/application/application.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/application/application.interface.ts
@@ -35,7 +35,6 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Id } from '../id.interface';
-import { Category } from './category.interface';
 
 export interface Application extends Id {
   identifier: string;
@@ -50,9 +49,4 @@ export interface Application extends Id {
   hasCustomerList: boolean;
   hasTenantList: boolean;
   target: string;
-}
-
-export interface ApplicationInfo {
-  APPLICATION_CONFIGURATION: Application[];
-  CATEGORY_CONFIGURATION: Category[];
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/application/identifier-name.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/application/identifier-name.interface.ts
@@ -34,8 +34,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-export * from './application.interface';
-export * from './category.interface';
-export * from './identifier-name.interface';
-export * from './ui.interface';
-export * from './vitam-configuration.interface';
+
+export interface IdentifierName {
+  identifier: string;
+  name: string;
+}


### PR DESCRIPTION
- l'API `/applications` n'était pas utilisée => remplacée (voir point suivant)
- l'API `/applications/filtered` :
  - a été renommée `/applications`
  - ne prends plus `embedded` comme param (car inutilisé)
  - filtre systématiquement les applications en fonction de l'utilisateur connecté
- puisqu'il est également nécessaire de pouvoir lister toutes les applications (pour la liste déroulante des applications lors de la création de Groupes de profils par exemple), un nouveau point d'API `/applications/listNames` a été créé. Ce point d'API :
  - renvoie toutes les applications, quelque soit l'utilisateur
  - ne renvoie que l'identifiant et le nom des applications