### PR TITLE
Bug #16550: fix global header menu (and selects) z-index

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/header.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/header.component.html
@@ -29,6 +29,7 @@
           [items]="appTenants"
           [selectedItem]="selectedTenant"
           (itemSelected)="updateTenant($event)"
+          panelClass="header-select"
         >
         </vitamui-common-item-select>
       }
@@ -41,6 +42,7 @@
           [items]="customers"
           [selectedItem]="selectedCustomer"
           (itemSelected)="updateCustomer($event)"
+          panelClass="header-select"
         >
         </vitamui-common-item-select>
       }
@@ -58,7 +60,7 @@
       </div>
 
       <div class="account-menu">
-        <mat-menu #accountMenu="matMenu" [overlapTrigger]="false" xPosition="before">
+        <mat-menu #accountMenu="matMenu" [overlapTrigger]="false" xPosition="before" class="header-select">
           <ng-container>
             @if (hasAccountProfile) {
               <button mat-menu-item [routerLink]="['/account']">{{ 'HEADER.MY_ACCOUNT' | translate }}</button>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/item-select/item-select.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/item-select/item-select.component.html
@@ -5,7 +5,11 @@
   @if (_selectedItem) {
     <mat-label class="unselected-item-label">{{ selectedLabel }}</mat-label>
   }
-  <mat-select (selectionChange)="selectItem($event.source.value)" [(value)]="_selectedItem" panelClass="vitamui-mat-select">
+  <mat-select
+    (selectionChange)="selectItem($event.source.value)"
+    [(value)]="_selectedItem"
+    [panelClass]="'vitamui-mat-select ' + panelClass"
+  >
     @for (item of items; track item) {
       <mat-option [value]="item.label">
         {{ item.label }}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/item-select/item-select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/item-select/item-select.component.ts
@@ -49,6 +49,7 @@ export class ItemSelectComponent {
   @Input() selectedLabel: string;
   @Input() items: MenuOption[];
   @Input() appearance: 'fill' | 'outline' = 'fill';
+  @Input() panelClass: string = '';
   @Output() itemSelected = new EventEmitter<MenuOption>();
 
   @Input() set selectedItem(value: MenuOption) {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/select-language/select-language.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/header/select-language/select-language.component.html
@@ -13,6 +13,7 @@
           : { label: 'SELECT_LANGUAGE.ENGLISH' | translate, value: 'en' }
       "
       (itemSelected)="use($event.value)"
+      panelClass="header-select"
     >
     </vitamui-common-item-select>
   </div>

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/vitamui-library.module.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/vitamui-library.module.ts
@@ -62,6 +62,7 @@ import { ConfirmActionComponent } from './components/confirm-action/confirm-acti
 import { ManagementRuleSearchComponent } from './components/management-rule-search/management-rule-search.component';
 import { ConfirmDialogComponent } from './components/dialog/confirm-dialog/confirm-dialog.component';
 import { ErrorsDetailsDialogComponent } from './components/dialog/errors-details-dialog/errors-details-dialog.component';
+import { OVERLAY_DEFAULT_CONFIG } from '@angular/cdk/overlay';
 
 const components = [
   AlertDialogComponent,
@@ -97,6 +98,14 @@ const components = [
     { provide: MAT_RADIO_DEFAULT_OPTIONS, useValue: { color: 'primary' } },
     { provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: { autoFocus: false } },
     { provide: MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS, useValue: { hideSingleSelectionIndicator: true } },
+    {
+      provide: OVERLAY_DEFAULT_CONFIG,
+      useValue: {
+        // Forces Angular Material to use CDK overlay implementation instead of the native Popover API (top-layer).
+        // This restores pre-Angular 21 behavior where overlays respect z-index stacking contexts, preventing dialogs/tooltips from always appearing above structural UI elements like sticky headers.
+        usePopover: false,
+      },
+    },
   ],
 })
 export class VitamUILibraryModule {}

--- a/ui/ui-frontend/projects/vitamui-library/src/sass/material/_dialog.scss
+++ b/ui/ui-frontend/projects/vitamui-library/src/sass/material/_dialog.scss
@@ -6,8 +6,8 @@
   .cdk-overlay-container {
     z-index: 1000; // Should be the Angular Material default value for overlays, but we make sure it'll stay the same in the future
 
-    &:has(.mat-mdc-dialog-container) {
-      z-index: 1002; // Make sure the overlay for a dialog is over the header
+    &:has(.mat-mdc-dialog-container, vitamui-common-menu, .header-select) {
+      z-index: 1002; // Make sure the overlay for a dialog (or the global menu or select options from the header) is over the header
     }
   }
 


### PR DESCRIPTION
Le bug #16550 n'était présent que jusqu'à la montée de version Angular 21 (en v10 vitam).

En effet, Angular (material) 21 utilise dorénavant la Popover API par défaut pour tous les overlays. Par conséquent, tous ces overlays se retrouvent dans le #top-layer HTML qui est une couche qui est systématiquement au-dessus de tout le reste (quel que soit leur z-index).
Cela "corrigeait" alors le bug #16550, ... tout en réintroduisant le bug #14438.

Cette MR :
-  désactive (sur la v10, Angular 21) l'utilisation de l'API Popover pour revenir au fonctionnement à base de z-index, ce qui corrige (à nouveau) le bug #14438 et fait apparaître le bug #16550 sur la v10 (comme sur toutes les autres versions)
- corrige le bug #16550 en faisant passer les select du header et le menu principal par dessus le header