### PR TITLE
Bug #15758: [Collect & Search] - Fix: correctly remove and restore waiting rule recalculation filter.

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -578,7 +578,8 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
           val.values.forEach((value) => {
             this.removeCriteria(key, value.value, true);
             const keyToRemove = key === WAITING_RECALCULATE ? ORIGIN_WAITING_RECALCULATE : value.value.id;
-            builder.removeQueryParam(keyToRemove, value.value.value);
+            const valueToRemove = key === WAITING_RECALCULATE ? ORIGIN_WAITING_RECALCULATE : value.value.value;
+            builder.removeQueryParam(keyToRemove, valueToRemove);
             builder.navigate();
           });
         }
@@ -743,6 +744,8 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
   mapSearchCriteriaHistory() {
     let searchCriteriaHistoryObject: SearchCriteriaHistory;
     const criteriaListObject: SearchCriteriaEltements[] = [];
+    const selectedRuleCategory = this.additionalSearchCriteriaCategories[this.additionalSearchCriteriaCategoryIndex - 1]?.name;
+    const waitingRecalculateCategory = selectedRuleCategory || this.additionalSearchCriteriaCategories[0]?.name;
     this.searchCriterias.forEach((criteria: CriteriaSearchCriteria) => {
       const strValues: CriteriaValue[] = [];
       criteria.values.forEach((elt) => {
@@ -751,7 +754,10 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
       criteriaListObject.push({
         criteria: criteria.key,
         values: strValues,
-        category: SearchCriteriaTypeEnum[criteria.category],
+        category:
+          criteria.key === WAITING_RECALCULATE && waitingRecalculateCategory
+            ? waitingRecalculateCategory
+            : SearchCriteriaTypeEnum[criteria.category],
         operator: criteria.operator,
         keyTranslated: criteria.keyTranslated,
         valueTranslated: criteria.valueTranslated,
@@ -820,20 +826,28 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
     storedSearchCriteriaHistory.searchCriteriaList.forEach((criteria: SearchCriteriaEltements) => {
       this.fillTreeNodeAsSearchCriteriaHistory(criteria);
 
-      const category = criteria.category as SearchCriteriaTypeEnum;
-      const isRuleCategory = Object.keys(SearchCriteriaTypeEnum)
-        .filter((key) => key.includes('RULE'))
-        .includes(category);
+      const categoryName = typeof criteria.category === 'string' ? criteria.category : SearchCriteriaTypeEnum[criteria.category];
+      const category = SearchCriteriaTypeEnum[categoryName as keyof typeof SearchCriteriaTypeEnum] as SearchCriteriaTypeEnum;
+      const isRuleCategory = categoryName.includes('RULE');
 
       if (isRuleCategory) {
-        this.addCriteriaCategory(category);
+        this.addCriteriaCategory(categoryName);
       }
 
       criteria.values.forEach((value) => {
+        const isWaitingRecalculateCriteria =
+          criteria.criteria === WAITING_RECALCULATE ||
+          criteria.criteria === ORIGIN_WAITING_RECALCULATE ||
+          value.id === ORIGIN_WAITING_RECALCULATE;
+        const criteriaKey = isWaitingRecalculateCriteria ? ORIGIN_WAITING_RECALCULATE : criteria.criteria;
+        const valueToRestore = isWaitingRecalculateCriteria
+          ? { ...value, id: ORIGIN_WAITING_RECALCULATE, value: ORIGIN_WAITING_RECALCULATE }
+          : value;
+
         this.addCriteria(
-          criteria.criteria,
-          value,
-          value.value,
+          criteriaKey,
+          valueToRestore,
+          valueToRestore.value,
           criteria.keyTranslated,
           criteria.operator,
           category,
@@ -843,9 +857,9 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
         );
 
         criteriaToAddToUrl.push({
-          keyElt: criteria.criteria,
-          valueElt: value,
-          labelElt: value.value,
+          keyElt: criteriaKey,
+          valueElt: valueToRestore,
+          labelElt: valueToRestore.value,
           keyTranslated: criteria.keyTranslated,
           operator: criteria.operator,
           category,

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/common-services/archive-search-helper.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/common-services/archive-search-helper.service.ts
@@ -266,43 +266,41 @@ export class ArchiveSearchHelperService {
   ) {
     if (searchCriterias && searchCriterias.size > 0) {
       if (valueElt && valueElt.id === WAITING_RECALCULATE) {
-        valueElt.id = ORIGIN_WAITING_RECALCULATE;
-        valueElt.value = ORIGIN_WAITING_RECALCULATE;
+        const waitingRecalculateValueElt = { id: ORIGIN_WAITING_RECALCULATE, value: ORIGIN_WAITING_RECALCULATE };
         if (emit === true) {
           this.archiveExchangeDataService.sendAppraisalFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
 
           this.archiveExchangeDataService.sendAccessFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
 
           this.archiveExchangeDataService.sendStorageFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
           this.archiveExchangeDataService.sendReuseFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
           this.archiveExchangeDataService.sendDisseminationFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
         }
-        valueElt.id = WAITING_RECALCULATE;
       }
       if (valueElt && valueElt.id === ORIGIN_WAITING_RECALCULATE) {
         this.removeCriteria(
           WAITING_RECALCULATE,
-          { id: WAITING_RECALCULATE, value: valueElt.value },
+          { id: WAITING_RECALCULATE, value: 'true' },
           emit,
           searchCriteriaKeys,
           searchCriterias,
@@ -375,9 +373,11 @@ export class ArchiveSearchHelperService {
             emit === true &&
             [SearchCriteriaTypeEnum.FIELDS, SearchCriteriaTypeEnum.NODES, ALL_ARCHIVE_UNIT_TYPES].includes(val.category)
           ) {
+            const valueEltToRemove =
+              key === WAITING_RECALCULATE ? { id: ORIGIN_WAITING_RECALCULATE, value: ORIGIN_WAITING_RECALCULATE } : valueElt;
             this.archiveExchangeDataService.sendRemoveFromChildSearchCriteriaAction({
               keyElt,
-              valueElt,
+              valueElt: valueEltToRemove,
               action: 'REMOVE',
             });
           }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/criteria-search/criteria-search.component.ts
@@ -38,10 +38,12 @@ import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import {
   CriteriaSearchCriteria,
   CriteriaValue,
+  ORIGIN_WAITING_RECALCULATE,
   QueryParamsService,
   SearchCriteriaTypeEnum,
   SearchCriteriaValue,
   TranslateWithOptionalTypeSuffixPipe,
+  WAITING_RECALCULATE,
 } from 'vitamui-library';
 import { TranslateService } from '@ngx-translate/core';
 @Component({
@@ -72,11 +74,14 @@ export class CriteriaSearchComponent {
     const builder = this.queryParamsService.builder();
     criteriaValues.forEach((criteriaValue) => {
       //fixme manage navigation
-      let value =
-        criteriaValue.id === 'VIRTUAL'
-          ? criteriaValue.value + '/' + criteriaValue.virtualNodeRealParentId + '/' + criteriaValue.virtualNodeRealParentTitle
-          : criteriaValue.value;
-      builder.removeQueryParam(criteriaValue.id, value);
+      const queryParamKey = criteriaValue.id === WAITING_RECALCULATE ? ORIGIN_WAITING_RECALCULATE : criteriaValue.id;
+      const value =
+        criteriaValue.id === WAITING_RECALCULATE
+          ? ORIGIN_WAITING_RECALCULATE
+          : criteriaValue.id === 'VIRTUAL'
+            ? criteriaValue.value + '/' + criteriaValue.virtualNodeRealParentId + '/' + criteriaValue.virtualNodeRealParentTitle
+            : criteriaValue.value;
+      builder.removeQueryParam(queryParamKey, value);
       this.criteriaRemoveEvent.emit({ keyElt: this.criteriaKey, valueElt: criteriaValue });
     });
     builder.navigate();

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -941,7 +941,8 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
           val.values.forEach((value) => {
             this.removeCriteria(key, value.value, true);
             const keyToRemove = key === WAITING_RECALCULATE ? ORIGIN_WAITING_RECALCULATE : value.value.id;
-            builder.removeQueryParam(keyToRemove, value.value.value);
+            const valueToRemove = key === WAITING_RECALCULATE ? ORIGIN_WAITING_RECALCULATE : value.value.value;
+            builder.removeQueryParam(keyToRemove, valueToRemove);
             builder.navigate();
           });
         }
@@ -962,6 +963,8 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   mapSearchCriteriaHistory() {
     let searchCriteriaHistoryObject: SearchCriteriaHistory;
     const criteriaListObject: SearchCriteriaEltements[] = [];
+    const selectedRuleCategory = this.additionalSearchCriteriaCategories[this.additionalSearchCriteriaCategoryIndex - 1]?.name;
+    const waitingRecalculateCategory = selectedRuleCategory || this.additionalSearchCriteriaCategories[0]?.name;
     this.searchCriterias.forEach((criteria: CriteriaSearchCriteria) => {
       const strValues: CriteriaValue[] = [];
       criteria.values.forEach((elt) => {
@@ -970,7 +973,10 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
       criteriaListObject.push({
         criteria: criteria.key,
         values: strValues,
-        category: SearchCriteriaTypeEnum[criteria.category],
+        category:
+          criteria.key === WAITING_RECALCULATE && waitingRecalculateCategory
+            ? waitingRecalculateCategory
+            : SearchCriteriaTypeEnum[criteria.category],
         operator: criteria.operator,
         keyTranslated: criteria.keyTranslated,
         valueTranslated: criteria.valueTranslated,
@@ -1205,20 +1211,28 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     storedSearchCriteriaHistory.searchCriteriaList.forEach((criteria: SearchCriteriaEltements) => {
       this.fillTreeNodeAsSearchCriteriaHistory(criteria);
 
-      const category = criteria.category as SearchCriteriaTypeEnum;
-      const isRuleCategory = Object.keys(SearchCriteriaTypeEnum)
-        .filter((key) => key.includes('RULE'))
-        .includes(category);
+      const categoryName = typeof criteria.category === 'string' ? criteria.category : SearchCriteriaTypeEnum[criteria.category];
+      const category = SearchCriteriaTypeEnum[categoryName as keyof typeof SearchCriteriaTypeEnum] as SearchCriteriaTypeEnum;
+      const isRuleCategory = categoryName.includes('RULE');
 
       if (isRuleCategory) {
-        this.addCriteriaCategory(category);
+        this.addCriteriaCategory(categoryName);
       }
 
       criteria.values.forEach((value) => {
+        const isWaitingRecalculateCriteria =
+          criteria.criteria === WAITING_RECALCULATE ||
+          criteria.criteria === ORIGIN_WAITING_RECALCULATE ||
+          value.id === ORIGIN_WAITING_RECALCULATE;
+        const criteriaKey = isWaitingRecalculateCriteria ? ORIGIN_WAITING_RECALCULATE : criteria.criteria;
+        const valueToRestore = isWaitingRecalculateCriteria
+          ? { ...value, id: ORIGIN_WAITING_RECALCULATE, value: ORIGIN_WAITING_RECALCULATE }
+          : value;
+
         this.addCriteria(
-          criteria.criteria,
-          value,
-          value.value,
+          criteriaKey,
+          valueToRestore,
+          valueToRestore.value,
           criteria.keyTranslated,
           criteria.operator,
           category,
@@ -1228,9 +1242,9 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
         );
 
         criteriaToAddToUrl.push({
-          keyElt: criteria.criteria,
-          valueElt: value,
-          labelElt: value.value,
+          keyElt: criteriaKey,
+          valueElt: valueToRestore,
+          labelElt: valueToRestore.value,
           keyTranslated: criteria.keyTranslated,
           operator: criteria.operator,
           category,

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/criteria-search/criteria-search.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/components/criteria-search/criteria-search.component.ts
@@ -40,10 +40,12 @@ import { TranslateService } from '@ngx-translate/core';
 import {
   CriteriaSearchCriteria,
   CriteriaValue,
+  ORIGIN_WAITING_RECALCULATE,
   QueryParamsService,
   SearchCriteriaTypeEnum,
   SearchCriteriaValue,
   TranslateWithOptionalTypeSuffixPipe,
+  WAITING_RECALCULATE,
 } from 'vitamui-library';
 
 @Component({
@@ -73,11 +75,14 @@ export class CriteriaSearchComponent {
   private removeCriteriaList(criteriaValues: CriteriaValue[]) {
     const builder = this.queryParamsService.builder();
     criteriaValues.forEach((criteriaValue) => {
-      let value =
-        criteriaValue.id === 'VIRTUAL'
-          ? criteriaValue.value + '/' + criteriaValue.virtualNodeRealParentId + '/' + criteriaValue.virtualNodeRealParentTitle
-          : criteriaValue.value;
-      builder.removeQueryParam(criteriaValue.id, value);
+      const queryParamKey = criteriaValue.id === WAITING_RECALCULATE ? ORIGIN_WAITING_RECALCULATE : criteriaValue.id;
+      const value =
+        criteriaValue.id === WAITING_RECALCULATE
+          ? ORIGIN_WAITING_RECALCULATE
+          : criteriaValue.id === 'VIRTUAL'
+            ? criteriaValue.value + '/' + criteriaValue.virtualNodeRealParentId + '/' + criteriaValue.virtualNodeRealParentTitle
+            : criteriaValue.value;
+      builder.removeQueryParam(queryParamKey, value);
       this.criteriaRemoveEvent.emit({ keyElt: this.criteriaKey, valueElt: criteriaValue });
     });
     builder.navigate();

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/services/archive-search-helper.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-criteria/services/archive-search-helper.service.ts
@@ -272,43 +272,41 @@ export class ArchiveSearchHelperService {
   ) {
     if (searchCriterias && searchCriterias.size > 0) {
       if (valueElt && valueElt.id === WAITING_RECALCULATE) {
-        valueElt.id = ORIGIN_WAITING_RECALCULATE;
-        valueElt.value = ORIGIN_WAITING_RECALCULATE;
+        const waitingRecalculateValueElt = { id: ORIGIN_WAITING_RECALCULATE, value: ORIGIN_WAITING_RECALCULATE };
         if (emit === true) {
           this.archiveExchangeDataService.sendAppraisalFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
 
           this.archiveExchangeDataService.sendAccessFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
 
           this.archiveExchangeDataService.sendStorageFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
           this.archiveExchangeDataService.sendReuseFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
           this.archiveExchangeDataService.sendDisseminationFromMainSearchCriteriaAction({
             keyElt,
-            valueElt,
+            valueElt: waitingRecalculateValueElt,
             action: 'REMOVE',
           });
         }
-        valueElt.id = WAITING_RECALCULATE;
       }
       if (valueElt && valueElt.id === ORIGIN_WAITING_RECALCULATE) {
         this.removeCriteria(
           WAITING_RECALCULATE,
-          { id: WAITING_RECALCULATE, value: valueElt.value },
+          { id: WAITING_RECALCULATE, value: 'true' },
           emit,
           searchCriteriaKeys,
           searchCriterias,
@@ -378,9 +376,11 @@ export class ArchiveSearchHelperService {
             });
           }
           if (emit === true && fieldKeys.includes(searchCriteria.category)) {
+            const valueEltToRemove =
+              key === WAITING_RECALCULATE ? { id: ORIGIN_WAITING_RECALCULATE, value: ORIGIN_WAITING_RECALCULATE } : valueElt;
             this.archiveExchangeDataService.sendRemoveFromChildSearchCriteriaAction({
               keyElt,
-              valueElt,
+              valueElt: valueEltToRemove,
               action: 'REMOVE',
             });
           }

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/management-rule-search/services/management-rule-criteria.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/management-rule-search/services/management-rule-criteria.service.ts
@@ -46,6 +46,8 @@ import {
   SearchCriteriaValue,
   ORIGIN_HAS_AT_LEAST_ONE,
   ORIGIN_INHERITE_AT_LEAST_ONE,
+  ORIGIN_WAITING_RECALCULATE,
+  WAITING_RECALCULATE,
 } from '../../../../app/modules';
 import { QueryParamsService } from '../../../../app/modules/url/query-params.service';
 import { SearchCriteriaService } from '../../../../app/modules/models/criteria/search-criteria.service';
@@ -91,6 +93,11 @@ export class ManagementRuleCriteriaService {
       )
       .subscribe((searchCriteria: Map<string, CriteriaSearchCriteria>) => {
         const filteredCriterias = new Map([...searchCriteria.entries()].filter(([key]) => keysList.includes(key)));
+        const hasWaitingRecalculateCriteria = searchCriteria.has(WAITING_RECALCULATE);
+
+        if (hasWaitingRecalculateCriteria) {
+          additionalCriteria.set(ORIGIN_WAITING_RECALCULATE, true);
+        }
 
         if (filteredCriterias && filteredCriterias.size > 0) {
           filteredCriterias.forEach((value: CriteriaSearchCriteria) => {


### PR DESCRIPTION
le fix : corrige la synchronisation du filtre WAITING_RECALCULATE

- Aligne la suppression du filtre avec le paramètre et la valeur réellement présents dans l’URL
- Empêche la réinjection du filtre après sa suppression
- Restaure l’état de la case à cocher ORIGIN_WAITING_RECALCULATE lors du chargement des recherches sauvegardées
- Synchronise l’état de l’interface avec les critères internes et les paramètres de l’URL