### PR TITLE
Bug #16510: [Audit] - Fix: The filtering by producer service name is not working.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-create/audit-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-create/audit-create.component.ts
@@ -38,11 +38,12 @@ import { HttpHeaders } from '@angular/common/http';
 import { Component, Input, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { EMPTY, Subject } from 'rxjs';
-import { map, switchMap, take, takeUntil } from 'rxjs/operators';
+import { EMPTY, forkJoin, of, Subject } from 'rxjs';
+import { catchError, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import {
   AccessContractService,
   AccessionRegisterSummary,
+  AgencyService,
   ConfirmDialogService,
   ExternalParameters,
   ExternalParametersService,
@@ -93,6 +94,7 @@ export class AuditCreateComponent implements OnInit, OnDestroy {
   private formBuilder = inject(FormBuilder);
   private confirmDialogService = inject(ConfirmDialogService);
   private auditService = inject(AuditService);
+  private agencyService = inject(AgencyService);
   private startupService = inject(StartupService);
   protected accessContractService = inject(AccessContractService);
   private auditCreateValidator = inject(AuditCreateValidators);
@@ -109,7 +111,6 @@ export class AuditCreateComponent implements OnInit, OnDestroy {
   public startDateControl = new FormControl('');
   public endDateControl = new FormControl('');
   public accessContractId: string = null;
-  public accessionRegisterSummaries: AccessionRegisterSummary[];
   public producerServicesOptions: Option[] = [];
   public producerServicesMultiSelectOptions: VitamuiSelectOptions;
   public isDisabledButton = false;
@@ -148,15 +149,11 @@ export class AuditCreateComponent implements OnInit, OnDestroy {
 
     this.externalParameterService
       .getUserExternalParameters()
-      .pipe(switchMap((params: Map<string, string>) => this.extractAccesContractIdAndGetAccessionRegisterSummaries(params)))
+      .pipe(switchMap((params: Map<string, string>) => this.loadAccessContractAndProducerServicesOptions(params)))
       .pipe(take(1))
-      .subscribe((accessContractAndRegisterSummary) => {
-        this.accessContractId = accessContractAndRegisterSummary.accessContractId;
-        this.accessionRegisterSummaries = accessContractAndRegisterSummary.accessionRegisterSummaries;
-        this.producerServicesOptions = this.accessionRegisterSummaries.map((summary) => ({
-          key: summary.originatingAgency,
-          label: summary.originatingAgency,
-        }));
+      .subscribe(({ accessContractId, producerServicesOptions }) => {
+        this.accessContractId = accessContractId;
+        this.producerServicesOptions = producerServicesOptions;
         this.producerServicesMultiSelectOptions = {
           options: this.producerServicesOptions,
           customSorting: this.sortAlphabetically,
@@ -279,16 +276,22 @@ export class AuditCreateComponent implements OnInit, OnDestroy {
     return this.form.controls.startDate.hasValidator(Validators.required);
   }
 
-  private extractAccesContractIdAndGetAccessionRegisterSummaries(params: Map<string, string>) {
+  private loadAccessContractAndProducerServicesOptions(params: Map<string, string>) {
     const accessContractId = params.get(ExternalParameters.PARAM_ACCESS_CONTRACT);
     if (!accessContractId || accessContractId.length < 1) {
       this.snackBarService.open({ message: 'SNACKBAR.NO_ACCESS_CONTRACT_LINKED' });
       return EMPTY;
     }
 
-    return this.auditService
-      .getAllAccessionRegister(accessContractId)
-      .pipe(map((accessionRegisterSummaries) => ({ accessContractId, accessionRegisterSummaries })));
+    return forkJoin({
+      accessionRegisterSummaries: this.auditService.getAllAccessionRegister(accessContractId),
+      originatingAgenciesOptions: this.agencyService.getOriginatingAgenciesAsOptions().pipe(catchError(() => of([]))),
+    }).pipe(
+      map(({ accessionRegisterSummaries, originatingAgenciesOptions }) => ({
+        accessContractId,
+        producerServicesOptions: this.buildProducerServicesOptions({ accessionRegisterSummaries, originatingAgenciesOptions }),
+      })),
+    );
   }
 
   private changeDefaultOnActionSelection(auditActions: AuditAction): void {
@@ -496,5 +499,20 @@ export class AuditCreateComponent implements OnInit, OnDestroy {
           this.dialogRef.close({ success: false, action: 'none' });
         },
       );
+  }
+
+  private buildProducerServicesOptions({
+    accessionRegisterSummaries,
+    originatingAgenciesOptions,
+  }: {
+    accessionRegisterSummaries: AccessionRegisterSummary[];
+    originatingAgenciesOptions: Option[];
+  }): Option[] {
+    const originatingAgencyLabelById = new Map(originatingAgenciesOptions.map((option) => [option.key, option.label]));
+
+    return accessionRegisterSummaries.map((summary) => ({
+      key: summary.originatingAgency,
+      label: originatingAgencyLabelById.get(summary.originatingAgency) || summary.originatingAgency,
+    }));
   }
 }


### PR DESCRIPTION
- le sélecteur d’audit enrichit maintenant les producteurs avec les libellés du référentiel agences (ID - nom).
- le composant vitamui-select recherche désormais à la fois sur le libellé et sur la clé, donc l’utilisateur peut filtrer par ID ou par nom.