### PR TITLE
Bug #16602: Logbook operation Internal error 500

### DIFF
--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/config/ApiArchiveServerConfig.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/config/ApiArchiveServerConfig.java
@@ -47,6 +47,7 @@ import fr.gouv.vitamui.commons.api.converter.UpdateMultiQueriesToBulkCommandDto;
 import fr.gouv.vitamui.commons.mongo.dao.CustomSequenceRepository;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
+import fr.gouv.vitamui.commons.rest.config.Jackson2CompatibilityConfig;
 import fr.gouv.vitamui.commons.vitam.api.access.ExportDipV2Service;
 import fr.gouv.vitamui.commons.vitam.api.access.TransferAcknowledgmentService;
 import fr.gouv.vitamui.commons.vitam.api.access.TransferRequestService;
@@ -81,6 +82,7 @@ import org.springframework.web.client.RestClient;
         VitamAdministrationConfig.class,
         MongoDbConfig.class,
         ConverterConfig.class,
+        Jackson2CompatibilityConfig.class,
     }
 )
 public class ApiArchiveServerConfig extends AbstractContextConfiguration {

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/config/ApiCollectServerConfig.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/config/ApiCollectServerConfig.java
@@ -36,6 +36,7 @@ import fr.gouv.vitamui.commons.api.application.AbstractContextConfiguration;
 import fr.gouv.vitamui.commons.mongo.dao.CustomSequenceRepository;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
+import fr.gouv.vitamui.commons.rest.config.Jackson2CompatibilityConfig;
 import fr.gouv.vitamui.commons.vitam.api.administration.ConfigurationService;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAccessConfig;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAdministrationConfig;
@@ -64,6 +65,7 @@ import org.springframework.web.client.RestClient;
         VitamAccessConfig.class,
         VitamCollectConfig.class,
         VitamAdministrationConfig.class,
+        Jackson2CompatibilityConfig.class,
     }
 )
 public class ApiCollectServerConfig extends AbstractContextConfiguration {

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/ApiIamServerConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/ApiIamServerConfig.java
@@ -47,6 +47,7 @@ import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
 import fr.gouv.vitamui.commons.rest.client.BaseVitamuiRestClientFactory;
 import fr.gouv.vitamui.commons.rest.client.configuration.RestClientConfiguration;
+import fr.gouv.vitamui.commons.rest.config.Jackson2CompatibilityConfig;
 import fr.gouv.vitamui.commons.security.client.config.password.PasswordConfiguration;
 import fr.gouv.vitamui.commons.security.client.password.PasswordValidator;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
@@ -135,6 +136,7 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
         VitamAccessConfig.class,
         VitamAdministrationConfig.class,
         ConverterConfig.class,
+        Jackson2CompatibilityConfig.class,
     }
 )
 @EnableConfigurationProperties({ PasswordConfiguration.class })

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/config/ApiReferentialServerConfig.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/config/ApiReferentialServerConfig.java
@@ -43,6 +43,7 @@ import fr.gouv.vitam.access.external.client.AccessExternalClient;
 import fr.gouv.vitam.access.external.client.AdminExternalClient;
 import fr.gouv.vitamui.commons.api.application.AbstractContextConfiguration;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
+import fr.gouv.vitamui.commons.rest.config.Jackson2CompatibilityConfig;
 import fr.gouv.vitamui.commons.vitam.api.access.UnitCommonService;
 import fr.gouv.vitamui.commons.vitam.api.administration.AgencyCommonService;
 import fr.gouv.vitamui.commons.vitam.api.administration.VitamOperationCommonService;
@@ -94,6 +95,7 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
         VitamAccessConfig.class,
         VitamAdministrationConfig.class,
         ConverterConfig.class,
+        Jackson2CompatibilityConfig.class,
     }
 )
 public class ApiReferentialServerConfig extends AbstractContextConfiguration {

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfig.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.rest.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.gouv.vitamui.commons.rest.converter.Jackson2JsonNodeHttpMessageConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverters;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers {@link Jackson2JsonNodeHttpMessageConverter} ahead of the default Jackson 3 converter so that
+ * {@code @RequestBody com.fasterxml.jackson.databind.JsonNode} parameters keep working under Spring Boot 4.
+ * <p>
+ * Must be wired with {@link org.springframework.context.annotation.Import} in each microservice's server
+ * config, since this class lives outside every application's base package and is therefore not picked up by
+ * {@code @SpringBootApplication}'s component scan.
+ * <p>
+ * Uses the non-deprecated {@link #configureMessageConverters(HttpMessageConverters.ServerBuilder)} hook
+ * ({@code extendMessageConverters(List)} is {@code @Deprecated(since = "7.0", forRemoval = true)}).
+ * {@code builder.configureMessageConvertersList(...)} runs once the builder has already assembled the full
+ * default converter list (Jackson 3 included), so we only need to move our converter to the front of that
+ * list rather than rebuild it from scratch.
+ * <p>
+ * To remove once the controllers, their services and the Vitam SDK are migrated to Jackson 3.
+ */
+@Configuration
+public class Jackson2CompatibilityConfig implements WebMvcConfigurer {
+
+    private final ObjectMapper jackson2Mapper;
+
+    public Jackson2CompatibilityConfig(final ObjectMapper jackson2Mapper) {
+        this.jackson2Mapper = jackson2Mapper;
+    }
+
+    @Override
+    public void configureMessageConverters(final HttpMessageConverters.ServerBuilder builder) {
+        builder.configureMessageConvertersList(
+            converters -> converters.addFirst(new Jackson2JsonNodeHttpMessageConverter(jackson2Mapper))
+        );
+    }
+}

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/converter/Jackson2JsonNodeHttpMessageConverter.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/converter/Jackson2JsonNodeHttpMessageConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.rest.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Allows Jackson 2 / Jackson 3 coexistence for {@code @RequestBody com.fasterxml.jackson.databind.JsonNode}
+ * parameters. Spring Boot 4 registers a Jackson 3 ({@code tools.jackson}) converter by default, which cannot
+ * instantiate the abstract Jackson 2 {@link JsonNode} type. This converter reads the raw request body and parses
+ * it explicitly with a Jackson 2 {@link ObjectMapper}.
+ * <p>
+ * Only handles reading: {@link #canWrite(MediaType)} always returns {@code false} so response serialization is
+ * left to the default (Jackson 3) converter.
+ * <p>
+ * To remove once the controllers, their services and the Vitam SDK are migrated to Jackson 3.
+ */
+public class Jackson2JsonNodeHttpMessageConverter extends AbstractHttpMessageConverter<JsonNode> {
+
+    private final ObjectMapper jackson2Mapper;
+
+    public Jackson2JsonNodeHttpMessageConverter(final ObjectMapper jackson2Mapper) {
+        super(MediaType.APPLICATION_JSON, new MediaType("application", "*+json"));
+        this.jackson2Mapper = jackson2Mapper;
+    }
+
+    @Override
+    protected boolean supports(final Class<?> clazz) {
+        return JsonNode.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    protected JsonNode readInternal(final Class<? extends JsonNode> clazz, final HttpInputMessage inputMessage)
+        throws IOException, HttpMessageNotReadableException {
+        final String body = new String(inputMessage.getBody().readAllBytes(), StandardCharsets.UTF_8);
+        return jackson2Mapper.readTree(body);
+    }
+
+    @Override
+    protected void writeInternal(final JsonNode jsonNode, final HttpOutputMessage outputMessage)
+        throws IOException, HttpMessageNotWritableException {
+        outputMessage.getBody().write(jackson2Mapper.writeValueAsBytes(jsonNode));
+    }
+
+    @Override
+    protected boolean canWrite(final MediaType mediaType) {
+        return false;
+    }
+}

--- a/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/RestTestApplicationConfiguration.java
+++ b/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/RestTestApplicationConfiguration.java
@@ -1,5 +1,6 @@
 package fr.gouv.vitamui.commons.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.gouv.vitamui.commons.rest.client.configuration.HttpPoolConfiguration;
 import fr.gouv.vitamui.commons.rest.client.configuration.RestClientConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -33,5 +34,10 @@ public class RestTestApplicationConfiguration {
     @ConfigurationProperties("rest-client2")
     public RestClientConfiguration getRestClientConfiguration2() {
         return new RestClientConfiguration();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfigRegressionTest.java
+++ b/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfigRegressionTest.java
@@ -1,0 +1,68 @@
+package fr.gouv.vitamui.commons.rest.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+/**
+ * Regression test documenting the failure that {@link Jackson2CompatibilityConfig} was introduced to fix.
+ *
+ * <p>When only the default Spring Boot 4 Jackson 3 converter
+ * ({@link JacksonJsonHttpMessageConverter}, backed by {@code tools.jackson.databind.JsonMapper})
+ * is active, it cannot instantiate the abstract Jackson 2 type
+ * {@code com.fasterxml.jackson.databind.JsonNode}. Spring MVC raises an
+ * {@code HttpMessageConversionException} with "Type definition error" on any endpoint
+ * declaring {@code @RequestBody JsonNode}.
+ *
+ * <p>This test uses a standalone {@link MockMvc} setup to control the converter list precisely,
+ * bypassing the full Spring Boot context (where {@link Jackson2CompatibilityConfig} is always
+ * present via component scan). The counterpart passing test is
+ * {@link Jackson2CompatibilityConfigTest}.
+ */
+class Jackson2CompatibilityConfigRegressionTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        // Register only the Jackson 3 converter — no Jackson2JsonNodeHttpMessageConverter
+        mockMvc = MockMvcBuilders.standaloneSetup(new JsonNodeController())
+            .setMessageConverters(new JacksonJsonHttpMessageConverter())
+            .build();
+    }
+
+    @RestController
+    static class JsonNodeController {
+
+        @PostMapping(value = "/test/jsonNode", consumes = MediaType.APPLICATION_JSON_VALUE)
+        public String echo(@RequestBody final JsonNode body) {
+            return body.path("key").asText();
+        }
+    }
+
+    @Test
+    void whenOnlyJackson3ConverterPresent_thenJsonNodeDeserializationFails() {
+        // Without Jackson2JsonNodeHttpMessageConverter, the Jackson 3 converter (JacksonJsonHttpMessageConverter)
+        // raises HttpMessageConversionException because it cannot construct the abstract Jackson 2 type
+        // com.fasterxml.jackson.databind.JsonNode. The exception propagates out of MockMvc since
+        // DefaultHandlerExceptionResolver does not handle HttpMessageConversionException.
+        assertThatThrownBy(
+            () ->
+                mockMvc.perform(
+                    post("/test/jsonNode").contentType(MediaType.APPLICATION_JSON).content("{\"key\": \"value\"}")
+                )
+        )
+            .hasMessageContaining("Type definition error")
+            .hasMessageContaining("com.fasterxml.jackson.databind.JsonNode");
+    }
+}

--- a/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfigTest.java
+++ b/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfigTest.java
@@ -1,0 +1,67 @@
+package fr.gouv.vitamui.commons.rest.config;
+
+import fr.gouv.vitamui.commons.rest.RestTestApplication;
+import fr.gouv.vitamui.commons.rest.controller.TestController;
+import fr.gouv.vitamui.commons.rest.converter.Jackson2JsonNodeHttpMessageConverter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link Jackson2CompatibilityConfig}.
+ *
+ * <p>Verifies, in a real Spring Boot 4 context, that importing {@code Jackson2CompatibilityConfig}:
+ * <ol>
+ *   <li>Allows a controller with {@code @RequestBody com.fasterxml.jackson.databind.JsonNode} to
+ *       deserialize a JSON body without error (the default Jackson 3 converter alone cannot do
+ *       this — see {@link Jackson2CompatibilityConfigRegressionTest}).</li>
+ *   <li>Places {@link Jackson2JsonNodeHttpMessageConverter} ahead of the default Jackson 3
+ *       converter in the resolved {@code HttpMessageConverter} list.</li>
+ * </ol>
+ *
+ * <p>{@link Jackson2CompatibilityConfig} lives in a sub-package of {@link RestTestApplication}'s
+ * base package and is therefore auto-scanned in this test context — no explicit {@code @Import} is
+ * needed here (unlike in production microservices where it must be wired with {@code @Import}).
+ */
+@SpringBootTest(classes = RestTestApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureRestTestClient
+class Jackson2CompatibilityConfigTest {
+
+    @Autowired
+    private RestTestClient restTestClient;
+
+    @Autowired
+    private RequestMappingHandlerAdapter handlerAdapter;
+
+    @Test
+    void whenJackson2CompatibilityConfigActive_thenJsonNodeDeserializationSucceeds() {
+        restTestClient
+            .post()
+            .uri(TestController.JACKSON2_JSON_NODE)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{\"key\": \"value\"}")
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.OK)
+            .expectBody(String.class)
+            .isEqualTo("value");
+    }
+
+    @Test
+    void whenJackson2CompatibilityConfigActive_thenJackson2ConverterIsFirstInList() {
+        final List<HttpMessageConverter<?>> converters = handlerAdapter.getMessageConverters();
+        assertThat(converters).isNotEmpty().first().isInstanceOf(Jackson2JsonNodeHttpMessageConverter.class);
+    }
+}

--- a/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/controller/TestController.java
+++ b/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/controller/TestController.java
@@ -1,5 +1,6 @@
 package fr.gouv.vitamui.commons.rest.controller;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.ParseOperationException;
@@ -94,6 +95,8 @@ public class TestController {
     public static final String VALIDATION_EXCEPTION = "/test/validationException";
 
     public static final String REQUEST_TIMEOUT_ERROR = "/test/requestTimeOutException";
+
+    public static final String JACKSON2_JSON_NODE = "/test/jackson2JsonNode";
 
     @PostMapping(value = VITAMUI_EXCEPTION, consumes = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody String vitamuiException(@RequestBody final VitamUIDto name) {
@@ -251,6 +254,11 @@ public class TestController {
     @RequestMapping(value = REQUEST_TIMEOUT_ERROR)
     public String getRequestTimeOutException() {
         throw ApiErrorGenerator.getRequestTimeOutException();
+    }
+
+    @PostMapping(value = JACKSON2_JSON_NODE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody String jackson2JsonNode(@RequestBody final JsonNode body) {
+        return body.path("key").asText();
     }
 
     @Override


### PR DESCRIPTION
## Description

Spring Boot 4 registers a Jackson 3 (tools.jackson) converter by default, which cannot instantiate the abstract Jackson 2 (com.fasterxml.jackson.databind) JsonNode type still required by the Vitam SDK client. This broke deserialization of @RequestBody JsonNode parameters across the affected controllers.

Add Jackson2JsonNodeHttpMessageConverter and Jackson2CompatibilityConfig to register a dedicated Jackson 2 converter ahead of the default Jackson 3 one, restoring correct JsonNode deserialization while keeping Jackson 3 for everything else.

To be removed once controllers, services and the Vitam SDK are fully migrated to Jackson 3.

## Type de changement

* Correction