### PR TITLE
Bug #16596: [Funds Registry] - The label of the "Select All" checkbox in the "Entry Method" filter is not translated.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.html
@@ -108,7 +108,7 @@
                     class="mat-mdc-option-pseudo-checkbox"
                   ></mat-pseudo-checkbox>
                   <span class="mat-mdc-option-text text normal secondary bold">
-                    {{ selectAllLabel }}
+                    {{ selectAllLabel | translate }}
                   </span>
                 </div>
                 <mat-divider></mat-divider>

--- a/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/components/select/select.component.ts
@@ -72,7 +72,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatOption, MatOptionModule, MatOptionSelectionChange, MatPseudoCheckboxModule } from '@angular/material/core';
 import { MatSelect, MatSelectModule } from '@angular/material/select';
 import { PipesModule } from '../../../app/modules/pipes/pipes.module';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { normalizeString } from '../../utils/string.util';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
@@ -127,7 +127,6 @@ export interface VitamuiSelectOptions {
 export class SelectComponent extends AbstractFormInputDirective implements AfterViewInit, AfterViewChecked {
   private cd = inject(ChangeDetectorRef);
   readonly sd = inject(ScrollDispatcher);
-  private translateService = inject(TranslateService);
 
   @Input() placeholder: string;
   @Input() searchBarPlaceHolder: string;
@@ -218,7 +217,7 @@ export class SelectComponent extends AbstractFormInputDirective implements After
 
   private optionsResource: Resource<VitamuiSelectOptions | any[]>;
 
-  @Input() selectAllLabel = this.translateService.instant('SELECT.SELECT_ALL');
+  @Input() selectAllLabel = 'SELECT.SELECT_ALL';
   @Input() allSelectedLabel?: string;
   loading: Signal<boolean> = computed(() => (this.optionsResource ? this.optionsResource.isLoading() : false));
 


### PR DESCRIPTION
Cause racine : Le composant partagé vitamui-select initialise selectAllLabel avec :

@Input() selectAllLabel = this.translateService.instant('SELECT.SELECT_ALL');

Cet appel à instant() est exécuté une seule fois à la création du composant. 
Si les traductions ne sont pas encore chargées, la clé SELECT.SELECT_ALL est renvoyée telle quelle et n'est jamais mise à jour lors d'un changement de langue.