### PR TITLE
Bug #16620: [Profile Groups] 500 Error When Exporting the List of Profile Groups.

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/group/dto/ProfileGroupExport.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/group/dto/ProfileGroupExport.java
@@ -8,7 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.mapstruct.ap.internal.util.Strings;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -113,7 +112,7 @@ public final class ProfileGroupExport implements LineDto {
     }
 
     private String parseDateToFormat(String date) {
-        if (Strings.isEmpty(date)) {
+        if (date == null || date.isBlank()) {
             return "";
         }
         var frDate = LocalDateTime.parse(date).plusHours(1);

--- a/api/api-pastis/pastis-commons/pom.xml
+++ b/api/api-pastis/pastis-commons/pom.xml
@@ -75,11 +75,6 @@
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok</artifactId>
                 </exclusion>
-                <!-- exclusion for Lombok-->
-                <exclusion>
-                    <groupId>org.mapstruct</groupId>
-                    <artifactId>mapstruct-processor</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,7 +51,6 @@
         <jsonassert.version>1.5.3</jsonassert.version>
         <logback.version>1.5.34</logback.version>
         <lombok.version>1.18.46</lombok.version>
-        <mapstruct.version>1.6.3</mapstruct.version>
         <micrometer.version>1.16.5</micrometer.version>
         <nio.multipart.parser.version>1.1.0</nio.multipart.parser.version>
         <opencsv.version>5.12.0</opencsv.version>
@@ -547,13 +546,6 @@
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
                 <scope>provided</scope>
-            </dependency>
-
-            <!-- Dependency for Lombok-->
-            <dependency>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${mapstruct.version}</version>
             </dependency>
 
             <dependency>

--- a/commons/commons-api/pom.xml
+++ b/commons/commons-api/pom.xml
@@ -85,11 +85,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>
-        <!-- Dependency for Lombok-->
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/commons/commons-utils/pom.xml
+++ b/commons/commons-utils/pom.xml
@@ -50,11 +50,6 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!-- Dependency for Lombok-->
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>


### PR DESCRIPTION
après la migration de spring mapstruct-processor ( qui contient  org.mapstruct:mapstruct-processor ) n'est plus disponible au runtime.

supprimer la dep "mapstruct" qui n'est utilisée que ici.