### PR TITLE
Bug #16638: [Identity] Fix 401 error when exporting users.

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
@@ -320,7 +320,9 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
         final boolean applyAuthorization
     ) {
         try (final var xlsOutputStream = new ByteArrayOutputStream()) {
-            final List<UserDto> usersDto = this.getAll(criteria);
+            final List<UserDto> usersDto = applyAuthorization
+                ? this.getAll(criteria)
+                : this.getAllByAuthorizedCriteria(criteria);
             final List<String> userIds = usersDto.stream().map(UserDto::getIdentifier).collect(Collectors.toList());
             final List<String> userInfoIds = usersDto.stream().map(UserDto::getUserInfoId).collect(Collectors.toList());
             final List<String> userGroupIds = usersDto.stream().map(UserDto::getGroupId).collect(Collectors.toList());


### PR DESCRIPTION
il faut appler getAllByAuthorizedCriteria() au lieu de getAll(criteria), car l'export signé utilise désormais les critères déjà autorisés du token, sans relire le SecurityContext absent.
