### PR TITLE
CP V9.0 - Bug #16591: prevent tooltip flickering on screen resize by disabling overlay push

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/common-tooltip/tooltip.directive.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/common-tooltip/tooltip.directive.ts
@@ -157,7 +157,7 @@ export class TooltipDirective implements OnInit, OnDestroy, OnChanges {
 
   private createOverlayRef() {
     const position = VITAMUI_TOOL_TIP_POSITIONS[this.vitamuiTooltipPosition];
-    const positionStrategy = this.overlayPositionBuilder.flexibleConnectedTo(this.elementRef).withPositions([position]);
+    const positionStrategy = this.overlayPositionBuilder.flexibleConnectedTo(this.elementRef).withPositions([position]).withPush(false);
     this.#overlayRef = this.overlay.create({
       positionStrategy,
       scrollStrategy: this.overlay.scrollStrategies.reposition(),


### PR DESCRIPTION
see #3815 