### PR TITLE
Bug #16637: [Referential] Fix 500 error when generating an evidentiary value report.

### DIFF
--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/converter/Jackson2JsonNodeHttpMessageConverter.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/converter/Jackson2JsonNodeHttpMessageConverter.java
@@ -36,20 +36,18 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Field;
 
 /**
  * Allows Jackson 2 / Jackson 3 coexistence for {@code @RequestBody com.fasterxml.jackson.databind.JsonNode}
- * parameters. Spring Boot 4 registers a Jackson 3 ({@code tools.jackson}) converter by default, which cannot
- * instantiate the abstract Jackson 2 {@link JsonNode} type. This converter reads the raw request body and parses
- * it explicitly with a Jackson 2 {@link ObjectMapper}.
+ * parameters and DTOs containing a Jackson 2 {@link JsonNode}. Spring Boot 4 registers a Jackson 3
+ * ({@code tools.jackson}) converter by default, which cannot instantiate the abstract Jackson 2 type.
  * <p>
- * Only handles reading: {@link #canWrite(MediaType)} always returns {@code false} so response serialization is
- * left to the default (Jackson 3) converter.
+ * The converter deliberately declines unrelated types so that they remain handled by the default Jackson 3 converter.
  * <p>
  * To remove once the controllers, their services and the Vitam SDK are migrated to Jackson 3.
  */
-public class Jackson2JsonNodeHttpMessageConverter extends AbstractHttpMessageConverter<JsonNode> {
+public class Jackson2JsonNodeHttpMessageConverter extends AbstractHttpMessageConverter<Object> {
 
     private final ObjectMapper jackson2Mapper;
 
@@ -60,24 +58,41 @@ public class Jackson2JsonNodeHttpMessageConverter extends AbstractHttpMessageCon
 
     @Override
     protected boolean supports(final Class<?> clazz) {
-        return JsonNode.class.isAssignableFrom(clazz);
+        return requiresJackson2(clazz);
     }
 
     @Override
-    protected JsonNode readInternal(final Class<? extends JsonNode> clazz, final HttpInputMessage inputMessage)
+    protected Object readInternal(final Class<?> clazz, final HttpInputMessage inputMessage)
         throws IOException, HttpMessageNotReadableException {
-        final String body = new String(inputMessage.getBody().readAllBytes(), StandardCharsets.UTF_8);
-        return jackson2Mapper.readTree(body);
+        return jackson2Mapper.readValue(inputMessage.getBody(), clazz);
     }
 
     @Override
-    protected void writeInternal(final JsonNode jsonNode, final HttpOutputMessage outputMessage)
+    protected void writeInternal(final Object value, final HttpOutputMessage outputMessage)
         throws IOException, HttpMessageNotWritableException {
-        outputMessage.getBody().write(jackson2Mapper.writeValueAsBytes(jsonNode));
+        jackson2Mapper.writeValue(outputMessage.getBody(), value);
     }
 
     @Override
-    protected boolean canWrite(final MediaType mediaType) {
-        return super.canWrite(mediaType);
+    public boolean canWrite(final Class<?> clazz, final MediaType mediaType) {
+        return JsonNode.class.isAssignableFrom(clazz) && super.canWrite(clazz, mediaType);
+    }
+
+    private static boolean requiresJackson2(final Class<?> clazz) {
+        if (clazz == null) {
+            return false;
+        }
+        if (JsonNode.class.isAssignableFrom(clazz)) {
+            return true;
+        }
+
+        for (Class<?> current = clazz; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (Field field : current.getDeclaredFields()) {
+                if (JsonNode.class.isAssignableFrom(field.getType())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfigTest.java
+++ b/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/config/Jackson2CompatibilityConfigTest.java
@@ -60,6 +60,20 @@ class Jackson2CompatibilityConfigTest {
     }
 
     @Test
+    void whenJackson2CompatibilityConfigActive_thenNestedJsonNodeDeserializationSucceeds() {
+        restTestClient
+            .post()
+            .uri(TestController.JACKSON2_JSON_NODE_PROPERTY)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{\"jsonNode\": {\"key\": \"value\"}}")
+            .exchange()
+            .expectStatus()
+            .isEqualTo(HttpStatus.OK)
+            .expectBody(String.class)
+            .isEqualTo("value");
+    }
+
+    @Test
     void whenJackson2CompatibilityConfigActive_thenJackson2ConverterIsFirstInList() {
         final List<HttpMessageConverter<?>> converters = handlerAdapter.getMessageConverters();
         assertThat(converters).isNotEmpty().first().isInstanceOf(Jackson2JsonNodeHttpMessageConverter.class);

--- a/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/controller/TestController.java
+++ b/commons/commons-rest/src/test/java/fr/gouv/vitamui/commons/rest/controller/TestController.java
@@ -1,5 +1,7 @@
 package fr.gouv.vitamui.commons.rest.controller;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -101,6 +103,8 @@ public class TestController {
     public static final String JACKSON2_JSON_NODE = "/test/jackson2JsonNode";
 
     public static final String JACKSON2_JSON_NODE_RETURN = "/test/jackson2JsonNodeReturn";
+
+    public static final String JACKSON2_JSON_NODE_PROPERTY = "/test/jackson2JsonNodeProperty";
 
     @PostMapping(value = VITAMUI_EXCEPTION, consumes = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody String vitamuiException(@RequestBody final VitamUIDto name) {
@@ -270,6 +274,18 @@ public class TestController {
         final ObjectNode node = JsonNodeFactory.instance.objectNode();
         node.put("key", "value");
         return node;
+    }
+
+    @PostMapping(value = JACKSON2_JSON_NODE_PROPERTY, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody String jackson2JsonNodeProperty(@RequestBody final Jackson2JsonNodeContainer body) {
+        return body.jsonNode().path("key").asText();
+    }
+
+    public record Jackson2JsonNodeContainer(JsonNode jsonNode) {
+        @JsonCreator
+        public Jackson2JsonNodeContainer(@JsonProperty("jsonNode") final JsonNode jsonNode) {
+            this.jsonNode = jsonNode;
+        }
     }
 
     @Override


### PR DESCRIPTION
Problème : 
Depuis Spring Boot 4, le convertisseur Jackson 3 par défaut ne sait pas instancier le JsonNode abstrait de Jackson 2 utilisé par le SDK Vitam ; le convertisseur maison de compatibilité ne gérait que les corps de requête étant directement un JsonNode, donc le rapport de valeur probante  (ProbativeValueRequest, un DTO contenant un champ JsonNode imbriqué) échouait en HTTP 500.

 Solution :
 Le convertisseur a été généralisé pour détecter par réflexion les DTO possédant un champ JsonNode et les désérialiser entièrement via l'ObjectMapper Jackson 2 (readValue), tout en limitant la sérialisation en réponse aux seuls vrais JsonNode.