### PR TITLE
Bug #16639: [Search/Collect] CSV export of more than 10,000 archive units displays a 413 error instead of the expected snackbar.

### DIFF
--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/rest/ArchivesSearchController.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/rest/ArchivesSearchController.java
@@ -258,11 +258,14 @@ public class ArchivesSearchController {
     @PostMapping(RestApi.EXPORT_CSV_SEARCH_PATH + "/signed-url")
     @Secured(ServicesData.ARCHIVE_SEARCH_GET_ARCHIVE_SEARCH_ROLE)
     public String prepareSignedExportCsvArchiveUnitsByCriteria(final @RequestBody SearchCriteriaDto query)
-        throws PreconditionFailedException {
+        throws PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter(MANDATORY_QUERY, query);
         SanityChecker.sanitizeCriteria(query);
         LOGGER.debug("Prepare signed export to csv search archive Units By Criteria {} ", query);
         archiveSearchThresholdService.retrieveProfilThresholds().ifPresent(query::setThreshold);
+        // Check the results size limit here so the 413 is returned on this request (the one the
+        // client subscribes to) and the limit-reached snackbar can be displayed.
+        archiveSearchUnitExportCsvService.checkExportCsvSizeLimit(query);
 
         DownloadClaims claims = new DownloadClaims();
         claims.setResource(ARCHIVE_UNIT_EXPORT_RESOURCE);

--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/service/ArchiveSearchUnitExportCsvService.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/service/ArchiveSearchUnitExportCsvService.java
@@ -277,6 +277,20 @@ public class ArchiveSearchUnitExportCsvService {
     }
 
     /**
+     * Check the results size limit before generating a signed download URL, so that the
+     * {@link RequestEntityTooLargeException} (HTTP 413) is raised on the request the client
+     * subscribes to instead of during the browser navigation to the signed URL.
+     */
+    public void checkExportCsvSizeLimit(final SearchCriteriaDto searchQuery) throws VitamClientException {
+        VitamContext vitamContext = archiveSearchExternalParametersService.buildVitamContextFromExternalParam();
+        try {
+            checkSizeLimit(vitamContext, searchQuery);
+        } catch (IOException e) {
+            throw new BadRequestException("Can't parse criteria as Vitam query", e);
+        }
+    }
+
+    /**
      * check limit of results limit
      *
      * @param vitamContext

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionArchiveUnitController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionArchiveUnitController.java
@@ -162,11 +162,18 @@ public class TransactionArchiveUnitController {
     public String prepareSignedExportCsvArchiveUnitsByCriteria(
         final @PathVariable("transactionId") String transactionId,
         final @RequestBody SearchCriteriaDto query
-    ) throws PreconditionFailedException {
+    ) throws PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter(MANDATORY_QUERY, query);
         SanityChecker.checkSecureParameter(transactionId);
         SanityChecker.sanitizeCriteria(query);
         LOGGER.debug("Prepare signed export to csv search archive Units By Criteria {} ", query);
+        // Check the results size limit here so the 413 is returned on this request (the one the
+        // client subscribes to) and the limit-reached snackbar can be displayed.
+        transactionArchiveUnitService.checkExportCsvSizeLimit(
+            transactionId,
+            query,
+            externalParametersService.buildVitamContextFromExternalParam()
+        );
 
         DownloadClaims claims = new DownloadClaims();
         claims.setResource(COLLECT_TRANSACTION_ARCHIVE_UNIT_EXPORT_RESOURCE);

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionArchiveUnitService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionArchiveUnitService.java
@@ -886,6 +886,23 @@ public class TransactionArchiveUnitService {
         return archiveUnit;
     }
 
+    /**
+     * Check the results size limit before generating a signed download URL, so that the
+     * {@link RequestEntityTooLargeException} (HTTP 413) is raised on the request the client
+     * subscribes to instead of during the browser navigation to the signed URL.
+     */
+    public void checkExportCsvSizeLimit(
+        String transactionId,
+        final SearchCriteriaDto searchQuery,
+        final VitamContext vitamContext
+    ) throws VitamClientException {
+        try {
+            checkSizeLimit(transactionId, vitamContext, searchQuery);
+        } catch (IOException | InvalidParseOperationException | InvalidCreateOperationException e) {
+            throw new BadRequestException("Can't parse criteria as Vitam query", e);
+        }
+    }
+
     private void checkSizeLimit(String transactionId, VitamContext vitamContext, SearchCriteriaDto searchQuery)
         throws VitamClientException, IOException, InvalidCreateOperationException, InvalidParseOperationException {
         SearchCriteriaDto searchQueryCounting = new SearchCriteriaDto();

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
@@ -1,5 +1,8 @@
 {
   "COLLECT": {
+    "EXPORT_CSV": {
+      "EXPORT_CSV_LIMIT_REACHED": "It's not possible to export more than 10,000 results, please update your filters."
+    },
     "ADD_UNITS": {
       "ACTION_TITLE": "Add archival units",
       "TITLE": "Add archival units to the upload project",

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
@@ -1,5 +1,8 @@
 {
   "COLLECT": {
+    "EXPORT_CSV": {
+      "EXPORT_CSV_LIMIT_REACHED": "Il n'est pas possible de réaliser un export csv sur plus de 10 000 résultats de recherche, veuillez restreindre votre sélection ou affiner votre recherche."
+    },
     "ADD_UNITS": {
       "ACTION_TITLE": "Ajouter des unités archivistiques",
       "TITLE": "Ajouter des unités archivistiques au projet de versement",


### PR DESCRIPTION
déplacer le contrôle du seuil à l'étape de préparation de l'URL signée, pour que le 413 soit renvoyé sur la requête.