### PR TITLE
Bug #16646: [Pastis, Access/Entry contract] The download of profiles and templates starts without notifying the user.

### DIFF
--- a/ui/ui-frontend/projects/pastis/src/app/profile/profile-preview/profile-preview.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/profile/profile-preview/profile-preview.component.ts
@@ -186,6 +186,7 @@ export class ProfilePreviewComponent implements AfterViewInit {
     link.download = typeProfile === ProfileType.PA ? inputProfile.path : 'pastis_' + inputProfile.identifier + '.json';
     // this is necessary as link.click() does not work on the latest firefox
     link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+    this.snackBarService.notifyDownloadStarted();
     setTimeout(() => {
       // For Firefox it is necessary to delay revoking the ObjectURL
       window.URL.revokeObjectURL(data);

--- a/ui/ui-frontend/projects/pastis/src/app/user-actions/save-profile/save-profile.component.ts
+++ b/ui/ui-frontend/projects/pastis/src/app/user-actions/save-profile/save-profile.component.ts
@@ -374,6 +374,7 @@ export class UserActionSaveProfileComponent implements OnInit, OnDestroy {
         link.download = filename;
         // this is necessary as link.click() does not work on the latest firefox
         link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+        this.snackBarService.notifyDownloadStarted();
         setTimeout(() => {
           // For Firefox it is necessary to delay revoking the ObjectURL
           window.URL.revokeObjectURL(href);

--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract.component.ts
@@ -58,6 +58,8 @@ import { AccessContractCreateComponent } from './access-contract-create/access-c
 import { AccessContractListComponent } from './access-contract-list/access-contract-list.component';
 import { finalize, shareReplay } from 'rxjs/operators';
 
+const IMPORT_FILE_MODEL_NAME = 'Import_access_contrat_template.csv';
+
 @Component({
   selector: 'app-access',
   templateUrl: './access-contract.component.html',
@@ -155,11 +157,10 @@ export class AccessContractComponent extends SidenavPage<AccessContract> impleme
   }
 
   public downloadModel(): void {
-    this.accessContractService
-      .downloadImportAccessContractFileModel()
-      .subscribe((response: HttpResponse<Blob>) =>
-        DownloadUtils.loadFromBlob(response, response.body.type, 'Import_access_contrat_template.csv'),
-      );
+    this.accessContractService.downloadImportAccessContractFileModel().subscribe((response: HttpResponse<Blob>) => {
+      DownloadUtils.loadFromBlob(response, response.body.type, IMPORT_FILE_MODEL_NAME);
+      this.snackBarService.notifyDownloadStarted();
+    });
   }
 
   public onSearchSubmit(search: string) {

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract.component.ts
@@ -59,6 +59,8 @@ import { ImportDialogComponent } from '../shared/import-dialog/import-dialog.com
 import { IngestContractService } from './ingest-contract.service';
 import { HttpResponse } from '@angular/common/http';
 
+const IMPORT_FILE_MODEL_NAME = 'Import_ingest_contract_template.csv';
+
 @Component({
   selector: 'app-ingest-contract',
   templateUrl: './ingest-contract.component.html',
@@ -170,11 +172,10 @@ export class IngestContractComponent extends SidenavPage<IngestContract> impleme
   }
 
   public downloadModel(): void {
-    this.ingestContractService
-      .downloadImportFileModel()
-      .subscribe((response: HttpResponse<Blob>) =>
-        DownloadUtils.loadFromBlob(response, response.body.type, 'Import_ingest_contract_template.csv'),
-      );
+    this.ingestContractService.downloadImportFileModel().subscribe((response: HttpResponse<Blob>) => {
+      DownloadUtils.loadFromBlob(response, response.body.type, IMPORT_FILE_MODEL_NAME);
+      this.snackBarService.notifyDownloadStarted();
+    });
   }
 
   public export(): void {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/snack-bar/snack-bar.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/snack-bar/snack-bar.service.ts
@@ -85,11 +85,15 @@ export class SnackBarService {
     return this.matSnackBar.openFromComponent(component, { duration, data });
   }
 
-  public startDownload(url: string): void {
+  public notifyDownloadStarted(): void {
     this.open({
       message: DOWNLOAD_STARTED_MESSAGE,
       icon: 'vitamui-icon vitamui-icon-telecharger',
     });
+  }
+
+  public startDownload(url: string): void {
+    this.notifyDownloadStarted();
     window.location.href = url;
   }
 


### PR DESCRIPTION
Lors de l'export d'un profil (PA/PUA) ou d'un modèle de contrat (entrée ou accès), le téléchargement est correctement lancé, mais aucun snackbar n'est affiché pour informer l'utilisateur que le téléchargement a démarré.