### PR TITLE
Bug #16633: fix i18n provider fallbackLang

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/lib/i18n/i18n.provider.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/lib/i18n/i18n.provider.ts
@@ -55,7 +55,7 @@ export function provideI18n(): Provider[] {
       provide: MissingTranslationHandler,
       useClass: VitamuiMissingTranslationHandler,
     },
-    defaultLanguage: 'fr',
+    fallbackLang: 'fr',
     loader: {
       provide: TranslateLoader,
       useFactory: httpLoaderFactory,


### PR DESCRIPTION
Fix ngx-translate defaultLang deprecation after angular migration 