### PR TITLE
Bug #15362: [Collect] Fix technical error when validating a manual ingest transaction before the SIP import is complete.

### DIFF
--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/dto/CollectOperationStatusDto.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/dto/CollectOperationStatusDto.java
@@ -25,40 +25,23 @@
  * accept its terms.
  */
 
-package fr.gouv.vitamui.collect.common.rest;
+package fr.gouv.vitamui.collect.common.dto;
 
-import lombok.experimental.UtilityClass;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@UtilityClass
-public class RestApi {
+/**
+ * Status of a Vitam operation (workflow) related to a transaction, e.g. a SIP import.
+ * globalState: PAUSE | RUNNING | COMPLETED
+ * globalStatus: UNKNOWN | STARTED | ALREADY_EXECUTED | OK | WARNING | KO | FATAL
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CollectOperationStatusDto {
 
-    public static final String COLLECT_PATH = "/collect-api/v1";
-    public static final String ARCHIVE_UNITS = "/archive-units";
-    public static final String PROJECTS = "/projects";
-    public static final String CONFIGURATIONS = "/configurations";
+    private String globalState;
 
-    public static final String TRANSACTIONS = "/transactions";
-
-    public static final String OBJECT_GROUPS = "/object-groups";
-    public static final String STREAM_UPLOAD_PATH = "/upload";
-
-    public static final String UPDATE_UNITS_METADATA_PATH = "/update-units-metadata";
-    public static final String SEARCH = "/search";
-    public static final String SEND_PATH = "/send";
-
-    public static final String REOPEN_PATH = "/reopen";
-
-    public static final String ABORT_PATH = "/abort";
-    public static final String VALIDATE_PATH = "/validate";
-    public static final String OPERATION_STATUS_PATH = "/operations/{operationId}/status";
-    public static final String DOWNLOAD_SIP_PATH = "/downloadSip";
-    public static final String SEARCH_CRITERIA_HISTORY = "/searchcriteriahistory";
-    public static final String COLLECT_PROJECT_PATH = COLLECT_PATH + PROJECTS;
-    public static final String COLLECT_CONFIGURATIONS_PATH = COLLECT_PATH + CONFIGURATIONS;
-
-    public static final String COLLECT_ARCHIVE_UNITS = COLLECT_PATH + ARCHIVE_UNITS;
-
-    public static final String COLLECT_TRANSACTION_PATH = COLLECT_PATH + TRANSACTIONS;
-    public static final String COLLECT_TRANSACTION_ARCHIVE_UNITS_PATH = COLLECT_PATH + TRANSACTIONS;
-    public static final String COLLECT_PROJECT_OBJECT_GROUPS_PATH = COLLECT_PATH + PROJECTS + OBJECT_GROUPS;
+    private String globalStatus;
 }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionController.java
@@ -32,6 +32,7 @@ import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitamui.archives.search.common.dto.ReclassificationCriteriaDto;
+import fr.gouv.vitamui.collect.common.dto.CollectOperationStatusDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
 import fr.gouv.vitamui.collect.common.rest.RestApi;
 import fr.gouv.vitamui.collect.server.service.ExternalParametersService;
@@ -73,6 +74,7 @@ import java.util.Objects;
 
 import static fr.gouv.vitamui.collect.common.rest.RestApi.ABORT_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.DOWNLOAD_SIP_PATH;
+import static fr.gouv.vitamui.collect.common.rest.RestApi.OPERATION_STATUS_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.REOPEN_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.SEND_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.UPDATE_UNITS_METADATA_PATH;
@@ -159,6 +161,20 @@ public class TransactionController {
         LOGGER.debug("Find the Transactions with project Id {}", id);
         return transactionService.getTransactionById(
             id,
+            externalParametersService.buildVitamContextFromExternalParam()
+        );
+    }
+
+    @Operation(summary = "Get the status of an operation (workflow) linked to a transaction, e.g. a SIP import")
+    @Secured(ServicesData.ROLE_GET_TRANSACTIONS)
+    @GetMapping(OPERATION_STATUS_PATH)
+    public CollectOperationStatusDto getOperationStatus(final @PathVariable("operationId") String operationId)
+        throws PreconditionFailedException, VitamClientException {
+        ParameterChecker.checkParameter(MANDATORY_IDENTIFIER, operationId);
+        SanityChecker.checkSecureParameter(operationId);
+        LOGGER.debug("Get status of operation {}", operationId);
+        return transactionService.getOperationStatus(
+            operationId,
             externalParametersService.buildVitamContextFromExternalParam()
         );
     }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionService.java
@@ -39,13 +39,18 @@ import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
+import fr.gouv.vitam.common.model.ItemStatus;
+import fr.gouv.vitam.common.model.ProcessState;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitam.common.model.StatusCode;
 import fr.gouv.vitamui.archives.search.common.dto.ReclassificationCriteriaDto;
+import fr.gouv.vitamui.collect.common.dto.CollectOperationStatusDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
 import fr.gouv.vitamui.collect.server.service.converters.TransactionConverter;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
+import fr.gouv.vitamui.commons.vitam.api.administration.VitamOperationCommonService;
 import fr.gouv.vitamui.commons.vitam.api.collect.CollectService;
 import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
@@ -86,6 +91,7 @@ public class TransactionService {
     private static final String ACTION = "$action";
 
     private final CollectService collectService;
+    private final VitamOperationCommonService vitamOperationCommonService;
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -158,6 +164,32 @@ public class TransactionService {
         } catch (VitamClientException | InvalidParseOperationException e) {
             throw new VitamClientException("Unable to find transaction : ", e);
         }
+    }
+
+    /**
+     * Get the current status of a Vitam operation (workflow) linked to a transaction, e.g. a SIP import.
+     * When the operation is unknown to the processing engine (already purged after completion), it is
+     * reported as COMPLETED so callers never stay blocked on a finished workflow.
+     */
+    public CollectOperationStatusDto getOperationStatus(String operationId, VitamContext vitamContext)
+        throws VitamClientException {
+        RequestResponse<ItemStatus> requestResponse = vitamOperationCommonService.getOperationDetailsById(
+            vitamContext,
+            operationId
+        );
+        if (!requestResponse.isOk()) {
+            LOGGER.warn(
+                "Operation {} not found in the processing engine (http code {}), considering it completed",
+                operationId,
+                requestResponse.getHttpCode()
+            );
+            return new CollectOperationStatusDto(ProcessState.COMPLETED.name(), StatusCode.UNKNOWN.name());
+        }
+        ItemStatus itemStatus = ((RequestResponseOK<ItemStatus>) requestResponse).getFirstResult();
+        return new CollectOperationStatusDto(
+            itemStatus.getGlobalState() != null ? itemStatus.getGlobalState().name() : null,
+            itemStatus.getGlobalStatus() != null ? itemStatus.getGlobalStatus().name() : null
+        );
     }
 
     public CollectTransactionDto updateTransaction(

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/TransactionServiceTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/TransactionServiceTest.java
@@ -40,10 +40,15 @@ import fr.gouv.vitam.common.error.VitamErrorDetails;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
+import fr.gouv.vitam.common.model.ItemStatus;
+import fr.gouv.vitam.common.model.ProcessState;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitam.common.model.StatusCode;
+import fr.gouv.vitamui.collect.common.dto.CollectOperationStatusDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
 import fr.gouv.vitamui.collect.server.service.converters.TransactionConverter;
+import fr.gouv.vitamui.commons.vitam.api.administration.VitamOperationCommonService;
 import fr.gouv.vitamui.commons.vitam.api.collect.CollectService;
 import jakarta.ws.rs.core.Response;
 import org.json.JSONException;
@@ -77,6 +82,9 @@ class TransactionServiceTest {
 
     @Mock
     CollectService collectService;
+
+    @Mock
+    VitamOperationCommonService vitamOperationCommonService;
 
     final PodamFactory factory = new PodamFactoryImpl();
     final VitamContext vitamContext = new VitamContext(1);
@@ -376,5 +384,56 @@ class TransactionServiceTest {
             () -> transactionService.downloadSipTransaction(TRANSACTION_ID, vitamContext)
         );
         // The test still works because the exception is thrown before the Mono is created
+    }
+
+    @Test
+    void shouldReturnRunningStatusWhenOperationIsRunning() throws VitamClientException {
+        // GIVEN
+        final String operationId = "OPERATION_ID";
+        ItemStatus itemStatus = new ItemStatus(operationId);
+        itemStatus.setGlobalState(ProcessState.RUNNING);
+        RequestResponseOK<ItemStatus> requestResponse = new RequestResponseOK<>();
+        requestResponse.setHttpCode(200);
+        requestResponse.addResult(itemStatus);
+        when(vitamOperationCommonService.getOperationDetailsById(vitamContext, operationId)).thenReturn(
+            requestResponse
+        );
+
+        // WHEN
+        CollectOperationStatusDto status = transactionService.getOperationStatus(operationId, vitamContext);
+
+        // THEN
+        assertEquals(ProcessState.RUNNING.name(), status.getGlobalState());
+    }
+
+    @Test
+    void shouldReturnCompletedStatusWhenOperationIsUnknown() throws VitamClientException {
+        // GIVEN
+        final String operationId = "OPERATION_ID";
+        VitamError<ItemStatus> vitamError = new VitamError<>("NOT_FOUND");
+        vitamError.setHttpCode(404);
+        when(vitamOperationCommonService.getOperationDetailsById(vitamContext, operationId)).thenReturn(vitamError);
+
+        // WHEN
+        CollectOperationStatusDto status = transactionService.getOperationStatus(operationId, vitamContext);
+
+        // THEN
+        assertEquals(ProcessState.COMPLETED.name(), status.getGlobalState());
+        assertEquals(StatusCode.UNKNOWN.name(), status.getGlobalStatus());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenGetOperationStatusFails() throws VitamClientException {
+        // GIVEN
+        final String operationId = "OPERATION_ID";
+        when(vitamOperationCommonService.getOperationDetailsById(vitamContext, operationId)).thenThrow(
+            VitamClientException.class
+        );
+
+        // THEN
+        assertThrows(
+            VitamClientException.class,
+            () -> transactionService.getOperationStatus(operationId, vitamContext)
+        );
     }
 }

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.ts
@@ -55,6 +55,7 @@ import {
   StartupService,
 } from 'vitamui-library';
 import { ArchiveCollectService } from '../archive-collect.service';
+import { SipImportTrackingService } from '../../shared/sip-import-tracking.service';
 import { FormControl, Validators } from '@angular/forms';
 import { last, tap } from 'rxjs/operators';
 import { HttpEventType } from '@angular/common/http';
@@ -80,6 +81,7 @@ export class AddUnitsComponent implements OnInit {
   private dialog = inject(MatDialog);
   private addUnitsDialogRef = inject<MatDialogRef<AddUnitsComponent>>(MatDialogRef);
   private archiveCollectService = inject(ArchiveCollectService);
+  private sipImportTrackingService = inject(SipImportTrackingService);
 
   protected readonly FilingPlanMode = FilingPlanMode;
   protected readonly uploadMaxSizeInBytes = Math.pow(1024, 3); // 1 Gb
@@ -209,7 +211,9 @@ export class AddUnitsComponent implements OnInit {
 
   private handleUploadSuccess(operationId: string | null): void {
     if (operationId) {
-      // For SIP imports with operation ID
+      // For SIP imports with operation ID: track the import workflow to prevent
+      // validating the transaction before it is over
+      this.sipImportTrackingService.trackSipImport(this.data.transaction.id, operationId);
       const tenantId = this.startupService.getTenantIdentifier();
       this.snackBarService.open({
         message: 'COLLECT.MODAL.IMPORT_SIP_ARCHIVES_PACKAGE_WITH_SUCCESS',

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -75,7 +75,12 @@
               <button mat-menu-item [disabled]="isNotOpen$ | async" (click)="openAddUnitsForm()">
                 {{ 'COLLECT.ADD_UNITS.ACTION_TITLE' | translate }}
               </button>
-              <button mat-menu-item (click)="validateTransaction()" [disabled]="!hasCloseTransactionRole || (isNotOpen$ | async)">
+              <button
+                mat-menu-item
+                (click)="validateTransaction()"
+                [disabled]="!hasCloseTransactionRole || (isNotOpen$ | async) || sipImportInProgress()"
+                [vitamuiTooltip]="sipImportInProgress() ? ('COLLECT.SIP_IMPORT_IN_PROGRESS' | translate) : null"
+              >
                 {{ 'COLLECT.VALIDATE_ACTION' | translate }}
               </button>
               <button mat-menu-item (click)="sendTransaction()" [disabled]="!canSend(transaction)">

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -104,6 +104,7 @@ import { ArchiveSharedDataService } from '../core/archive-shared-data.service';
 import { UpdateUnitsMetadataComponent } from './update-units-metadata/update-units-metadata.component';
 import { AddUnitsComponent } from './add-units/add-units.component';
 import { TransactionsService } from '../transactions/transactions.service';
+import { SipImportTrackingService } from '../shared/sip-import-tracking.service';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { TransactionValidationMode } from '../models/transaction-validation-mode.enum';
 import { BatchStatus } from 'projects/vitamui-library/src/app/modules/models/collect/batch-status';
@@ -138,6 +139,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   private ruleService = inject(RuleService);
   private snackBarService = inject(SnackBarService);
   private transactionService = inject(TransactionsService);
+  private sipImportTrackingService = inject(SipImportTrackingService);
 
   readonly UnitType = UnitType;
 
@@ -1301,6 +1303,10 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
       this.isAllChecked,
       this.isIndeterminate,
     );
+  }
+
+  sipImportInProgress(): boolean {
+    return !!this.transaction && this.sipImportTrackingService.isSipImportInProgress(this.transaction.id);
   }
 
   validateTransaction() {

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
@@ -49,6 +49,7 @@ import {
   Unit,
   VitamError,
 } from 'vitamui-library';
+import { OperationStatus } from '../../models/operation-status.interface';
 import { TransactionValidationMode } from '../../models/transaction-validation-mode.enum';
 
 @Injectable({
@@ -90,6 +91,10 @@ export class TransactionApiService extends PaginatedHttpClient<Transaction> {
 
   abortTransaction(id: string) {
     return this.http.put<Transaction>(this.apiUrl + '/' + id + '/abort', {});
+  }
+
+  getOperationStatus(operationId: string): Observable<OperationStatus> {
+    return this.http.get<OperationStatus>(`${this.apiUrl}/operations/${encodeURIComponent(operationId)}/status`);
   }
 
   downloadSipTransaction(id: string) {

--- a/ui/ui-frontend/projects/collect/src/app/collect/models/operation-status.interface.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/models/operation-status.interface.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+export enum OperationState {
+  PAUSE = 'PAUSE',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+}
+
+export interface OperationStatus {
+  globalState: OperationState;
+  globalStatus: string;
+}

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
@@ -44,6 +44,7 @@ import { last, map, switchMap, tap } from 'rxjs/operators';
 import { ProjectsService } from '../projects.service';
 import { TransactionsService } from '../transactions.service';
 import { ArchiveCollectService } from '../../archive-search-collect/archive-collect.service';
+import { SipImportTrackingService } from '../../shared/sip-import-tracking.service';
 import { HttpEventType, HttpStatusCode } from '@angular/common/http';
 import {
   ExternalReferentialService,
@@ -110,6 +111,7 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
   private tenantSelectionService = inject(TenantSelectionService);
   private transactionsService = inject(TransactionsService);
   private archiveCollectService = inject(ArchiveCollectService);
+  private sipImportTrackingService = inject(SipImportTrackingService);
   private logger = inject(Logger);
   private cdr = inject(ChangeDetectorRef);
   private translationService = inject(TranslateService);
@@ -579,6 +581,16 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
       .subscribe({
         next: (_result) => {
           this.dialogRef.close(true);
+          if (this.importType === ImportType.SIP) {
+            // The response body of a SIP upload is the id of the import workflow operation:
+            // track it to prevent validating the transaction before the workflow is over
+            this.sipImportTrackingService.trackSipImport(transactionId, _result.body);
+            this.snackBarService.open({
+              message: 'COLLECT.UPLOAD.TERMINATED',
+              duration: 10_000,
+            });
+            return;
+          }
           let vitamError: VitamError = JSON.parse(_result.body);
           if (vitamError.httpCode === HttpStatusCode.Ok) {
             this.snackBarService.open({

--- a/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { defer, of, throwError } from 'rxjs';
+import { LoggerModule } from 'vitamui-library';
+
+import { TransactionApiService } from '../core/api/transaction-api.service';
+import { OperationState, OperationStatus } from '../models/operation-status.interface';
+import { SipImportTrackingService } from './sip-import-tracking.service';
+
+describe('SipImportTrackingService', () => {
+  let service: SipImportTrackingService;
+  let transactionApiService: { getOperationStatus: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    transactionApiService = { getOperationStatus: vi.fn() };
+    TestBed.configureTestingModule({
+      imports: [LoggerModule.forRoot()],
+      providers: [{ provide: TransactionApiService, useValue: transactionApiService }],
+    });
+    service = TestBed.inject(SipImportTrackingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should report the SIP import as in progress until the operation is completed', fakeAsync(() => {
+    const statuses: OperationStatus[] = [
+      { globalState: OperationState.RUNNING, globalStatus: 'STARTED' },
+      { globalState: OperationState.COMPLETED, globalStatus: 'OK' },
+    ];
+    let call = 0;
+    // Like HttpClient, the returned observable is cold: each poll triggers a new request
+    transactionApiService.getOperationStatus.mockReturnValue(defer(() => of(statuses[Math.min(call++, statuses.length - 1)])));
+
+    service.trackSipImport('transactionId', 'operationId');
+    expect(service.isSipImportInProgress('transactionId')).toBe(true);
+
+    tick(5_000);
+    expect(service.isSipImportInProgress('transactionId')).toBe(false);
+  }));
+
+  it('should stop blocking the transaction when the status polling fails', fakeAsync(() => {
+    transactionApiService.getOperationStatus.mockReturnValue(throwError(() => new Error('network error')));
+
+    service.trackSipImport('transactionId', 'operationId');
+
+    tick(5_000);
+    expect(service.isSipImportInProgress('transactionId')).toBe(false);
+  }));
+
+  it('should not track anything without an operation id', () => {
+    service.trackSipImport('transactionId', null);
+    expect(service.isSipImportInProgress('transactionId')).toBe(false);
+    expect(transactionApiService.getOperationStatus).not.toHaveBeenCalled();
+  });
+});

--- a/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { distinctUntilChanged, finalize, map } from 'rxjs/operators';
+import { Logger } from 'vitamui-library';
+import { TransactionApiService } from '../core/api/transaction-api.service';
+import { OperationState } from '../models/operation-status.interface';
+import { pollUntil } from '../transactions/polling';
+
+/**
+ * Tracks the SIP import workflows (Vitam operations) launched on transactions during this session.
+ * As long as the import operation of a transaction is not COMPLETED, the transaction must not be
+ * validated, otherwise Vitam raises a technical error.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SipImportTrackingService {
+  private transactionApiService = inject(TransactionApiService);
+  private logger = inject(Logger);
+
+  private static readonly POLLING_PERIOD_MS = 5_000;
+  private static readonly MAX_POLLING_RETRIES = 720; // stop polling after one hour
+
+  private pendingTransactionIds$ = new BehaviorSubject<Set<string>>(new Set());
+
+  /** Starts polling the SIP import operation status until it is completed. */
+  trackSipImport(transactionId: string, operationId: string): void {
+    if (!transactionId || !operationId || this.isSipImportInProgress(transactionId)) {
+      return;
+    }
+    this.setPending(transactionId, true);
+    const status$ = this.transactionApiService.getOperationStatus(operationId);
+    pollUntil(status$, {
+      period: SipImportTrackingService.POLLING_PERIOD_MS,
+      maxRetries: SipImportTrackingService.MAX_POLLING_RETRIES,
+      until: (status) => status.globalState === OperationState.COMPLETED,
+    })
+      // On error or timeout, stop blocking the validation (same behavior as before this guard)
+      .pipe(finalize(() => this.setPending(transactionId, false)))
+      .subscribe({
+        error: (error) => this.logger.warn(this, `Unable to track SIP import operation ${operationId}`, error),
+      });
+  }
+
+  isSipImportInProgress(transactionId: string): boolean {
+    return this.pendingTransactionIds$.value.has(transactionId);
+  }
+
+  sipImportInProgress$(transactionId: string): Observable<boolean> {
+    return this.pendingTransactionIds$.pipe(
+      map((pendingIds) => pendingIds.has(transactionId)),
+      distinctUntilChanged(),
+    );
+  }
+
+  private setPending(transactionId: string, pending: boolean): void {
+    const pendingIds = new Set(this.pendingTransactionIds$.value);
+    if (pending) {
+      pendingIds.add(transactionId);
+    } else {
+      pendingIds.delete(transactionId);
+    }
+    this.pendingTransactionIds$.next(pendingIds);
+  }
+}

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.html
@@ -73,6 +73,9 @@
                 @if (shouldShowBatchError(transaction)) {
                   <div class="text normal danger">{{ 'COLLECT.BATCH_ERROR_RECORDED' | translate }}</div>
                 }
+                @if (sipImportInProgress(transaction)) {
+                  <div class="text normal">{{ 'COLLECT.SIP_IMPORT_IN_PROGRESS' | translate }}</div>
+                }
               </td>
               <td>
                 <div class="hgap-2 justify-content-end">
@@ -92,7 +95,7 @@
                     </button>
                     <button
                       mat-menu-item
-                      [disabled]="!transactionIsOpen(transaction) || !hasCloseTransactionRole"
+                      [disabled]="!transactionIsValidatable(transaction) || !hasCloseTransactionRole"
                       (click)="validateTransaction(transaction)"
                     >
                       {{ 'COLLECT.VALIDATE_ACTION' | translate }}

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
@@ -50,6 +50,7 @@ import {
 import { TransactionsService } from '../transactions.service';
 import { ArchiveCollectService } from '../../archive-search-collect/archive-collect.service';
 import { ProjectsService } from '../../projects/projects.service';
+import { SipImportTrackingService } from '../../shared/sip-import-tracking.service';
 import { MatDialog } from '@angular/material/dialog';
 import { TransactionValidationMode } from '../../models/transaction-validation-mode.enum';
 import { BatchStatus } from 'projects/vitamui-library/src/app/modules/models/collect/batch-status';
@@ -69,6 +70,7 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
   private startupService = inject(StartupService);
   private snackBarService = inject(SnackBarService);
   private dialog = inject(MatDialog);
+  private sipImportTrackingService = inject(SipImportTrackingService);
 
   direction = Direction.DESCENDANT;
   orderBy = 'archivalAgreement';
@@ -212,6 +214,14 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
 
   transactionIsOpen(transaction: Transaction): boolean {
     return TransactionStatus.OPEN === transaction.status;
+  }
+
+  sipImportInProgress(transaction: Transaction): boolean {
+    return this.sipImportTrackingService.isSipImportInProgress(transaction.id);
+  }
+
+  transactionIsValidatable(transaction: Transaction): boolean {
+    return this.transactionIsOpen(transaction) && !this.sipImportInProgress(transaction);
   }
 
   transactionIsEditable(transaction: Transaction): boolean {

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
@@ -284,6 +284,7 @@
     "TRANSACTION_ABORTED": "The ingest request of the project has been aborted",
     "TRANSACTION_REOPENED": "The ingest request of the project has been reopened",
     "BATCH_ERROR_RECORDED": "Errors recorded",
+    "SIP_IMPORT_IN_PROGRESS": "SIP import in progress, validation will be available once the import is complete",
     "PROJECT_TRANSACTION_PREVIEW": {
       "ACTIONS": {
         "SHOW_TRANSACTIONS": "go to list transactions",

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
@@ -284,6 +284,7 @@
     "TRANSACTION_ABORTED": "La demande de versement du projet a été bien abandonnée",
     "TRANSACTION_REOPENED": "La demande de versement du projet a été bien rouverte",
     "BATCH_ERROR_RECORDED": "Erreurs enregistrées",
+    "SIP_IMPORT_IN_PROGRESS": "Import du SIP en cours, la validation sera possible une fois l'import terminé",
     "PROJECT_TRANSACTION_PREVIEW": {
       "ACTIONS": {
         "SHOW_TRANSACTIONS": "Accéder à la liste des versements du projet",


### PR DESCRIPTION
Lors d'un versement manuel avec import de SIP, la pop-up peut être fermée dès la fin du téléversement du fichier, alors que le workflow d'import côté Vitam est encore en cours. 
Si l'utilisateur valide la transaction à ce moment-là, elle passe en erreur technique.
  
=> Le bouton « Valider » est désactivé tant que le workflow d'import SIP n'est pas terminé, avec un message informant l'utilisateur que l'import est en cours.