### PR TITLE
Bug #13095: send relatedTransferReference as an array in transfer request

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/transfer-request-modal/transfer-request-modal.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/transfer-request-modal/transfer-request-modal.component.ts
@@ -207,8 +207,12 @@ export class TransferRequestModalComponent implements OnInit, OnDestroy {
     const step2Values = this.formGroups[1].getRawValue();
     const usages: { usage: ObjectQualifierTypeType; version: QualifierVersion }[] =
       step2Values.includeObjects === UsageVersionEnum.SELECTION ? step2Values.usages : [];
+    const transferRequestParameters = {
+      ...step1Values,
+      relatedTransferReference: step1Values.relatedTransferReference ? [step1Values.relatedTransferReference] : [],
+    };
     const transferRequestDto: TransferRequestDto = {
-      transferRequestParameters: step1Values,
+      transferRequestParameters,
       searchCriteria: this.data.searchCriteria,
       dataObjectVersionsPatterns: usages.reduce(
         (acc: TransferRequestDto['dataObjectVersionsPatterns'], uv) => {


### PR DESCRIPTION
Fixed a 400 error caused by the transfer form sending relatedTransferReference as a string instead of the expected List<String> on the backend.