### PR TITLE
CP V9.0 - Bug #15362: [Collect] Fix technical error when validating a manual ingest transaction before the SIP import is complete.

### DIFF
--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/dto/CollectOperationStatusDto.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/common/dto/CollectOperationStatusDto.java
@@ -25,40 +25,23 @@
  * accept its terms.
  */
 
-package fr.gouv.vitamui.collect.common.rest;
+package fr.gouv.vitamui.collect.common.dto;
 
-import lombok.experimental.UtilityClass;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@UtilityClass
-public class RestApi {
+/**
+ * Status of a Vitam operation (workflow) related to a transaction, e.g. a SIP import.
+ * globalState: PAUSE | RUNNING | COMPLETED
+ * globalStatus: UNKNOWN | STARTED | ALREADY_EXECUTED | OK | WARNING | KO | FATAL
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CollectOperationStatusDto {
 
-    public static final String COLLECT_PATH = "/collect-api/v1";
-    public static final String ARCHIVE_UNITS = "/archive-units";
-    public static final String PROJECTS = "/projects";
-    public static final String CONFIGURATIONS = "/configurations";
+    private String globalState;
 
-    public static final String TRANSACTIONS = "/transactions";
-
-    public static final String OBJECT_GROUPS = "/object-groups";
-    public static final String STREAM_UPLOAD_PATH = "/upload";
-
-    public static final String UPDATE_UNITS_METADATA_PATH = "/update-units-metadata";
-    public static final String SEARCH = "/search";
-    public static final String SEND_PATH = "/send";
-
-    public static final String REOPEN_PATH = "/reopen";
-
-    public static final String ABORT_PATH = "/abort";
-    public static final String VALIDATE_PATH = "/validate";
-    public static final String OPERATION_STATUS_PATH = "/operations/{operationId}/status";
-    public static final String DOWNLOAD_SIP_PATH = "/downloadSip";
-    public static final String SEARCH_CRITERIA_HISTORY = "/searchcriteriahistory";
-    public static final String COLLECT_PROJECT_PATH = COLLECT_PATH + PROJECTS;
-    public static final String COLLECT_CONFIGURATIONS_PATH = COLLECT_PATH + CONFIGURATIONS;
-
-    public static final String COLLECT_ARCHIVE_UNITS = COLLECT_PATH + ARCHIVE_UNITS;
-
-    public static final String COLLECT_TRANSACTION_PATH = COLLECT_PATH + TRANSACTIONS;
-    public static final String COLLECT_TRANSACTION_ARCHIVE_UNITS_PATH = COLLECT_PATH + TRANSACTIONS;
-    public static final String COLLECT_PROJECT_OBJECT_GROUPS_PATH = COLLECT_PATH + PROJECTS + OBJECT_GROUPS;
+    private String globalStatus;
 }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/ProjectController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/ProjectController.java
@@ -26,7 +26,9 @@
  */
 package fr.gouv.vitamui.collect.server.rest;
 
+import fr.gouv.vitam.collect.common.dto.UploadSipResult;
 import fr.gouv.vitam.common.exception.VitamClientException;
+import fr.gouv.vitam.common.model.RequestResponseOK;
 import fr.gouv.vitamui.collect.common.dto.CollectProjectAttachmentsDto;
 import fr.gouv.vitamui.collect.common.dto.CollectProjectConfigurationDto;
 import fr.gouv.vitamui.collect.common.dto.CollectProjectContextDto;
@@ -208,18 +210,23 @@ public class ProjectController {
     @Secured(ServicesData.ROLE_CREATE_PROJECTS)
     @Operation(summary = "Upload and stream SIP")
     @PostMapping(value = "/uploadSip", consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public void streamingUploadSip(
+    public String streamingUploadSip(
         InputStream inputStream,
         @RequestHeader(value = CommonConstants.X_TRANSACTION_ID_HEADER) final String transactionId
-    ) throws PreconditionFailedException {
+    ) throws PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter("The transaction ID is a mandatory parameter: ", transactionId);
         SanityChecker.checkSecureParameter(transactionId);
         LOGGER.debug("[External] upload SIP");
-        projectService.streamingUploadSip(
+        var requestResponse = projectService.streamingUploadSip(
             inputStream,
             transactionId,
             externalParametersService.buildVitamContextFromExternalParam()
         );
+        if (!requestResponse.isOk()) {
+            throw new VitamClientException("Error occurs when uploading SIP to: " + transactionId);
+        }
+        var response = (UploadSipResult) ((RequestResponseOK<?>) requestResponse).getFirstResult();
+        return response.requestId();
     }
 
     @Secured(ServicesData.ROLE_UPDATE_PROJECTS_DESCRIPTION)

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/TransactionController.java
@@ -28,6 +28,7 @@ package fr.gouv.vitamui.collect.server.rest;
 
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.archives.search.common.dto.ReclassificationCriteriaDto;
+import fr.gouv.vitamui.collect.common.dto.CollectOperationStatusDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
 import fr.gouv.vitamui.collect.common.rest.RestApi;
 import fr.gouv.vitamui.collect.server.service.ExternalParametersService;
@@ -62,6 +63,7 @@ import java.io.InputStream;
 
 import static fr.gouv.vitamui.collect.common.rest.RestApi.ABORT_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.DOWNLOAD_SIP_PATH;
+import static fr.gouv.vitamui.collect.common.rest.RestApi.OPERATION_STATUS_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.REOPEN_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.SEND_PATH;
 import static fr.gouv.vitamui.collect.common.rest.RestApi.UPDATE_UNITS_METADATA_PATH;
@@ -136,6 +138,20 @@ public class TransactionController {
         LOGGER.debug("Find the Transactions with project Id {}", id);
         return transactionService.getTransactionById(
             id,
+            externalParametersService.buildVitamContextFromExternalParam()
+        );
+    }
+
+    @Operation(summary = "Get the status of an operation (workflow) linked to a transaction, e.g. a SIP import")
+    @Secured(ServicesData.ROLE_GET_TRANSACTIONS)
+    @GetMapping(OPERATION_STATUS_PATH)
+    public CollectOperationStatusDto getOperationStatus(final @PathVariable("operationId") String operationId)
+        throws PreconditionFailedException, VitamClientException {
+        ParameterChecker.checkParameter(MANDATORY_IDENTIFIER, operationId);
+        SanityChecker.checkSecureParameter(operationId);
+        LOGGER.debug("Get status of operation {}", operationId);
+        return transactionService.getOperationStatus(
+            operationId,
             externalParametersService.buildVitamContextFromExternalParam()
         );
     }

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ProjectService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ProjectService.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.gouv.vitam.collect.common.dto.CriteriaProjectDto;
 import fr.gouv.vitam.collect.common.dto.ProjectDto;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
+import fr.gouv.vitam.collect.common.dto.UploadSipResult;
 import fr.gouv.vitam.collect.external.external.exception.CollectExternalClientInvalidRequestException;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
@@ -234,10 +235,14 @@ public class ProjectService {
         }
     }
 
-    public void streamingUploadSip(InputStream inputStream, String transactionId, VitamContext vitamContext) {
+    public RequestResponse<UploadSipResult> streamingUploadSip(
+        InputStream inputStream,
+        String transactionId,
+        VitamContext vitamContext
+    ) {
         LOGGER.debug("TransactionId: {}", transactionId);
         try {
-            collectService.uploadSipToTransaction(vitamContext, transactionId, inputStream);
+            return collectService.uploadSipToTransaction(vitamContext, transactionId, inputStream);
         } catch (VitamClientException e) {
             LOGGER.debug(UNABLE_TO_UPLOAD_SIP_TO_TRANSACTION, e);
             throw new BadRequestException(UNABLE_TO_UPLOAD_SIP_TO_TRANSACTION, e);

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionService.java
@@ -37,14 +37,19 @@ import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
+import fr.gouv.vitam.common.model.ItemStatus;
+import fr.gouv.vitam.common.model.ProcessState;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitam.common.model.StatusCode;
 import fr.gouv.vitamui.archives.search.common.dto.ReclassificationCriteriaDto;
+import fr.gouv.vitamui.collect.common.dto.CollectOperationStatusDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
 import fr.gouv.vitamui.collect.server.service.converters.TransactionConverter;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.RequestTimeOutException;
+import fr.gouv.vitamui.commons.vitam.api.administration.VitamOperationCommonService;
 import fr.gouv.vitamui.commons.vitam.api.collect.CollectService;
 import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
@@ -86,6 +91,7 @@ public class TransactionService {
     private static final String ACTION = "$action";
 
     private final CollectService collectService;
+    private final VitamOperationCommonService vitamOperationCommonService;
 
     public void validateTransaction(String idTransaction, VitamContext vitamContext) throws VitamClientException {
         try {
@@ -148,6 +154,32 @@ public class TransactionService {
         } catch (VitamClientException | InvalidParseOperationException e) {
             throw new VitamClientException("Unable to find transaction : ", e);
         }
+    }
+
+    /**
+     * Get the current status of a Vitam operation (workflow) linked to a transaction, e.g. a SIP import.
+     * When the operation is unknown to the processing engine (already purged after completion), it is
+     * reported as COMPLETED so callers never stay blocked on a finished workflow.
+     */
+    public CollectOperationStatusDto getOperationStatus(String operationId, VitamContext vitamContext)
+        throws VitamClientException {
+        RequestResponse<ItemStatus> requestResponse = vitamOperationCommonService.getOperationDetailsById(
+            vitamContext,
+            operationId
+        );
+        if (!requestResponse.isOk()) {
+            LOGGER.warn(
+                "Operation {} not found in the processing engine (http code {}), considering it completed",
+                operationId,
+                requestResponse.getHttpCode()
+            );
+            return new CollectOperationStatusDto(ProcessState.COMPLETED.name(), StatusCode.UNKNOWN.name());
+        }
+        ItemStatus itemStatus = ((RequestResponseOK<ItemStatus>) requestResponse).getFirstResult();
+        return new CollectOperationStatusDto(
+            itemStatus.getGlobalState() != null ? itemStatus.getGlobalState().name() : null,
+            itemStatus.getGlobalStatus() != null ? itemStatus.getGlobalStatus().name() : null
+        );
     }
 
     public CollectTransactionDto updateTransaction(

--- a/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/TransactionServiceTest.java
+++ b/api/api-collect/collect/src/test/java/fr/gouv/vitamui/collect/server/service/TransactionServiceTest.java
@@ -34,14 +34,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
 import fr.gouv.vitam.common.client.VitamContext;
+import fr.gouv.vitam.common.error.VitamError;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
+import fr.gouv.vitam.common.model.ItemStatus;
+import fr.gouv.vitam.common.model.ProcessState;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitam.common.model.StatusCode;
+import fr.gouv.vitamui.collect.common.dto.CollectOperationStatusDto;
 import fr.gouv.vitamui.collect.common.dto.CollectTransactionDto;
 import fr.gouv.vitamui.collect.server.service.converters.TransactionConverter;
 import fr.gouv.vitamui.commons.api.exception.RequestTimeOutException;
+import fr.gouv.vitamui.commons.vitam.api.administration.VitamOperationCommonService;
 import fr.gouv.vitamui.commons.vitam.api.collect.CollectService;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -75,6 +81,9 @@ class TransactionServiceTest {
 
     @Mock
     CollectService collectService;
+
+    @Mock
+    VitamOperationCommonService vitamOperationCommonService;
 
     final PodamFactory factory = new PodamFactoryImpl();
     final VitamContext vitamContext = new VitamContext(1);
@@ -359,5 +368,56 @@ class TransactionServiceTest {
             () -> transactionService.downloadSipTransaction(TRANSACTION_ID, vitamContext)
         );
         // The test still works because the exception is thrown before the Mono is created
+    }
+
+    @Test
+    void shouldReturnRunningStatusWhenOperationIsRunning() throws VitamClientException {
+        // GIVEN
+        final String operationId = "OPERATION_ID";
+        ItemStatus itemStatus = new ItemStatus(operationId);
+        itemStatus.setGlobalState(ProcessState.RUNNING);
+        RequestResponseOK<ItemStatus> requestResponse = new RequestResponseOK<>();
+        requestResponse.setHttpCode(200);
+        requestResponse.addResult(itemStatus);
+        when(vitamOperationCommonService.getOperationDetailsById(vitamContext, operationId)).thenReturn(
+            requestResponse
+        );
+
+        // WHEN
+        CollectOperationStatusDto status = transactionService.getOperationStatus(operationId, vitamContext);
+
+        // THEN
+        assertEquals(ProcessState.RUNNING.name(), status.getGlobalState());
+    }
+
+    @Test
+    void shouldReturnCompletedStatusWhenOperationIsUnknown() throws VitamClientException {
+        // GIVEN
+        final String operationId = "OPERATION_ID";
+        VitamError<ItemStatus> vitamError = new VitamError<>("NOT_FOUND");
+        vitamError.setHttpCode(404);
+        when(vitamOperationCommonService.getOperationDetailsById(vitamContext, operationId)).thenReturn(vitamError);
+
+        // WHEN
+        CollectOperationStatusDto status = transactionService.getOperationStatus(operationId, vitamContext);
+
+        // THEN
+        assertEquals(ProcessState.COMPLETED.name(), status.getGlobalState());
+        assertEquals(StatusCode.UNKNOWN.name(), status.getGlobalStatus());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenGetOperationStatusFails() throws VitamClientException {
+        // GIVEN
+        final String operationId = "OPERATION_ID";
+        when(vitamOperationCommonService.getOperationDetailsById(vitamContext, operationId)).thenThrow(
+            VitamClientException.class
+        );
+
+        // THEN
+        assertThrows(
+            VitamClientException.class,
+            () -> transactionService.getOperationStatus(operationId, vitamContext)
+        );
     }
 }

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.collect.common.dto.CriteriaProjectDto;
 import fr.gouv.vitam.collect.common.dto.ProjectDto;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
+import fr.gouv.vitam.collect.common.dto.UploadSipResult;
 import fr.gouv.vitam.collect.external.client.CollectExternalClient;
 import fr.gouv.vitam.collect.external.external.exception.CollectExternalClientException;
 import fr.gouv.vitam.common.CharsetUtils;
@@ -263,13 +264,13 @@ public class CollectService {
      * @return
      * @throws VitamClientException
      */
-    public RequestResponse uploadSipToTransaction(
+    public RequestResponse<UploadSipResult> uploadSipToTransaction(
         final VitamContext vitamContext,
         final String transactionId,
         final InputStream inputStream
     ) throws VitamClientException {
         LOGGER.debug("upload SIP by transaction id : {}", transactionId);
-        final RequestResponse result = collectExternalClient.uploadSipToTransaction(
+        final RequestResponse<UploadSipResult> result = collectExternalClient.uploadSipToTransaction(
             vitamContext,
             transactionId,
             inputStream

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -71,7 +71,12 @@
             <button mat-menu-item [disabled]="isNotOpen$ | async" (click)="openAddUnitsForm()">
               {{ 'COLLECT.ADD_UNITS.ACTION_TITLE' | translate }}
             </button>
-            <button mat-menu-item (click)="validateTransaction()" [disabled]="!hasCloseTransactionRole || (isNotOpen$ | async)">
+            <button
+              mat-menu-item
+              (click)="validateTransaction()"
+              [disabled]="!hasCloseTransactionRole || (isNotOpen$ | async) || sipImportInProgress()"
+              [vitamuiTooltip]="sipImportInProgress() ? ('COLLECT.SIP_IMPORT_IN_PROGRESS' | translate) : null"
+            >
               {{ 'COLLECT.VALIDATE_ACTION' | translate }}
             </button>
             <button mat-menu-item (click)="sendTransaction()" [disabled]="!canSend(transaction)">

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -98,6 +98,7 @@ import { ArchiveSharedDataService } from '../core/archive-shared-data.service';
 import { UpdateUnitsMetadataComponent } from './update-units-metadata/update-units-metadata.component';
 import { AddUnitsComponent } from './add-units/add-units.component';
 import { TransactionsService } from '../transactions/transactions.service';
+import { SipImportTrackingService } from '../shared/sip-import-tracking.service';
 
 const PAGE_SIZE = 10;
 const ELIMINATION_TECHNICAL_ID = 'ELIMINATION_TECHNICAL_ID';
@@ -225,6 +226,7 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     private ruleService: RuleService,
     private snackBarService: SnackBarService,
     private transactionService: TransactionsService,
+    private sipImportTrackingService: SipImportTrackingService,
   ) {
     super(route, globalEventService);
 
@@ -1270,6 +1272,10 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
       this.isAllChecked,
       this.isIndeterminate,
     );
+  }
+
+  sipImportInProgress(): boolean {
+    return !!this.transaction && this.sipImportTrackingService.isSipImportInProgress(this.transaction.id);
   }
 
   validateTransaction() {

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/api/transaction-api.service.ts
@@ -48,6 +48,7 @@ import {
   Transaction,
   Unit,
 } from 'vitamui-library';
+import { OperationStatus } from '../../models/operation-status.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -84,6 +85,10 @@ export class TransactionApiService extends PaginatedHttpClient<Transaction> {
 
   abortTransaction(id: string) {
     return this.http.put<Transaction>(this.apiUrl + '/' + id + '/abort', {});
+  }
+
+  getOperationStatus(operationId: string): Observable<OperationStatus> {
+    return this.http.get<OperationStatus>(`${this.apiUrl}/operations/${encodeURIComponent(operationId)}/status`);
   }
 
   downloadSipTransaction(id: string) {

--- a/ui/ui-frontend/projects/collect/src/app/collect/models/operation-status.interface.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/models/operation-status.interface.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+export enum OperationState {
+  PAUSE = 'PAUSE',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+}
+
+export interface OperationStatus {
+  globalState: OperationState;
+  globalStatus: string;
+}

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
@@ -44,6 +44,7 @@ import { last, map, switchMap, tap } from 'rxjs/operators';
 import { ProjectsService } from '../projects.service';
 import { TransactionsService } from '../transactions.service';
 import { ArchiveCollectService } from '../../archive-search-collect/archive-collect.service';
+import { SipImportTrackingService } from '../../shared/sip-import-tracking.service';
 import { HttpEventType } from '@angular/common/http';
 import {
   ExternalReferentialService,
@@ -153,6 +154,7 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
     private tenantSelectionService: TenantSelectionService,
     private transactionsService: TransactionsService,
     private archiveCollectService: ArchiveCollectService,
+    private sipImportTrackingService: SipImportTrackingService,
     private logger: Logger,
     private cdr: ChangeDetectorRef,
     private translationService: TranslateService,
@@ -508,6 +510,11 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
       )
       .subscribe({
         next: (_result) => {
+          if (this.importType === ImportType.SIP) {
+            // The response body of a SIP upload is the id of the import workflow operation:
+            // track it to prevent validating the transaction before the workflow is over
+            this.sipImportTrackingService.trackSipImport(transactionId, _result.body);
+          }
           this.snackBarService.open({
             message: 'COLLECT.UPLOAD.TERMINATED',
             duration: 10_000,

--- a/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.spec.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { defer, of, throwError } from 'rxjs';
+import { LoggerModule } from 'vitamui-library';
+
+import { TransactionApiService } from '../core/api/transaction-api.service';
+import { OperationState, OperationStatus } from '../models/operation-status.interface';
+import { SipImportTrackingService } from './sip-import-tracking.service';
+
+describe('SipImportTrackingService', () => {
+  let service: SipImportTrackingService;
+  let transactionApiService: { getOperationStatus: jasmine.Spy };
+
+  beforeEach(() => {
+    transactionApiService = { getOperationStatus: jasmine.createSpy('getOperationStatus') };
+    TestBed.configureTestingModule({
+      imports: [LoggerModule.forRoot()],
+      providers: [{ provide: TransactionApiService, useValue: transactionApiService }],
+    });
+    service = TestBed.inject(SipImportTrackingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should report the SIP import as in progress until the operation is completed', fakeAsync(() => {
+    const statuses: OperationStatus[] = [
+      { globalState: OperationState.RUNNING, globalStatus: 'STARTED' },
+      { globalState: OperationState.COMPLETED, globalStatus: 'OK' },
+    ];
+    let call = 0;
+    // Like HttpClient, the returned observable is cold: each poll triggers a new request
+    transactionApiService.getOperationStatus.and.returnValue(defer(() => of(statuses[Math.min(call++, statuses.length - 1)])));
+
+    service.trackSipImport('transactionId', 'operationId');
+    expect(service.isSipImportInProgress('transactionId')).toBe(true);
+
+    tick(5_000);
+    expect(service.isSipImportInProgress('transactionId')).toBe(false);
+  }));
+
+  it('should stop blocking the transaction when the status polling fails', fakeAsync(() => {
+    transactionApiService.getOperationStatus.and.returnValue(throwError(() => new Error('network error')));
+
+    service.trackSipImport('transactionId', 'operationId');
+
+    tick(5_000);
+    expect(service.isSipImportInProgress('transactionId')).toBe(false);
+  }));
+
+  it('should not track anything without an operation id', () => {
+    service.trackSipImport('transactionId', null);
+    expect(service.isSipImportInProgress('transactionId')).toBe(false);
+    expect(transactionApiService.getOperationStatus).not.toHaveBeenCalled();
+  });
+});

--- a/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/shared/sip-import-tracking.service.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { distinctUntilChanged, finalize, map } from 'rxjs/operators';
+import { Logger } from 'vitamui-library';
+import { TransactionApiService } from '../core/api/transaction-api.service';
+import { OperationState } from '../models/operation-status.interface';
+import { pollUntil } from '../transactions/polling';
+
+/**
+ * Tracks the SIP import workflows (Vitam operations) launched on transactions during this session.
+ * As long as the import operation of a transaction is not COMPLETED, the transaction must not be
+ * validated, otherwise Vitam raises a technical error.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SipImportTrackingService {
+  private transactionApiService = inject(TransactionApiService);
+  private logger = inject(Logger);
+
+  private static readonly POLLING_PERIOD_MS = 5_000;
+  private static readonly MAX_POLLING_RETRIES = 720; // stop polling after one hour
+
+  private pendingTransactionIds$ = new BehaviorSubject<Set<string>>(new Set());
+
+  /** Starts polling the SIP import operation status until it is completed. */
+  trackSipImport(transactionId: string, operationId: string): void {
+    if (!transactionId || !operationId || this.isSipImportInProgress(transactionId)) {
+      return;
+    }
+    this.setPending(transactionId, true);
+    const status$ = this.transactionApiService.getOperationStatus(operationId);
+    pollUntil(status$, {
+      period: SipImportTrackingService.POLLING_PERIOD_MS,
+      maxRetries: SipImportTrackingService.MAX_POLLING_RETRIES,
+      until: (status) => status.globalState === OperationState.COMPLETED,
+    })
+      // On error or timeout, stop blocking the validation (same behavior as before this guard)
+      .pipe(finalize(() => this.setPending(transactionId, false)))
+      .subscribe({
+        error: (error) => this.logger.warn(this, `Unable to track SIP import operation ${operationId}`, error),
+      });
+  }
+
+  isSipImportInProgress(transactionId: string): boolean {
+    return this.pendingTransactionIds$.value.has(transactionId);
+  }
+
+  sipImportInProgress$(transactionId: string): Observable<boolean> {
+    return this.pendingTransactionIds$.pipe(
+      map((pendingIds) => pendingIds.has(transactionId)),
+      distinctUntilChanged(),
+    );
+  }
+
+  private setPending(transactionId: string, pending: boolean): void {
+    const pendingIds = new Set(this.pendingTransactionIds$.value);
+    if (pending) {
+      pendingIds.add(transactionId);
+    } else {
+      pendingIds.delete(transactionId);
+    }
+    this.pendingTransactionIds$.next(pendingIds);
+  }
+}

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.html
@@ -67,7 +67,12 @@
             </td>
             <td>{{ transaction.messageIdentifier }}</td>
             <td>{{ transaction.id }}</td>
-            <td>{{ 'COLLECT.PROJECT_TRANSACTION_PREVIEW.STATUS.' + transaction.status | translate }}</td>
+            <td>
+              {{ 'COLLECT.PROJECT_TRANSACTION_PREVIEW.STATUS.' + transaction.status | translate }}
+              @if (sipImportInProgress(transaction)) {
+                <div class="text normal">{{ 'COLLECT.SIP_IMPORT_IN_PROGRESS' | translate }}</div>
+              }
+            </td>
             <td>
               <div class="hgap-2 justify-content-end">
                 @if (transactionIsDownloadable(transaction)) {
@@ -86,7 +91,7 @@
                   </button>
                   <button
                     mat-menu-item
-                    [disabled]="!transactionIsOpen(transaction) || !hasCloseTransactionRole"
+                    [disabled]="!transactionIsValidatable(transaction) || !hasCloseTransactionRole"
                     (click)="validateTransaction(transaction)"
                   >
                     {{ 'COLLECT.VALIDATE_ACTION' | translate }}

--- a/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/transactions/transaction-list/transaction-list.component.ts
@@ -41,6 +41,7 @@ import { Direction, InfiniteScrollTable, SnackBarService, StartupService, Transa
 import { TransactionsService } from '../transactions.service';
 import { ArchiveCollectService } from '../../archive-search-collect/archive-collect.service';
 import { ProjectsService } from '../../projects/projects.service';
+import { SipImportTrackingService } from '../../shared/sip-import-tracking.service';
 
 @Component({
   selector: 'app-transaction-list',
@@ -68,6 +69,7 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
     private router: Router,
     private startupService: StartupService,
     private snackBarService: SnackBarService,
+    private sipImportTrackingService: SipImportTrackingService,
   ) {
     super(transactionService);
   }
@@ -175,6 +177,14 @@ export class TransactionListComponent extends InfiniteScrollTable<Transaction> i
 
   transactionIsOpen(transaction: Transaction): boolean {
     return TransactionStatus.OPEN === transaction.status;
+  }
+
+  sipImportInProgress(transaction: Transaction): boolean {
+    return this.sipImportTrackingService.isSipImportInProgress(transaction.id);
+  }
+
+  transactionIsValidatable(transaction: Transaction): boolean {
+    return this.transactionIsOpen(transaction) && !this.sipImportInProgress(transaction);
   }
 
   transactionIsEditable(transaction: Transaction): boolean {

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
@@ -165,6 +165,7 @@
     "VALIDATE_TRANSACTION_VALIDATED": "The ingest request of the project has been validated",
     "TRANSACTION_ABORTED": "The ingest request of the project has been aborted",
     "TRANSACTION_REOPENED": "The ingest request of the project has been reopened",
+    "SIP_IMPORT_IN_PROGRESS": "SIP import in progress, validation will be available once the import is complete",
     "PROJECT_TRANSACTION_PREVIEW": {
       "ACTIONS": {
         "SHOW_TRANSACTIONS": "go to list transactions",

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
@@ -165,6 +165,7 @@
     "VALIDATE_TRANSACTION_VALIDATED": "La demande de versement du projet a été bien validée",
     "TRANSACTION_ABORTED": "La demande de versement du projet a été bien abandonnée",
     "TRANSACTION_REOPENED": "La demande de versement du projet a été bien rouverte",
+    "SIP_IMPORT_IN_PROGRESS": "Import du SIP en cours, la validation sera possible une fois l'import terminé",
     "PROJECT_TRANSACTION_PREVIEW": {
       "ACTIONS": {
         "SHOW_TRANSACTIONS": "Accéder à la liste des versements du projet",


### PR DESCRIPTION
see: https://github.com/ProgrammeVitam/vitam-ui/pull/3834

- adaptation angular 19/21
-  sur cette version, streamingUploadSip retournait void : le frontend n'aurait jamais reçu l'id de l'opération d'import, et le tracking n'aurait rien bloqué. J'ai backporté la plomberie (issue de la Story #15526)
