### PR TITLE
Bug #15815: fix cas server healthCheck

### DIFF
--- a/cas/cas-server/src/main/resources/application.properties
+++ b/cas/cas-server/src/main/resources/application.properties
@@ -118,6 +118,12 @@ management.health.memoryHealthIndicator.enabled=true
 # Define a default that doesn't require module /cas/actuator/health/ping serves as status
 management.health.ping.enabled=true
 
+# Dedicated health group for Consul routing checks: liveness only (ping), decoupled
+# from diagnostic indicators (e.g. memoryHealthIndicator) that are not indicative of
+# the instance's ability to serve traffic and must not cause Consul to evict it.
+management.endpoint.health.group.consul.include=ping
+management.endpoint.health.group.consul.show-details=always
+
 ##
 # CAS Monitor Security
 #

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -10,7 +10,7 @@ spring:
         serviceName: ${spring.application.name}
         preferIpAddress: true
         ipAddress: ${server.address}
-        healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health
+        healthCheckUrl: http://${management.server.address}:${management.server.port}/actuator/health/consul
         tags: vitamui, {{ vitamui_struct.vitamui_component }}
         instanceId: ${spring.application.name}-${spring.cloud.client.hostname}-${server.port}
 


### PR DESCRIPTION
## Description

L'endpoint **health check** de **cas server** renvoie par intermittence de faux négatifs alors que le service reste pleinement opérationnel.

L'indicateur de mémoire spécifique à CAS (memoryHealthIndicator) est englobé par défaut dans l'endpoint global /actuator/health. Cet indicateur fait passer tout l'Actuator à DOWN dès que l'espace mémoire instantané franchit un seuil fixe (10 %).

## Type de changement

La solution utilise les health group d'Actuator pour créer deux routes distinctes :
- Un groupe dédié au health check de Consul (qui valide uniquement que l'application est prête à recevoir du trafic).
- Le groupe de santé normal d'Actuator (qui conserve les diagnostics profonds, incluant le memoryHealthIndicator de CAS).