### PR TITLE
Bug #16651: Error while searching for the archive

### DIFF
--- a/api/api-archive-search/archive-search/src/main/resources/application.yml
+++ b/api/api-archive-search/archive-search/src/main/resources/application.yml
@@ -29,3 +29,9 @@ swagger:
 
 gateway:
   enabled: true
+
+#Bug #16651: per-collection fields for which sorting is disabled (analyzed fields whose sort is too costly at high volume)
+query:
+  non-sortable-fields:
+    Unit:
+      - Title

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionArchiveUnitService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/TransactionArchiveUnitService.java
@@ -73,6 +73,7 @@ import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.exception.InvalidTypeException;
 import fr.gouv.vitamui.commons.api.exception.RequestEntityTooLargeException;
 import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import fr.gouv.vitamui.commons.api.utils.OntologyServiceReader;
 import fr.gouv.vitamui.commons.vitam.api.administration.AgencyCommonService;
 import fr.gouv.vitamui.commons.vitam.api.administration.RuleCommonService;
@@ -1263,7 +1264,7 @@ public class TransactionArchiveUnitService {
             }
             selectMultiQuery = createSelectMultiQuery(searchQuery.getCriteriaList());
 
-            if (orderBy.isPresent()) {
+            if (orderBy.isPresent() && NonSortableFields.isSortable(NonSortableFields.UNIT_COLLECTION, orderBy.get())) {
                 if (DirectionDto.DESC.equals(direction.get())) {
                     selectMultiQuery.addOrderByDescFilter(orderBy.get());
                 } else {

--- a/api/api-collect/collect/src/main/resources/application.yml
+++ b/api/api-collect/collect/src/main/resources/application.yml
@@ -30,3 +30,9 @@ metrics:
 
 gateway:
   enabled: true
+
+#Bug #16651: per-collection fields for which sorting is disabled (analyzed fields whose sort is too costly at high volume)
+query:
+  non-sortable-fields:
+    Unit:
+      - Title

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/config/NonSortableFieldsAutoConfiguration.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/config/NonSortableFieldsAutoConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.api.config;
+
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutoConfiguration
+@EnableConfigurationProperties(NonSortableFieldsAutoConfiguration.NonSortableFieldsProperties.class)
+public class NonSortableFieldsAutoConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NonSortableFieldsAutoConfiguration.class);
+
+    public NonSortableFieldsAutoConfiguration(final NonSortableFieldsProperties properties) {
+        NonSortableFields.setNonSortableFields(properties.getNonSortableFields());
+        LOGGER.info("Server-side non-sortable metadata fields set to {}", properties.getNonSortableFields());
+    }
+
+    @ConfigurationProperties(prefix = "query")
+    public static class NonSortableFieldsProperties {
+
+        private Map<String, List<String>> nonSortableFields = new HashMap<>();
+
+        public Map<String, List<String>> getNonSortableFields() {
+            return nonSortableFields;
+        }
+
+        public void setNonSortableFields(final Map<String, List<String>> nonSortableFields) {
+            this.nonSortableFields = nonSortableFields;
+        }
+    }
+}

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/dsl/VitamQueryHelper.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/dsl/VitamQueryHelper.java
@@ -27,6 +27,7 @@
 package fr.gouv.vitamui.commons.api.dsl;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.gouv.vitam.common.database.builder.query.BooleanQuery;
 import fr.gouv.vitam.common.database.builder.query.Query;
 import fr.gouv.vitam.common.database.builder.request.exception.InvalidCreateOperationException;
@@ -36,6 +37,7 @@ import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.QueryProjection;
 import fr.gouv.vitamui.commons.api.domain.DirectionDto;
 import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,7 @@ import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,6 +68,9 @@ import static fr.gouv.vitam.common.database.builder.query.QueryHelper.or;
 public class VitamQueryHelper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VitamQueryHelper.class);
+
+    private static final String FILTER = "$filter";
+    private static final String ORDER_BY = "$orderby";
 
     public static void addParameterCriteria(
         BooleanQuery query,
@@ -239,5 +245,35 @@ public class VitamQueryHelper {
 
         LOGGER.debug("Final query: {}", select.getFinalSelect().toPrettyString());
         return select.getFinalSelect();
+    }
+
+    /**
+     * Sorting on an analyzed (text) field is very expensive in Elasticsearch: it forces the use of fielddata,
+     * which loads the whole field into heap memory and can saturate it at scale (see bug #16651).
+     * <p>
+     * This method strips the {@code $orderby} entries from the final DSL for fields blocked in the configuration
+     * ({@link NonSortableFields}) for the given {@code collection}, before the query is sent to Vitam. If
+     * {@code $orderby} becomes empty after this cleanup, it is removed entirely.
+     * <p>
+     */
+    public static void stripNonSortableOrderBy(final String collection, final JsonNode dslQuery) {
+        final Set<String> blocklist = NonSortableFields.getNonSortableFields(collection);
+        if (blocklist.isEmpty() || dslQuery == null || !dslQuery.hasNonNull(FILTER)) {
+            return;
+        }
+        final JsonNode filter = dslQuery.get(FILTER);
+        if (!filter.isObject() || !filter.hasNonNull(ORDER_BY) || !filter.get(ORDER_BY).isObject()) {
+            return;
+        }
+        final ObjectNode orderBy = (ObjectNode) filter.get(ORDER_BY);
+        final Iterator<String> fields = orderBy.fieldNames();
+        while (fields.hasNext()) {
+            if (blocklist.contains(fields.next())) {
+                fields.remove();
+            }
+        }
+        if (orderBy.isEmpty()) {
+            ((ObjectNode) filter).remove(ORDER_BY);
+        }
     }
 }

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtils.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtils.java
@@ -180,7 +180,7 @@ public final class MetadataSearchCriteriaUtils {
                 orderBy = Optional.of(searchQuery.getSortingCriteria().getCriteria());
             }
 
-            if (orderBy.isPresent()) {
+            if (orderBy.isPresent() && NonSortableFields.isSortable(NonSortableFields.UNIT_COLLECTION, orderBy.get())) {
                 if (DirectionDto.DESC.equals(direction.get())) {
                     selectMultiQuery.addOrderByDescFilter(orderBy.get());
                 } else {
@@ -226,7 +226,7 @@ public final class MetadataSearchCriteriaUtils {
             selectMultiQuery = createSelectMultiQuery(searchQuery.getCriteriaList());
             manageProjections(searchQuery, selectMultiQuery);
             mapFacets(searchQuery, selectMultiQuery);
-            if (orderBy.isPresent()) {
+            if (orderBy.isPresent() && NonSortableFields.isSortable(NonSortableFields.UNIT_COLLECTION, orderBy.get())) {
                 if (DirectionDto.DESC.equals(direction.get())) {
                     selectMultiQuery.addOrderByDescFilter(orderBy.get());
                 } else {

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/NonSortableFields.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/NonSortableFields.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.api.utils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class NonSortableFields {
+
+    public static final String UNIT_COLLECTION = "Unit";
+
+    private static volatile Map<String, Set<String>> nonSortableFieldsByCollection = Map.of();
+
+    private NonSortableFields() {}
+
+    public static void setNonSortableFields(final Map<String, ? extends Collection<String>> byCollection) {
+        if (byCollection == null) {
+            nonSortableFieldsByCollection = Map.of();
+        } else {
+            nonSortableFieldsByCollection = byCollection
+                .entrySet()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> Set.copyOf(entry.getValue())));
+        }
+    }
+
+    public static Set<String> getNonSortableFields(final String collection) {
+        return nonSortableFieldsByCollection.getOrDefault(collection, Set.of());
+    }
+
+    public static boolean isSortable(final String collection, final String field) {
+        return field != null && !getNonSortableFields(collection).contains(field);
+    }
+}

--- a/commons/commons-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/commons/commons-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+fr.gouv.vitamui.commons.api.config.NonSortableFieldsAutoConfiguration

--- a/commons/commons-api/src/test/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtilsTest.java
+++ b/commons/commons-api/src/test/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtilsTest.java
@@ -35,7 +35,9 @@ import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitamui.commons.api.dtos.CriteriaValue;
 import fr.gouv.vitamui.commons.api.dtos.SearchCriteriaDto;
 import fr.gouv.vitamui.commons.api.dtos.SearchCriteriaEltDto;
+import fr.gouv.vitamui.commons.api.dtos.SearchCriteriaSort;
 import fr.gouv.vitamui.commons.api.dtos.TermsFacet;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,12 +46,18 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static fr.gouv.vitam.common.database.builder.query.QueryHelper.and;
 import static fr.gouv.vitamui.commons.api.utils.MetadataSearchCriteriaUtils.fillQueryFromMgtRulesCriteriaList;
 
 @ExtendWith(SpringExtension.class)
 public class MetadataSearchCriteriaUtilsTest {
+
+    @AfterEach
+    void resetNonSortableFields() {
+        NonSortableFields.setNonSortableFields(Map.of());
+    }
 
     @Test
     void testFillQueryFromCriteriaListWhenNullCriteriaList() throws InvalidCreateOperationException {
@@ -173,5 +181,74 @@ public class MetadataSearchCriteriaUtilsTest {
             "[{\"$name\":\"some_facet\",\"$terms\":{\"$field\":\"some_field\",\"$size\":10,\"$order\":\"ASC\"}}]",
             facetNode.toString()
         );
+    }
+
+    private SearchCriteriaDto searchQuerySortedBy(final String sortField) {
+        SearchCriteriaEltDto criteria = new SearchCriteriaEltDto()
+            .setCriteria("Title")
+            .setCategory(ArchiveSearchConsts.CriteriaCategory.FIELDS)
+            .setOperator(ArchiveSearchConsts.CriteriaOperators.EQ.name())
+            .setValues(List.of(new CriteriaValue().setValue("Some title")))
+            .setDataType(ArchiveSearchConsts.CriteriaDataType.STRING.name());
+
+        SearchCriteriaSort sort = new SearchCriteriaSort();
+        sort.setCriteria(sortField);
+
+        SearchCriteriaDto searchQuery = new SearchCriteriaDto();
+        searchQuery.setCriteriaList(List.of(criteria));
+        searchQuery.setSortingCriteria(sort);
+        return searchQuery;
+    }
+
+    @Test
+    void shouldRemoveOrderByWhenSortFieldIsBlocklisted() throws VitamClientException {
+        NonSortableFields.setNonSortableFields(Map.of(NonSortableFields.UNIT_COLLECTION, List.of("Title")));
+
+        SelectMultiQuery selectMultiQuery = MetadataSearchCriteriaUtils.mapRequestToSelectMultiQuery(
+            searchQuerySortedBy("Title")
+        );
+
+        JsonNode filter = selectMultiQuery.getFinalSelect().get("$filter");
+        Assertions.assertFalse(filter.has("$orderby"));
+    }
+
+    @Test
+    void shouldKeepOrderByWhenSortFieldIsNotBlocklisted() throws VitamClientException {
+        NonSortableFields.setNonSortableFields(Map.of(NonSortableFields.UNIT_COLLECTION, List.of("Title")));
+
+        SelectMultiQuery selectMultiQuery = MetadataSearchCriteriaUtils.mapRequestToSelectMultiQuery(
+            searchQuerySortedBy("StartDate")
+        );
+
+        JsonNode orderBy = selectMultiQuery.getFinalSelect().get("$filter").get("$orderby");
+        Assertions.assertNotNull(orderBy);
+        Assertions.assertTrue(orderBy.has("StartDate"));
+    }
+
+    @Test
+    void shouldEvaluateEachBlocklistedFieldIndependentlyWhenMultipleFieldsAreBlocklisted() throws VitamClientException {
+        NonSortableFields.setNonSortableFields(
+            Map.of(NonSortableFields.UNIT_COLLECTION, List.of("Title", "Description"))
+        );
+
+        Assertions.assertFalse(
+            MetadataSearchCriteriaUtils.mapRequestToSelectMultiQuery(searchQuerySortedBy("Title"))
+                .getFinalSelect()
+                .get("$filter")
+                .has("$orderby")
+        );
+        Assertions.assertFalse(
+            MetadataSearchCriteriaUtils.mapRequestToSelectMultiQuery(searchQuerySortedBy("Description"))
+                .getFinalSelect()
+                .get("$filter")
+                .has("$orderby")
+        );
+
+        JsonNode orderBy = MetadataSearchCriteriaUtils.mapRequestToSelectMultiQuery(searchQuerySortedBy("StartDate"))
+            .getFinalSelect()
+            .get("$filter")
+            .get("$orderby");
+        Assertions.assertNotNull(orderBy);
+        Assertions.assertTrue(orderBy.has("StartDate"));
     }
 }

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/access/UnitCommonService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/access/UnitCommonService.java
@@ -49,8 +49,10 @@ import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.OriginatingAgencyReassignmentRequest;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.elimination.EliminationRequestBody;
+import fr.gouv.vitamui.commons.api.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import fr.gouv.vitamui.commons.vitam.api.dto.VitamUISearchResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamResponseHandler;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
@@ -82,6 +84,7 @@ public class UnitCommonService {
 
     public RequestResponse<JsonNode> searchUnits(final JsonNode dslQuery, final VitamContext vitamContext)
         throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> result = accessExternalClient.selectUnits(vitamContext, dslQuery);
         VitamRestUtils.checkResponse(result);
         return result;
@@ -92,6 +95,7 @@ public class UnitCommonService {
         final JsonNode dslQuery,
         final VitamContext vitamContext
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> result;
         if (unitId.isPresent()) {
             result = accessExternalClient.selectUnitbyId(vitamContext, dslQuery, unitId.get());
@@ -105,6 +109,7 @@ public class UnitCommonService {
         final JsonNode dslQuery,
         final VitamContext vitamContext
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> result = accessExternalClient.selectUnitsWithInheritedRules(
             vitamContext,
             dslQuery
@@ -347,6 +352,7 @@ public class UnitCommonService {
      */
     public RequestResponse<JsonNode> computedInheritedRules(final VitamContext vitamContext, final JsonNode dslQuery)
         throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> jsonResponse = accessExternalClient.computedInheritedRules(
             vitamContext,
             dslQuery
@@ -367,6 +373,7 @@ public class UnitCommonService {
         final VitamContext vitamContext,
         final JsonNode dslQuery
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> jsonResponse = accessExternalClient.selectUnitsWithInheritedRules(
             vitamContext,
             dslQuery

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
@@ -42,8 +42,10 @@ import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.elimination.DeletionRequestBody;
+import fr.gouv.vitamui.commons.api.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.UnexpectedSettingsException;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
 import jakarta.ws.rs.core.Response;
 import org.apache.hc.core5.http.HttpStatus;
@@ -80,7 +82,7 @@ public class CollectService {
         final VitamContext vitamContext
     ) throws VitamClientException {
         LOGGER.debug(TRANSACTION_ID, transactionId);
-
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, searchQuery);
         try {
             RequestResponse<JsonNode> result = collectExternalClient.getUnitsByTransaction(
                 vitamContext,
@@ -425,6 +427,7 @@ public class CollectService {
         String transactionId,
         final VitamContext vitamContext
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         RequestResponse<JsonNode> response = collectExternalClient.selectUnitsWithInheritedRules(
             vitamContext,
             transactionId,

--- a/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
@@ -76,4 +76,7 @@
   {% if (vitamui_struct.vitamui_component == "ui-archive-search") %}
   ,"REASSIGNMENT_ENABLED": {{ vitamui.ui_archive_search.reassignment_enabled | default(false) | bool | lower }}
   {% endif %}
+  {% if (vitamui_struct.vitamui_component in ["ui-archive-search", "ui-collect"]) %}
+  ,"NON_SORTABLE_FIELDS": {{ vitamui_struct.non_sortable_fields | default({'Unit': ['Title']}) | to_json }}
+  {% endif %}
 }

--- a/deployment/roles/vitamui/templates/archive-search/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search/application.yml.j2
@@ -105,6 +105,10 @@ opentracing:
 
 ontologies_file_path: {{ vitamui_folder_data }}/external_ontology_fields.json
 
+#Bug #16651: per-collection fields for which  sorting is disabled (analyzed fields whose sort is too costly at high volume)
+query:
+  non-sortable-fields: {{ vitamui_struct.query.non_sortable_fields | default({'Unit': ['Title']}) | to_json }}
+
 download:
   signed-url:
     secret: {{ vitamui_struct.download.signed_url.secret | default(vitamui_defaults.services.download.signed_url.secret) }}

--- a/deployment/roles/vitamui/templates/collect/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect/application.yml.j2
@@ -108,6 +108,10 @@ collect:
 
 ontologies_file_path: {{ vitamui_folder_data }}/external_ontology_fields.json
 
+#Bug #16651: per-collection fields for which  sorting is disabled (analyzed fields whose sort is too costly at high volume)
+query:
+  non-sortable-fields: {{ vitamui_struct.query.non_sortable_fields | default({'Unit': ['Title']}) | to_json }}
+
 {% if opentracing.jaeger.enabled | default(false) | bool %}
 opentracing:
   jaeger:

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
@@ -638,7 +638,9 @@
 <ng-template #name_description>
   <span>
     {{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT.FIELDS.NAME' | translate }} <br />{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT.FIELDS.DESCRIPTION' | translate }}
-    <vitamui-order-by-button orderByKey="Title" [(orderBy)]="orderBy" [(direction)]="direction" (orderChange)="emitOrderChange()" />
+    @if (isSortableField('Title')) {
+      <vitamui-order-by-button orderByKey="Title" [(orderBy)]="orderBy" [(direction)]="direction" (orderChange)="emitOrderChange()" />
+    }
   </span>
 </ng-template>
 <ng-template #start_date>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -161,6 +161,9 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
   private securityService = inject(SecurityService);
   private vitamConfigurationService = inject(VitamTenantConfigService);
 
+  // Bug #16446: Title sort chevron shown only when Title is not in NON_SORTABLE_FIELDS
+  private nonSortableFields: string[] = this.configService.config?.NON_SORTABLE_FIELDS?.['Unit'] ?? [];
+
   readonly UnitType = UnitType;
   readonly ReassignmentMode = ReassignmentMode;
 
@@ -520,6 +523,11 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
 
   emitOrderChange() {
     this.orderChange.next();
+  }
+
+  // Bug #16446: hide the server-side sort chevron for fields configured as non-sortable (analyzed ES fields).
+  isSortableField(field: string): boolean {
+    return !this.nonSortableFields.includes(field);
   }
 
   removeCriteriaEvent(criteriaToRemove: any) {

--- a/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
@@ -63,5 +63,6 @@
       "order": 5
     }
   ],
-  "REASSIGNMENT_ENABLED": false
+  "REASSIGNMENT_ENABLED": false,
+  "NON_SORTABLE_FIELDS": { "Unit": ["Title"] }
 }

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -625,7 +625,9 @@
 <ng-template #name_description>
   <span>
     {{ 'COLLECT.ARCHIVE_UNIT.FIELDS.NAME' | translate }} <br />{{ 'COLLECT.ARCHIVE_UNIT.FIELDS.DESCRIPTION' | translate }}
-    <vitamui-order-by-button orderByKey="Title" [(orderBy)]="orderBy" [(direction)]="direction" (orderChange)="emitOrderChange()" />
+    @if (isSortableField('Title')) {
+      <vitamui-order-by-button orderByKey="Title" [(orderBy)]="orderBy" [(direction)]="direction" (orderChange)="emitOrderChange()" />
+    }
   </span>
 </ng-template>
 <ng-template #start_date>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -52,6 +52,7 @@ import {
   ArchiveSearchResultFacets,
   ArchiveUnit,
   BreadCrumbData,
+  ConfigService,
   ConfirmDialogComponent,
   ConfirmDialogData,
   CriteriaDataType,
@@ -142,6 +143,9 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   private transactionService = inject(TransactionsService);
   private vitamConfigurationService = inject(VitamTenantConfigService);
   private sipImportTrackingService = inject(SipImportTrackingService);
+  private configService = inject(ConfigService);
+
+  private nonSortableFields: string[] = this.configService.config?.NON_SORTABLE_FIELDS?.['Unit'] ?? [];
 
   readonly UnitType = UnitType;
 
@@ -713,6 +717,11 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
 
   emitOrderChange() {
     this.orderChange.next();
+  }
+
+  // Bug #16446: hide the server-side sort chevron for fields configured as non-sortable (analyzed ES fields).
+  isSortableField(field: string): boolean {
+    return !this.nonSortableFields.includes(field);
   }
 
   showPreviewArchiveUnit(item: Unit) {

--- a/ui/ui-frontend/projects/collect/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/collect/src/assets/config-dev.json
@@ -65,5 +65,6 @@
   ],
   "COLLECT": {
     "OFFLINE_SERVICES": []
-  }
+  },
+  "NON_SORTABLE_FIELDS": { "Unit": ["Title"] }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/app.configuration.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/app.configuration.interface.ts
@@ -67,6 +67,8 @@ export interface AppConfiguration {
   };
   [key: string]: any;
   REASSIGNMENT_ENABLED: boolean;
+  // Bug #16651: per-collection fields for which server-side sorting is disabled (analyzed fields whose sort is too costly at high volume)
+  NON_SORTABLE_FIELDS?: { [collection: string]: string[] };
 }
 
 export type SearchProvider = 'agencies' | 'archive-unit-profiles';


### PR DESCRIPTION
Bug #16651: [INPI] Error while searching for the archive

Sorting a Vitam DSL query on an analyzed Elasticsearch field (e.g. Unit.Title,
text + fielddata) is functionally wrong and loads the whole-index fielddata into
the ES heap, which times out on high-volume tenants. Such sorts are now
neutralised by default and driven by configuration.

- New per-collection blocklist `query.non-sortable-fields` (default
  `{ Unit: [Title] }`), single source of truth, overridable via Ansible without
  rebuilding the binary.
- NonSortableFields static holder (commons-api) bridges the config to the static
  query builders; loaded at startup by NonSortableFieldsAutoConfiguration.
- Guards in the builders (MetadataSearchCriteriaUtils, TransactionArchiveUnitService)
  + a central strip (VitamQueryHelper.stripNonSortableOrderBy) applied at the Unit
  Vitam client choke points (UnitCommonService, CollectService), so even injected
  DSLs are covered.
- Front (archive-search + collect): the Title sort chevron is hidden when the
  field is declared non-sortable (NON_SORTABLE_FIELDS config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable non-sortable fields for archive search and collection searches.
  * Sorting controls are now hidden for fields that cannot be sorted.
  * Backend queries automatically omit unsupported sorting criteria.
  * Added consistent JSON handling across services, including support for dates, optional values, and constructor-based deserialization.

* **Bug Fixes**
  * Prevented invalid sort requests from being sent to the search backend.
  * Preserved priority for specialized JSON message converters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->