### PR TITLE
Story #16471: Fix Automatically create CP PRs from labels

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -63,6 +63,10 @@ jobs:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
       fail-fast: false # Prevents a failure on branch 9.1 from canceling branch 9.2
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetches all history for all branches and tags (required for cherry-picking)
       - name: Backport Action
         uses: korthout/backport-action@v4.6.0
         with:


### PR DESCRIPTION
Correction de l'erreur
```
Fetching all the commits from the pull request: 2
/usr/bin/git fetch --depth=2 origin refs/pull/3848/head
fatal: not a git repository (or any of the parent directories): .git
Expected to fetch 'refs/pull/3848/head' from 'origin', but couldn't find it
Error: Expected to fetch 'refs/pull/3848/head' from 'origin', but couldn't find it
```

