### PR TITLE
CP V7.1 - Bug #16651: Error while searching for the archive

### DIFF
--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/config/NonSortableFieldsAutoConfiguration.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/config/NonSortableFieldsAutoConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.api.config;
+
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@EnableConfigurationProperties(NonSortableFieldsAutoConfiguration.NonSortableFieldsProperties.class)
+public class NonSortableFieldsAutoConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NonSortableFieldsAutoConfiguration.class);
+
+    public NonSortableFieldsAutoConfiguration(final NonSortableFieldsProperties properties) {
+        NonSortableFields.setNonSortableFields(properties.getNonSortableFields());
+        LOGGER.info("Server-side non-sortable metadata fields set to {}", properties.getNonSortableFields());
+    }
+
+    @ConfigurationProperties(prefix = "query")
+    public static class NonSortableFieldsProperties {
+
+        private Map<String, List<String>> nonSortableFields = new HashMap<>();
+
+        public Map<String, List<String>> getNonSortableFields() {
+            return nonSortableFields;
+        }
+
+        public void setNonSortableFields(final Map<String, List<String>> nonSortableFields) {
+            this.nonSortableFields = nonSortableFields;
+        }
+    }
+}

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/dsl/VitamQueryHelper.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/dsl/VitamQueryHelper.java
@@ -27,6 +27,7 @@
 package fr.gouv.vitamui.commons.api.dsl;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.gouv.vitam.common.database.builder.query.BooleanQuery;
 import fr.gouv.vitam.common.database.builder.query.Query;
 import fr.gouv.vitam.common.database.builder.request.exception.InvalidCreateOperationException;
@@ -38,11 +39,13 @@ import fr.gouv.vitamui.commons.api.domain.DirectionDto;
 import fr.gouv.vitamui.commons.api.logger.VitamUILogger;
 import fr.gouv.vitamui.commons.api.logger.VitamUILoggerFactory;
 import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,6 +68,9 @@ import static fr.gouv.vitam.common.database.builder.query.QueryHelper.or;
 public class VitamQueryHelper {
 
     private static final VitamUILogger LOGGER = VitamUILoggerFactory.getInstance(VitamQueryHelper.class);
+
+    private static final String FILTER = "$filter";
+    private static final String ORDER_BY = "$orderby";
 
     public static void addParameterCriteria(
         BooleanQuery query,
@@ -239,5 +245,35 @@ public class VitamQueryHelper {
 
         LOGGER.debug("Final query: {}", select.getFinalSelect().toPrettyString());
         return select.getFinalSelect();
+    }
+
+    /**
+     * Sorting on an analyzed (text) field is very expensive in Elasticsearch: it forces the use of fielddata,
+     * which loads the whole field into heap memory and can saturate it at scale.
+     * <p>
+     * This method strips the {@code $orderby} entries from the final DSL for fields blocked in the configuration
+     * ({@link NonSortableFields}) for the given {@code collection}, before the query is sent to Vitam. If
+     * {@code $orderby} becomes empty after this cleanup, it is removed entirely.
+     * <p>
+     */
+    public static void stripNonSortableOrderBy(final String collection, final JsonNode dslQuery) {
+        final Set<String> blocklist = NonSortableFields.getNonSortableFields(collection);
+        if (blocklist.isEmpty() || dslQuery == null || !dslQuery.hasNonNull(FILTER)) {
+            return;
+        }
+        final JsonNode filter = dslQuery.get(FILTER);
+        if (!filter.isObject() || !filter.hasNonNull(ORDER_BY) || !filter.get(ORDER_BY).isObject()) {
+            return;
+        }
+        final ObjectNode orderBy = (ObjectNode) filter.get(ORDER_BY);
+        final Iterator<String> fields = orderBy.fieldNames();
+        while (fields.hasNext()) {
+            if (blocklist.contains(fields.next())) {
+                fields.remove();
+            }
+        }
+        if (orderBy.isEmpty()) {
+            ((ObjectNode) filter).remove(ORDER_BY);
+        }
     }
 }

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtils.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/MetadataSearchCriteriaUtils.java
@@ -169,7 +169,7 @@ public final class MetadataSearchCriteriaUtils {
                 orderBy = Optional.of(searchQuery.getSortingCriteria().getCriteria());
             }
 
-            if (orderBy.isPresent()) {
+            if (orderBy.isPresent() && NonSortableFields.isSortable(NonSortableFields.UNIT_COLLECTION, orderBy.get())) {
                 if (DirectionDto.DESC.equals(direction.get())) {
                     selectMultiQuery.addOrderByDescFilter(orderBy.get());
                 } else {
@@ -208,7 +208,7 @@ public final class MetadataSearchCriteriaUtils {
                 orderBy = Optional.of(searchQuery.getSortingCriteria().getCriteria());
             }
             selectMultiQuery = createSelectMultiQuery(searchQuery.getCriteriaList());
-            if (orderBy.isPresent()) {
+            if (orderBy.isPresent() && NonSortableFields.isSortable(NonSortableFields.UNIT_COLLECTION, orderBy.get())) {
                 if (DirectionDto.DESC.equals(direction.get())) {
                     selectMultiQuery.addOrderByDescFilter(orderBy.get());
                 } else {

--- a/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/NonSortableFields.java
+++ b/commons/commons-api/src/main/java/fr/gouv/vitamui/commons/api/utils/NonSortableFields.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.api.utils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class NonSortableFields {
+
+    public static final String UNIT_COLLECTION = "Unit";
+
+    private static volatile Map<String, Set<String>> nonSortableFieldsByCollection = Map.of();
+
+    private NonSortableFields() {}
+
+    public static void setNonSortableFields(final Map<String, ? extends Collection<String>> byCollection) {
+        if (byCollection == null) {
+            nonSortableFieldsByCollection = Map.of();
+        } else {
+            nonSortableFieldsByCollection = byCollection
+                .entrySet()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> Set.copyOf(entry.getValue())));
+        }
+    }
+
+    public static Set<String> getNonSortableFields(final String collection) {
+        return nonSortableFieldsByCollection.getOrDefault(collection, Set.of());
+    }
+
+    public static boolean isSortable(final String collection, final String field) {
+        return field != null && !getNonSortableFields(collection).contains(field);
+    }
+}

--- a/commons/commons-api/src/main/resources/META-INF/spring.factories
+++ b/commons/commons-api/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=fr.gouv.vitamui.commons.api.identity.ServerIdentityAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+fr.gouv.vitamui.commons.api.identity.ServerIdentityAutoConfiguration,\
+fr.gouv.vitamui.commons.api.config.NonSortableFieldsAutoConfiguration

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/access/UnitService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/access/UnitService.java
@@ -48,10 +48,12 @@ import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.elimination.EliminationRequestBody;
+import fr.gouv.vitamui.commons.api.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.commons.api.exception.ApplicationServerException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
 import fr.gouv.vitamui.commons.api.logger.VitamUILogger;
 import fr.gouv.vitamui.commons.api.logger.VitamUILoggerFactory;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import fr.gouv.vitamui.commons.vitam.api.dto.VitamUISearchResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamResponseHandler;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
@@ -83,6 +85,7 @@ public class UnitService {
 
     public RequestResponse<JsonNode> searchUnits(final JsonNode dslQuery, final VitamContext vitamContext)
         throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> result = accessExternalClient.selectUnits(vitamContext, dslQuery);
         VitamRestUtils.checkResponse(result);
         return result;
@@ -93,6 +96,7 @@ public class UnitService {
         final JsonNode dslQuery,
         final VitamContext vitamContext
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> result;
         if (unitId.isPresent()) {
             result = accessExternalClient.selectUnitbyId(vitamContext, dslQuery, unitId.get());
@@ -106,6 +110,7 @@ public class UnitService {
         final JsonNode dslQuery,
         final VitamContext vitamContext
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> result = accessExternalClient.selectUnitsWithInheritedRules(
             vitamContext,
             dslQuery
@@ -348,6 +353,7 @@ public class UnitService {
      */
     public RequestResponse<JsonNode> computedInheritedRules(final VitamContext vitamContext, final JsonNode dslQuery)
         throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> jsonResponse = accessExternalClient.computedInheritedRules(
             vitamContext,
             dslQuery
@@ -368,6 +374,7 @@ public class UnitService {
         final VitamContext vitamContext,
         final JsonNode dslQuery
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         final RequestResponse<JsonNode> jsonResponse = accessExternalClient.selectUnitsWithInheritedRules(
             vitamContext,
             dslQuery

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
@@ -37,8 +37,10 @@ import fr.gouv.vitam.collect.external.client.CollectExternalClient;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.model.RequestResponse;
+import fr.gouv.vitamui.commons.api.dsl.VitamQueryHelper;
 import fr.gouv.vitamui.commons.api.logger.VitamUILogger;
 import fr.gouv.vitamui.commons.api.logger.VitamUILoggerFactory;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
 import fr.gouv.vitamui.commons.vitam.api.util.VitamRestUtils;
 
 import javax.ws.rs.core.Response;
@@ -72,6 +74,7 @@ public class CollectService {
         final VitamContext vitamContext
     ) throws VitamClientException {
         LOGGER.debug(TRANSACTION_ID, transactionId);
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, searchQuery);
         final RequestResponse<JsonNode> result = collectExternalClient.getUnitsByTransaction(
             vitamContext,
             transactionId,
@@ -87,6 +90,7 @@ public class CollectService {
         final VitamContext vitamContext
     ) throws VitamClientException {
         LOGGER.debug(PROJECT_ID, transactionId);
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, searchQuery);
         final RequestResponse<JsonNode> result = collectExternalClient.getUnitsByTransaction(
             vitamContext,
             transactionId,
@@ -378,6 +382,7 @@ public class CollectService {
         String transactionId,
         final VitamContext vitamContext
     ) throws VitamClientException {
+        VitamQueryHelper.stripNonSortableOrderBy(NonSortableFields.UNIT_COLLECTION, dslQuery);
         RequestResponse<JsonNode> response = collectExternalClient.selectUnitsWithInheritedRules(
             vitamContext,
             transactionId,

--- a/commons/commons-vitam/src/test/java/fr/gouv/vitamui/commons/vitam/api/access/UnitCommonServiceTest.java
+++ b/commons/commons-vitam/src/test/java/fr/gouv/vitamui/commons/vitam/api/access/UnitCommonServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
+ *
+ * contact.vitam@culture.gouv.fr
+ *
+ * This software is a computer program whose purpose is to implement a digital archiving back-office system managing
+ * high volumetry securely and efficiently.
+ *
+ * This software is governed by the CeCILL 2.1 license under French law and abiding by the rules of distribution of free
+ * software. You can use, modify and/ or redistribute the software under the terms of the CeCILL 2.1 license as
+ * circulated by CEA, CNRS and INRIA at the following URL "https://cecill.info".
+ *
+ * As a counterpart to the access to the source code and rights to copy, modify and redistribute granted by the license,
+ * users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the
+ * successive licensors have only limited liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated with loading, using, modifying and/or
+ * developing or reproducing the software by the user in light of its specific status of free software, that may mean
+ * that it is complicated to manipulate, and that also therefore means that it is reserved for developers and
+ * experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the
+ * software's suitability as regards their requirements in conditions enabling the security of their systems and/or data
+ * to be ensured and, more generally, to use and operate it in the same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
+ * accept its terms.
+ */
+package fr.gouv.vitamui.commons.vitam.api.access;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.gouv.vitam.access.external.client.AccessExternalClient;
+import fr.gouv.vitam.common.client.VitamContext;
+import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitamui.commons.api.utils.NonSortableFields;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UnitCommonServiceTest {
+
+    @Mock
+    private AccessExternalClient accessExternalClient;
+
+    @InjectMocks
+    private UnitService unitCommonService;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @AfterEach
+    void resetHolder() {
+        NonSortableFields.setNonSortableFields(Map.of());
+    }
+
+    @Test
+    void searchUnits_stripsBlocklistedOrderByBeforeReachingVitam() throws Exception {
+        NonSortableFields.setNonSortableFields(Map.of(NonSortableFields.UNIT_COLLECTION, List.of("Title")));
+        when(accessExternalClient.selectUnits(any(), any())).thenReturn(okResponse());
+        JsonNode dsl = mapper.readTree("{\"$filter\":{\"$orderby\":{\"Title\":1}}}");
+
+        unitCommonService.searchUnits(dsl, new VitamContext(1));
+
+        ArgumentCaptor<JsonNode> captor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(accessExternalClient).selectUnits(any(), captor.capture());
+        assertThat(captor.getValue().get("$filter").has("$orderby")).isFalse();
+    }
+
+    @Test
+    void searchUnits_keepsSortableOrderBy() throws Exception {
+        NonSortableFields.setNonSortableFields(Map.of(NonSortableFields.UNIT_COLLECTION, List.of("Title")));
+        when(accessExternalClient.selectUnits(any(), any())).thenReturn(okResponse());
+        JsonNode dsl = mapper.readTree("{\"$filter\":{\"$orderby\":{\"StartDate\":1}}}");
+
+        unitCommonService.searchUnits(dsl, new VitamContext(1));
+
+        ArgumentCaptor<JsonNode> captor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(accessExternalClient).selectUnits(any(), captor.capture());
+        assertThat(captor.getValue().get("$filter").get("$orderby").has("StartDate")).isTrue();
+    }
+
+    private RequestResponseOK<JsonNode> okResponse() {
+        RequestResponseOK<JsonNode> response = new RequestResponseOK<>();
+        response.setHttpCode(200);
+        return response;
+    }
+}

--- a/deployment/roles/nginx_webapp/defaults/main.yml
+++ b/deployment/roles/nginx_webapp/defaults/main.yml
@@ -13,4 +13,6 @@ nginx_ssl_dir: /etc/nginx/conf.d/ssl
 
 secure: "{{ vitamui_defaults.services.secure | default(true) | bool }}"
 
+default_non_sortable_fields: "{{ vitamui_defaults.services.query_non_sortable_fields | default({ 'Unit': ['Title'] }) }}"
+
 package_name: "vitamui-{{ vitamui_struct.vitamui_component }}-rsc"

--- a/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
+++ b/deployment/roles/nginx_webapp/templates/frontend/config.json.j2
@@ -64,4 +64,7 @@
   {% else %}
   ]
   {% endif %}
+  {% if vitamui_struct.vitamui_component in ["ui-archive-search", "ui-collect"] %}
+  ,"NON_SORTABLE_FIELDS": {{ vitamui_struct.query_non_sortable_fields | default(default_non_sortable_fields) | to_json }}
+  {% endif %}
 }

--- a/deployment/roles/vitamui/defaults/main.yml
+++ b/deployment/roles/vitamui/defaults/main.yml
@@ -2,6 +2,8 @@
 
 default_gc_opts: "-Xlog:gc*,gc+age=trace,safepoint:file={{ vitamui_folder_log }}/gc.log:utctime,pid,tags:filecount=8,filesize=32m"
 
+default_non_sortable_fields: "{{ vitamui_defaults.services.query_non_sortable_fields | default({ 'Unit': ['Title'] }) }}"
+
 jvm_opts:
   memory: "{{ vitamui_defaults.services.jvm_opts.memory | default('-Xms128m -Xmx512m') }}"
   gc: "{{ vitamui_defaults.services.jvm_opts.gc | default(default_gc_opts) }}"

--- a/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-external/application.yml.j2
@@ -105,3 +105,6 @@ logging:
     fr.gouv.vitamui.archives.search.external.*: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
     org.springframework.web.filter.CommonsRequestLoggingFilter: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
     fr.gouv.vitamui.iam.security: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
+
+query:
+  non-sortable-fields: {{ vitamui_struct.query_non_sortable_fields | default(default_non_sortable_fields) | to_json }}

--- a/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/archive-search-internal/application.yml.j2
@@ -81,3 +81,6 @@ logging:
   level:
     fr.gouv.vitamui.archives.search.internal.*: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
     fr.gouv.vitam.archives.*: {{ vitamui_struct.log.vitamui_level | default(log.vitamui_level) }}
+
+query:
+  non-sortable-fields: {{ vitamui_struct.query_non_sortable_fields | default(default_non_sortable_fields) | to_json }}

--- a/deployment/roles/vitamui/templates/collect-external/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect-external/application.yml.j2
@@ -120,3 +120,6 @@ opentracing:
       host: {{ opentracing.jaeger.udp_sender.host }}
       port: {{ opentracing.jaeger.udp_sender.port }}
 {% endif %}
+
+query:
+  non-sortable-fields: {{ vitamui_struct.query_non_sortable_fields | default(default_non_sortable_fields) | to_json }}

--- a/deployment/roles/vitamui/templates/collect-internal/application.yml.j2
+++ b/deployment/roles/vitamui/templates/collect-internal/application.yml.j2
@@ -87,3 +87,6 @@ opentracing:
       host: {{ opentracing.jaeger.udp_sender.host }}
       port: {{ opentracing.jaeger.udp_sender.port }}
 {% endif %}
+
+query:
+  non-sortable-fields: {{ vitamui_struct.query_non_sortable_fields | default(default_non_sortable_fields) | to_json }}

--- a/docs/fr/migration/update_v7_1.md
+++ b/docs/fr/migration/update_v7_1.md
@@ -55,6 +55,32 @@ ansible-vault edit --vault-password-file vault_pass.txt environments/group_vars/
 
 > Attention, la clé devrait être configurée avec une clé alphanumérique longue et sans caractères spéciaux.
 
+### Neutralisation du tri sur les champs de métadonnées analysés
+
+Le tri sur certains champs de métadonnées, tel que `Unit.Title`, est désormais neutralisé par défaut : il provoquait l'expiration des recherches sur les tenants volumineux. Le chevron de tri correspondant n'est plus proposé dans les interfaces.
+
+Aucune action n'est requise : la variable `query_non_sortable_fields` n'est déclarée dans aucun fichier de `group_vars`. En son absence, la valeur `{ 'Unit': ['Title'] }` est appliquée automatiquement.
+
+Pour modifier ce comportement, déclarer la variable globalement via `vitamui_defaults.services.query_non_sortable_fields` ou par composant via `vitamui.<composant>.query_non_sortable_fields`. La valeur déclarée remplace intégralement la valeur par défaut.
+
+* Neutraliser d'autres champs, en reconduisant `Unit: ['Title']` pour le conserver :
+
+  ```yaml
+  vitamui_defaults:
+    services:
+      query_non_sortable_fields: { 'Unit': ['Title', '<autre_champ>'] }
+  ```
+
+* Restaurer le tri sur l'ensemble des champs :
+
+  ```yaml
+  vitamui_defaults:
+    services:
+      query_non_sortable_fields: {}
+  ```
+
+> Attention, cette dernière valeur restaure le comportement à l'origine des expirations de recherche. Elle n'est destinée qu'à des fins de test et ne doit pas être utilisée en production.
+
 ---
 
 ## Procédures à exécuter AVANT la montée de version

--- a/docs/fr/migration/upgrade_v7_1.md
+++ b/docs/fr/migration/upgrade_v7_1.md
@@ -110,6 +110,32 @@ ansible-vault edit --vault-password-file vault_pass.txt environments/group_vars/
 
 > Attention, la clé devrait être configurée avec une clé alphanumérique longue et sans caractères spéciaux.
 
+### Neutralisation du tri sur les champs de métadonnées analysés
+
+Le tri sur certains champs de métadonnées, tel que `Unit.Title`, est désormais neutralisé par défaut : il provoquait l'expiration des recherches sur les tenants volumineux. Le chevron de tri correspondant n'est plus proposé dans les interfaces.
+
+Aucune action n'est requise : la variable `query_non_sortable_fields` n'est déclarée dans aucun fichier de `group_vars`. En son absence, la valeur `{ 'Unit': ['Title'] }` est appliquée automatiquement.
+
+Pour modifier ce comportement, déclarer la variable globalement via `vitamui_defaults.services.query_non_sortable_fields` ou par composant via `vitamui.<composant>.query_non_sortable_fields`. La valeur déclarée remplace intégralement la valeur par défaut.
+
+* Neutraliser d'autres champs, en reconduisant `Unit: ['Title']` pour le conserver :
+
+  ```yaml
+  vitamui_defaults:
+    services:
+      query_non_sortable_fields: { 'Unit': ['Title', '<autre_champ>'] }
+  ```
+
+* Restaurer le tri sur l'ensemble des champs :
+
+  ```yaml
+  vitamui_defaults:
+    services:
+      query_non_sortable_fields: {}
+  ```
+
+> Attention, cette dernière valeur restaure le comportement à l'origine des expirations de recherche. Elle n'est destinée qu'à des fins de test et ne doit pas être utilisée en production.
+
 ---
 
 ## Procédures à exécuter AVANT la montée de version

--- a/ui/ui-frontend-common/src/app/modules/models/app.configuration.interface.ts
+++ b/ui/ui-frontend-common/src/app/modules/models/app.configuration.interface.ts
@@ -62,4 +62,5 @@ export interface AppConfiguration {
   UI: Ui;
   VITAM: VitamConfiguration;
   VITAM_ADMIN_TENANT?: number;
+  NON_SORTABLE_FIELDS?: { [collection: string]: string[] };
 }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.html
@@ -375,6 +375,7 @@
         >
 
         <vitamui-common-order-by-button
+          *ngIf="isTitleSortable"
           orderByKey="Title"
           [(orderBy)]="orderBy"
           [(direction)]="direction"

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/archive-search.component.ts
@@ -1,4 +1,5 @@
 /*
+/*
  * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2015-2022)
  *
  * contact.vitam@culture.gouv.fr
@@ -66,6 +67,7 @@ import {
   SearchCriteriaRemoveAction,
   SearchCriteriaStatusEnum,
   SearchCriteriaTypeEnum,
+  StartupService,
   Unit,
   UnitType,
   VitamuiRoles,
@@ -122,6 +124,8 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
   private readonly orderChange = new Subject<string>();
 
   orderBy = 'Title';
+
+  isTitleSortable = true;
   isIndeterminate: boolean;
   isAllChecked: boolean;
   hasResults = false;
@@ -208,7 +212,10 @@ export class ArchiveSearchComponent implements OnInit, OnChanges, OnDestroy, Aft
     private computeInheritedRulesService: ComputeInheritedRulesService,
     private archiveUnitDipService: ArchiveUnitDipService,
     private cdr: ChangeDetectorRef,
+    private startupService: StartupService,
   ) {
+    const unitNonSortableFields: string[] = (this.startupService.getConfigObjectValue('NON_SORTABLE_FIELDS') || {})['Unit'] || [];
+    this.isTitleSortable = !unitNonSortableFields.includes('Title');
     this.subscriptions.add(
       this.managementRulesSharedDataService.getBulkOperationsThreshold().subscribe((bulkOperationsThreshold) => {
         this.bulkOperationsThreshold = bulkOperationsThreshold;

--- a/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/archive-search/src/assets/config-dev.json
@@ -62,5 +62,6 @@
       "title": "Organisation & droits utilisateurs",
       "order": 5
     }
-  ]
+  ],
+  "NON_SORTABLE_FIELDS": { "Unit": ["Title"] }
 }

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.html
@@ -373,6 +373,7 @@
               >
 
               <vitamui-common-order-by-button
+                *ngIf="isTitleSortable"
                 orderByKey="Title"
                 [(orderBy)]="orderBy"
                 [(direction)]="direction"

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-search-collect.component.ts
@@ -57,6 +57,7 @@ import {
   SearchCriteriaStatusEnum,
   SearchCriteriaTypeEnum,
   SidenavPage,
+  StartupService,
   Transaction,
   TransactionStatus,
   Unit,
@@ -134,6 +135,8 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
   waitingToGetFixedCount = false;
   totalResults = 0;
   orderBy = 'Title';
+
+  isTitleSortable = true;
   direction = Direction.ASCENDANT;
   DEFAULT_RESULT_THRESHOLD = 10000;
   searchHasResults = false;
@@ -174,8 +177,11 @@ export class ArchiveSearchCollectComponent extends SidenavPage<any> implements O
     private archiveFacetsService: ArchiveFacetsService,
     private snackBar: MatSnackBar,
     public dialog: MatDialog,
+    private startupService: StartupService,
   ) {
     super(route, globalEventService);
+    const unitNonSortableFields: string[] = (this.startupService.getConfigObjectValue('NON_SORTABLE_FIELDS') || {})['Unit'] || [];
+    this.isTitleSortable = !unitNonSortableFields.includes('Title');
     this.subscriptionSimpleSearchCriteriaAdd = this.archiveExchangeDataService
       .receiveSimpleSearchCriteriaSubject()
       .subscribe((criteria) => {

--- a/ui/ui-frontend/projects/collect/src/assets/config-dev.json
+++ b/ui/ui-frontend/projects/collect/src/assets/config-dev.json
@@ -62,5 +62,6 @@
       "title": "Organisation & droits utilisateurs",
       "order": 5
     }
-  ]
+  ],
+  "NON_SORTABLE_FIELDS": { "Unit": ["Title"] }
 }


### PR DESCRIPTION
## Description

Sorting a Vitam DSL query on an analyzed Elasticsearch field (e.g. Unit.Title, text + fielddata) is functionally wrong and loads the whole-index fielddata into the ES heap, which times out on high-volume tenants. Such sorts are now neutralised by default and driven by configuration.

- New per-collection blocklist `query.non-sortable-fields` (default `{ Unit: [Title] }`), single source of truth, overridable via Ansible without rebuilding the binary.
- NonSortableFields static holder (commons-api) bridges the config to the static query builders; loaded at startup by NonSortableFieldsAutoConfiguration.
- Guards in the builders (MetadataSearchCriteriaUtils, TransactionArchiveUnitService)
  + a central strip (VitamQueryHelper.stripNonSortableOrderBy) applied at the Unit Vitam client choke points (UnitCommonService, CollectService), so even injected DSLs are covered.
- Front (archive-search + collect): the Title sort chevron is hidden when the field is declared non-sortable (NON_SORTABLE_FIELDS config).

## Type de changement

* Ansiblerie
* Nouveau Code
* Correction

## Contributeur

* Programme Vitam