### PR TITLE
Story #16655: Collect - Add an SIP to an attachment position

### DIFF
--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/ProjectController.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/rest/ProjectController.java
@@ -213,14 +213,16 @@ public class ProjectController {
     @PostMapping(value = "/uploadSip", consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public String streamingUploadSip(
         InputStream inputStream,
-        @RequestHeader(value = CommonConstants.X_TRANSACTION_ID_HEADER) final String transactionId
+        @RequestHeader(value = CommonConstants.X_TRANSACTION_ID_HEADER) final String transactionId,
+        @RequestHeader(value = CommonConstants.X_ATTACHMENT_ID_HEADER, required = false) final String attachmentId
     ) throws PreconditionFailedException, VitamClientException {
         ParameterChecker.checkParameter("The transaction ID is a mandatory parameter: ", transactionId);
-        SanityChecker.checkSecureParameter(transactionId);
+        SanityChecker.checkSecureParameter(transactionId, attachmentId);
         LOGGER.debug("[External] upload SIP");
         var requestResponse = projectService.streamingUploadSip(
             inputStream,
             transactionId,
+            attachmentId,
             externalParametersService.buildVitamContextFromExternalParam()
         );
         if (!requestResponse.isOk()) {

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ProjectService.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/service/ProjectService.java
@@ -247,11 +247,12 @@ public class ProjectService {
     public RequestResponse<UploadSipResult> streamingUploadSip(
         InputStream inputStream,
         String transactionId,
+        String attachmentId,
         VitamContext vitamContext
     ) {
         LOGGER.debug("TransactionId: {}", transactionId);
         try {
-            return collectService.uploadSipToTransaction(vitamContext, transactionId, inputStream);
+            return collectService.uploadSipToTransaction(vitamContext, transactionId, attachmentId, inputStream);
         } catch (VitamClientException e) {
             LOGGER.debug(UNABLE_TO_UPLOAD_SIP_TO_TRANSACTION, e);
             throw new BadRequestException(UNABLE_TO_UPLOAD_SIP_TO_TRANSACTION, e);

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/collect/CollectService.java
@@ -268,13 +268,15 @@ public class CollectService {
     public RequestResponse<UploadSipResult> uploadSipToTransaction(
         final VitamContext vitamContext,
         final String transactionId,
+        final String attachmentId,
         final InputStream inputStream
     ) throws VitamClientException {
         LOGGER.debug("upload SIP by transaction id : {}", transactionId);
         final RequestResponse result = collectExternalClient.uploadSipToTransaction(
             vitamContext,
             transactionId,
-            inputStream
+            inputStream,
+            attachmentId
         );
         VitamRestUtils.checkResponse(result);
         return result;

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.html
@@ -64,13 +64,9 @@
     <mat-dialog-content>
       <div class="main-content">
         <div class="form-group">
-          @if (projectUnits && (importType === ImportType.DIRECTORIES_FILES || importType === ImportType.COMPRESSED)) {
+          @if (projectUnits) {
             <vitamui-library-filing-plan [mode]="FilingPlanMode.SOLO" [formControl]="linkParentIdControl" [dataSource]="projectUnits">
             </vitamui-library-filing-plan>
-          } @else if (importType === ImportType.SIP) {
-            <span class="text meduim">
-              {{ 'COLLECT.MODAL.ARCHIVE_POSITION_MSG_FOR_SIP' | translate }}
-            </span>
           }
         </div>
       </div>

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/add-units/add-units.component.ts
@@ -35,10 +35,11 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
-import { Component, OnInit, TemplateRef, ViewChild, inject } from '@angular/core';
+import { Component, inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { finalize, from, Observable, of, switchMap } from 'rxjs';
 import {
+  ApplicationId,
   CriteriaDataType,
   CriteriaOperator,
   Direction,
@@ -46,13 +47,12 @@ import {
   PagedResult,
   SearchCriteriaEltDto,
   SearchCriteriaTypeEnum,
+  SnackBarService,
+  StartupService,
   Transaction,
   Unit,
   ZipFile,
   ZipFileStatus,
-  ApplicationId,
-  SnackBarService,
-  StartupService,
 } from 'vitamui-library';
 import { ArchiveCollectService } from '../archive-collect.service';
 import { SipImportTrackingService } from '../../shared/sip-import-tracking.service';
@@ -177,7 +177,7 @@ export class AddUnitsComponent implements OnInit {
       .pipe(
         switchMap((content) =>
           this.importType === ImportType.SIP
-            ? this.archiveCollectService.uploadSip(content, this.data.transaction.id)
+            ? this.archiveCollectService.uploadSip(content, this.data.transaction.id, this.linkParentIdControl.value.included[0])
             : this.archiveCollectService.uploadZip(content, this.data.transaction.id, this.linkParentIdControl.value.included[0]),
         ),
         tap((httpEvent) => zipFile.updateUploadingZipFileStatus(httpEvent)),

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-collect.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/archive-collect.service.ts
@@ -35,7 +35,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { HttpErrorResponse, HttpEvent, HttpHeaders } from '@angular/common/http';
-import { Injectable, LOCALE_ID, TemplateRef, inject } from '@angular/core';
+import { inject, Injectable, LOCALE_ID, TemplateRef } from '@angular/core';
 import { Observable, of, throwError, TimeoutError } from 'rxjs';
 import { catchError, filter, map } from 'rxjs/operators';
 import {
@@ -194,8 +194,8 @@ export class ArchiveCollectService extends SearchService<any> implements SearchA
     return this.projectsApiService.uploadZip(content, transactionId, `${transactionId}.zip`, attachmentId);
   }
 
-  uploadSip(content: Blob, transactionId: string): Observable<HttpEvent<any>> {
-    return this.projectsApiService.uploadSip(content, transactionId);
+  uploadSip(content: Blob, transactionId: string, attachmentId?: string): Observable<HttpEvent<any>> {
+    return this.projectsApiService.uploadSip(content, transactionId, attachmentId);
   }
 
   exportCsvSearchArchiveUnitsByCriteria(criteriaDto: SearchCriteriaDto, projectId: string) {

--- a/ui/ui-frontend/projects/collect/src/app/collect/core/api/project-api.service.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/core/api/project-api.service.ts
@@ -36,18 +36,18 @@
  */
 
 import { HttpClient, HttpEvent, HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { map, Observable, switchMap } from 'rxjs';
 import {
   BASE_URL,
   PageRequest,
+  PaginatedHttpClient,
   PaginatedResponse,
   Project,
   ProjectAttachments,
   SearchCriteriaHistory,
   Transaction,
   VitamuiHttpHeaders,
-  PaginatedHttpClient,
 } from 'vitamui-library';
 
 @Injectable({
@@ -143,12 +143,17 @@ export class ProjectsApiService extends PaginatedHttpClient<any> {
     return this.http.request<Transaction>(new HttpRequest('POST', `${this.apiUrl}/upload`, content, options));
   }
 
-  uploadSip(content: Blob, transactionId: string): Observable<HttpEvent<any>> {
-    let headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TRANSACTION_ID, transactionId)
-      .set('Content-Type', 'application/octet-stream')
-      .set('reportProgress', 'true')
-      .set('ngsw-bypass', 'true');
+  uploadSip(content: Blob, transactionId: string, attachmentId?: string): Observable<HttpEvent<any>> {
+    const headersConfig: Record<string, string> = {
+      [VitamuiHttpHeaders.X_TRANSACTION_ID]: transactionId,
+      'Content-Type': 'application/octet-stream',
+      reportProgress: 'true',
+      'ngsw-bypass': 'true',
+    };
+    if (attachmentId) {
+      headersConfig[VitamuiHttpHeaders.X_ATTACHEMENT_ID] = attachmentId;
+    }
+    const headers = new HttpHeaders(headersConfig);
     const options: Object = {
       headers: headers,
       responseType: 'text',

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/en.json
@@ -237,7 +237,6 @@
       "DEFAULT_ATTACHMENT_TITLE": "Default attachment",
       "DEFAULT_ATTACHMENT_TOGGLE": "Define a default fixed attachment position",
       "DEFAULT_ATTACHMENT_TOOLTIP": "Define a default attachment position for archival units that are not eligible for any of the attachment rules defined above",
-      "ARCHIVE_POSITION_MSG_FOR_SIP": "For this import, reclassification within the transfer hierarchy will have to be carried out at a later stage, directly via the “Reclassify archival units” button.",
       "AUTO_INGEST": "Automatic transaction management:",
       "AUTO_INGEST_TRUE": "Yes",
       "AUTO_INGEST_FALSE": "No",

--- a/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
+++ b/ui/ui-frontend/projects/collect/src/assets/i18n/fr.json
@@ -237,7 +237,6 @@
       "DEFAULT_ATTACHMENT_TITLE": "Rattachement par défaut",
       "DEFAULT_ATTACHMENT_TOGGLE": "Définir une position fixe de rattachement par défaut",
       "DEFAULT_ATTACHMENT_TOOLTIP": "Définir une position de rattachement par défaut pour les unités archivistiques qui ne sont éligibles à aucune règle de rattachement définie précédemment",
-      "ARCHIVE_POSITION_MSG_FOR_SIP": "Pour cet import, le reclassement au sein de l'arborescence du versement devra être réalisé dans un second temps, directement via le bouton \"Reclasser des unités archivistiques\".",
       "AUTO_INGEST": "Gestion automatique des transactions :",
       "AUTO_INGEST_TRUE": "Oui",
       "AUTO_INGEST_FALSE": "Non",


### PR DESCRIPTION
## Description

Collecte - Depuis une transaction, il est désormais possible de rattacher un SIP à importer à une position définie


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SIP uploads can include an optional attachment identifier to associate content with related records.
  * Filing-plan selection is now available for all supported import types when project units are present.
  * SIP uploads can automatically associate content with the first included parent unit.
* **Improvements**
  * Upload processing continues to preserve existing validation, security checks, error handling, and response behavior.
  * Removed outdated SIP-specific guidance from the upload interface for a clearer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->