### PR TITLE
Bug #14888: apply access restrictions to getOne in IAM services

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/CasController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/CasController.java
@@ -276,7 +276,7 @@ public class CasController {
         String email = superUserEmail, customerId = superUserCustomerId;
         if (superUserId != null && !superUserId.isEmpty() && !superUserId.trim().isEmpty()) {
             SanityChecker.checkSecureParameter(superUserId);
-            final UserDto user = userService.getOne(superUserId, Optional.empty());
+            final UserDto user = userService.findUserById(superUserId);
             if (user != null && user.getStatus() == UserStatusEnum.ENABLED) {
                 email = user.getEmail();
                 customerId = user.getCustomerId();

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/security/AbstractResourceClientService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/security/AbstractResourceClientService.java
@@ -339,4 +339,12 @@ public abstract class AbstractResourceClientService<E extends IdDto, I extends B
     public boolean checkExist(final String criteria) {
         return super.checkExist(checkAuthorization(Optional.ofNullable(criteria)).get());
     }
+
+    /**
+     * Secures direct access by ID by applying access restrictions (tenant/customer).
+     */
+    @Override
+    public E getOne(final String id, final Optional<String> criteria, final Optional<String> embedded) {
+        return super.getOne(id, checkAuthorization(criteria), embedded);
+    }
 }

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/tenant/service/TenantService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/tenant/service/TenantService.java
@@ -564,11 +564,7 @@ public class TenantService extends AbstractResourceClientService<TenantDto, Tena
         final String[] apps = { CommonConstants.HIERARCHY_PROFILE_APPLICATIONS_NAME };
 
         final UserDto adminUserDto = userService.getDefaultAdminUser(customerId);
-        final GroupDto adminGroupDto = groupService.getOne(
-            adminUserDto.getGroupId(),
-            Optional.empty(),
-            Optional.empty()
-        );
+        final GroupDto adminGroupDto = groupService.getOneByPassSecurity(adminUserDto.getGroupId(), Optional.empty());
 
         for (final String app : apps) {
             final Profile profile = profiles

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserInfoService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserInfoService.java
@@ -68,6 +68,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -196,6 +197,11 @@ public class UserInfoService extends AbstractResourceClientService<UserInfoDto, 
         super.checkIdentifier(dto.getIdentifier(), message);
 
         dto.setIdentifier(getNextSequenceId(SequencesConstants.USER_INFOS_IDENTIFIER));
+    }
+
+    @Override
+    protected Collection<String> getRestrictedKeys() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserService.java
@@ -283,7 +283,7 @@ public class UserService extends AbstractResourceClientService<UserDto, User> {
         checkGroupId(dto.getGroupId(), message);
         super.checkIdentifier(dto.getIdentifier(), message);
 
-        final GroupDto groupDto = getGroupDtoById(dto.getGroupId(), message);
+        final GroupDto groupDto = getGroupDtoByIdByPassSecurity(dto.getGroupId(), message);
         checkGroup(groupDto, dto.getCustomerId(), message);
         checkLevel(groupDto.getLevel(), message);
         checkOtp(dto);

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/group/service/GroupServiceIntegrationTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/group/service/GroupServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import fr.gouv.vitamui.commons.api.domain.GroupDto;
 import fr.gouv.vitamui.commons.api.domain.ProfileDto;
 import fr.gouv.vitamui.commons.api.domain.QueryDto;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
+import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.domain.Event;
 import fr.gouv.vitamui.commons.mongo.dao.CustomSequenceRepository;
@@ -49,6 +50,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -120,6 +122,16 @@ public class GroupServiceIntegrationTest extends AbstractLogbookIntegrationTest 
         when(securityService.getCustomerId()).thenReturn(CUSTOMER_ID);
         when(securityService.getTenantIdentifier()).thenReturn(10);
         when(securityService.hasRole(eq(ServicesData.ROLE_GET_ALL_TENANTS))).thenReturn(true);
+    }
+
+    @Test
+    void getOne_shouldNotFindGroupOfAnotherCustomer() {
+        final String groupId = "idGroupOfAnotherCustomer";
+        repository.save(IamServerUtilsTest.buildGroup(groupId, "1001", "nametest", "anotherCustomerId"));
+
+        assertThatThrownBy(() -> service.getOne(groupId, Optional.empty(), Optional.empty())).isInstanceOf(
+            NotFoundException.class
+        );
     }
 
     @Test

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/profile/service/ProfileServiceIntegrationTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/profile/service/ProfileServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import fr.gouv.vitamui.commons.api.domain.ProfileDto;
 import fr.gouv.vitamui.commons.api.domain.QueryDto;
 import fr.gouv.vitamui.commons.api.domain.Role;
 import fr.gouv.vitamui.commons.api.domain.ServicesData;
+import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.logbook.common.EventType;
 import fr.gouv.vitamui.commons.logbook.dao.EventRepository;
 import fr.gouv.vitamui.commons.logbook.domain.Event;
@@ -56,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -145,6 +147,42 @@ public class ProfileServiceIntegrationTest extends AbstractLogbookIntegrationTes
     @AfterEach
     public void cleanUp() {
         repository.deleteAll();
+    }
+
+    @Test
+    void getOne_shouldNotFindProfileOfAnotherCustomerNorAnotherTenant() {
+        final String profileOfAnotherCustomerId = "IdProfileOfAnotherCustomer";
+        final String profileOfAnotherTenantId = "IdProfileOfAnotherTenant";
+
+        repository.save(
+            IamServerUtilsTest.buildProfile(
+                profileOfAnotherCustomerId,
+                "901",
+                "profile of another customer",
+                "anotherCustomerId",
+                TENANT_IDENTIFIER,
+                CommonConstants.USERS_APPLICATIONS_NAME,
+                ""
+            )
+        );
+        repository.save(
+            IamServerUtilsTest.buildProfile(
+                profileOfAnotherTenantId,
+                "902",
+                "profile of another tenant",
+                IamServerUtilsTest.CUSTOMER_ID,
+                11,
+                CommonConstants.USERS_APPLICATIONS_NAME,
+                ""
+            )
+        );
+
+        assertThatThrownBy(
+            () -> service.getOne(profileOfAnotherCustomerId, Optional.empty(), Optional.empty())
+        ).isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(
+            () -> service.getOne(profileOfAnotherTenantId, Optional.empty(), Optional.empty())
+        ).isInstanceOf(NotFoundException.class);
     }
 
     @Test

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/TenantCrudControllerTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/rest/TenantCrudControllerTest.java
@@ -174,7 +174,7 @@ public final class TenantCrudControllerTest implements CrudControllerTest {
 
         when(ownerService.getOne(tenantDto.getOwnerId(), Optional.empty())).thenReturn(buildOwnerDto());
 
-        when(groupService.getOne(buildUserDto().getGroupId(), Optional.empty(), Optional.empty())).thenReturn(
+        when(groupService.getOneByPassSecurity(buildUserDto().getGroupId(), Optional.empty())).thenReturn(
             buildGroupDto()
         );
         when(ownerRepository.findById(tenantDto.getOwnerId())).thenReturn(Optional.of(buildOwner()));

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/tenant/service/TenantServiceTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/tenant/service/TenantServiceTest.java
@@ -161,7 +161,7 @@ class TenantServiceTest {
 
         when(userService.getDefaultAdminUser(proofTenant.getCustomerId())).thenReturn(buildUserDto());
 
-        when(groupService.getOne(buildUserDto().getGroupId(), Optional.empty(), Optional.empty())).thenReturn(
+        when(groupService.getOneByPassSecurity(buildUserDto().getGroupId(), Optional.empty())).thenReturn(
             buildGroupDto()
         );
         when(userService.getAll(any(QueryDto.class))).thenReturn(Arrays.asList(buildUserDto()));


### PR DESCRIPTION
## Description

**GET identity-api/xxx/{id}**, retourne la ressource même lorsqu'elle appartient à une autre organisation ou à un autre tenant que celui de la session. 

**Origine du bug :** Fusion des couches internal/external de IAM. Avant la fusion, la restriction était appliquée dans la couche externe.                                                                                                                                                                                  


## Changement

Un seul point d'entrée, dans **AbstractResourceClientService**, avec application de la restriction d'accès **checkAuthorization**, aligné sur ce qui existe déjà pour **getAll**.                                                                                                                                                                                                             
                                                                                                                                                                                                                           
Trois appels internes qui doivent rester hors restriction ont été basculés sur **getOneByPassSecurity** (directement ou via son wrapper) ou **findUserById** :                                                                                                                                              
  - **CasController** — subrogation                                                                                                                                                                                          
  - **TenantService** — création d'un tenant pour une autre organisation                                                                                                                                                     
  - **UserService** — création de l'admin d'une nouvelle organisation, alors que                                                                                                                                             
  la session est encore celle de l'organisation émettrice
