### PR TITLE
Bug #16751: fix case-sensitive comparison of the email returned by th…

### DIFF
--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolver.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolver.java
@@ -335,7 +335,7 @@ public class UserPrincipalResolver implements PrincipalResolver {
             sessionStore.set(webContext, Constants.FLOW_LOGIN_CUSTOMER_ID, null);
 
             Assert.isTrue(
-                email.equals(loginEmailFromSession),
+                email.equalsIgnoreCase(loginEmailFromSession),
                 String.format("Invalid user from Idp : Expected: '%s', actual: '%s'", loginEmailFromSession, email)
             );
 

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolverTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolverTest.java
@@ -314,6 +314,46 @@ public final class UserPrincipalResolverTest extends BaseWebflowActionTest {
     }
 
     @Test
+    public void testResolveAuthnDelegationIsCaseInsensitiveOnTheEmailReturnedByTheIdp() {
+        // the user typed "user@test.com" in the login form: the webflow stored it in lower case in the session
+        givenLoginInfoInSessionForDeleguatedAuthn();
+
+        val provider = new IdentityProviderDto();
+        provider.setId(PROVIDER_ID);
+        provider.setMailAttribute(MAIL);
+        when(
+            identityProviderHelper.findByTechnicalName(eq(providersService.getProviders()), eq(PROVIDER_NAME))
+        ).thenReturn(Optional.of(provider));
+
+        //  the IdP returns "USER@test.com"
+        val princAttributes = new HashMap<String, List<Object>>();
+        princAttributes.put(MAIL, Collections.singletonList(USERNAME_EMAIL_WITH_OTHER_CASE));
+
+        // the user must be loaded from the lower case email of the session, not from the one of the IdP:
+        // this mock only answers to that value.
+        when(
+            casExternalRestClient.getUser(
+                any(ExternalHttpContext.class),
+                eq(USERNAME),
+                eq(CUSTOMER_ID),
+                eq(PROVIDER_ID),
+                eq(Optional.of("fake")),
+                eq(Optional.of(CommonConstants.AUTH_TOKEN_PARAMETER))
+            )
+        ).thenReturn(userProfile(UserStatusEnum.ENABLED));
+
+        val principal = resolver.resolve(
+            new ClientCredential(null, PROVIDER_NAME),
+            Optional.of(principalFactory.createPrincipal("fake", princAttributes)),
+            Optional.empty()
+        );
+
+        // the authentication succeeds despite the difference of case
+        assertEquals(USERNAME_ID, principal.getId());
+        assertEquals(USERNAME, principal.getAttributes().get(CommonConstants.EMAIL_ATTRIBUTE).get(0));
+    }
+
+    @Test
     public void testResolveAuthnDelegationIdentifierAttribute() {
         val provider = new IdentityProviderDto();
         provider.setId(PROVIDER_ID);


### PR DESCRIPTION
  Bug #16751 casse des emails en authentification déléguée. Remonté par le support #16745 (CNAM, 7.1.5).                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                           
 L'email saisi sur la page de login est normalisé en minuscules , alors que celui renvoyé par l'IdP est utilisé tel quel. La comparaison dans UserPrincipalResolver échouait donc sur la seule casse :                                                                             
                                                                                                                                                                                                                                                                                                           
  Invalid user from Idp : Expected: 'jean.dupont@…', actual: 'JEAN.DUPONT@…'                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                           
  Correctif : normaliser l'email de l'IdP avant comparaison. C'était le seul point sensible à la casse de toute la chaîne