### PR TITLE
Bug #16753: Accession register : Wrong tooltip label

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/accession-register/accession-register-list/accession-register-list.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/accession-register/accession-register-list/accession-register-list.component.html
@@ -101,7 +101,7 @@
                 </p>
               </td>
               <td>
-                <p [vitamuiTooltip]="accessionRegisterDetail.archivalAgreement">
+                <p [vitamuiTooltip]="accessionRegisterDetail.archivalAgreementLabel">
                   {{ accessionRegisterDetail.archivalAgreement | truncate: 12 }}
                 </p>
               </td>


### PR DESCRIPTION
## Description

Mauvais label utilisé dans un tooltip dans le registre des fonds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the tooltip label for archival agreement rows while preserving the displayed agreement text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->