### PR TITLE
Bug #16657: disable the SSO metadata download links when there is no metadata

### DIFF
--- a/api/api-iam/iam-commons/src/main/java/fr/gouv/vitamui/iam/common/dto/IdentityProviderDto.java
+++ b/api/api-iam/iam-commons/src/main/java/fr/gouv/vitamui/iam/common/dto/IdentityProviderDto.java
@@ -100,6 +100,10 @@ public class IdentityProviderDto extends CustomerIdDto {
 
     private String spMetadata;
 
+    private boolean hasIdpMetadata;
+
+    private boolean hasSpMetadata;
+
     private Integer maximumAuthenticationLifetime;
 
     private AuthnRequestBindingEnum authnRequestBinding = AuthnRequestBindingEnum.POST;

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/idp/service/IdentityProviderService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/idp/service/IdentityProviderService.java
@@ -647,6 +647,17 @@ public class IdentityProviderService extends AbstractResourceClientService<Ident
     }
 
     /**
+     * Sets the metadata presence flags, computed before the masking done by {@link #loadExtraInformation}.
+     */
+    @Override
+    public IdentityProviderDto internalConvertFromEntityToDto(final IdentityProvider entity) {
+        final IdentityProviderDto dto = super.internalConvertFromEntityToDto(entity);
+        dto.setHasIdpMetadata(StringUtils.isNotBlank(entity.getIdpMetadata()));
+        dto.setHasSpMetadata(StringUtils.isNotBlank(entity.getSpMetadata()));
+        return dto;
+    }
+
+    /**
      * Method for load or not file contents
      *
      * @param dto

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/idp/converter/IdentityProviderConverterTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/idp/converter/IdentityProviderConverterTest.java
@@ -78,7 +78,7 @@ class IdentityProviderConverterTest {
         idp.setUseNonce(USE_NONCE);
         idp.setUsePkce(USE_PKCE);
         IdentityProviderDto res = converter.convertEntityToDto(idp);
-        assertThat(res).isEqualToIgnoringGivenFields(idp);
+        assertThat(res).isEqualToIgnoringGivenFields(idp, "hasIdpMetadata", "hasSpMetadata");
     }
 
     @Test

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/idp/service/IdentityProviderIntegrationTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/idp/service/IdentityProviderIntegrationTest.java
@@ -159,11 +159,28 @@ public class IdentityProviderIntegrationTest extends AbstractLogbookIntegrationT
         assertThat(events).hasSize(8);
     }
 
+    @Test
+    void testGetOneKeepsTheMetadataPresenceWhenTheContentIsMasked() {
+        final IdentityProviderDto created = createIdp("<xml></xml>");
+
+        final IdentityProviderDto dto = service.getOne(created.getId(), Optional.empty(), Optional.empty());
+
+        assertThat(dto.getIdpMetadata()).isNull();
+        assertThat(dto.isHasIdpMetadata()).isTrue();
+        assertThat(dto.isHasSpMetadata()).isTrue();
+    }
+
     private IdentityProviderDto createIdp() {
+        return createIdp(null);
+    }
+
+    private IdentityProviderDto createIdp(final String idpMetadata) {
         final String customerId = "customerId";
         final IdentityProviderDto dto = IamServerUtilsTest.buildIdentityProviderDto();
         dto.setCustomerId(customerId);
         dto.setId(null);
+        dto.setIdpMetadata(idpMetadata);
+        Mockito.when(spMetadataGenerator.generate(any())).thenReturn("<sp></sp>");
 
         final Customer customer = new Customer();
         customer.setEnabled(true);

--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.html
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.html
@@ -41,16 +41,16 @@
           </div>
           <a
             class="provider-item-link clickable"
-            (click)="downloadFile(provider?.internal, provider?.idpMetadataUrl)"
-            [class.disabled]="provider?.internal"
+            (click)="downloadFile(provider?.idpMetadataUrl)"
+            [class.disabled]="!canDownloadIdpMetadata(provider)"
           >
             <i class="material-icons">file_download</i>
             <span class="p-0">{{ 'CUSTOMER.SSO.METADATA' | translate }}</span>
           </a>
           <a
             class="provider-item-link clickable"
-            (click)="downloadFile(provider?.internal, provider?.spMetadataUrl)"
-            [class.disabled]="provider?.internal"
+            (click)="downloadFile(provider?.spMetadataUrl)"
+            [class.disabled]="!canDownloadSpMetadata(provider)"
           >
             <i class="material-icons">file_download</i>
             <span class="p-0">{{ 'CUSTOMER.SSO.SP_METADATA' | translate }}</span>

--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.ts
@@ -137,10 +137,16 @@ export class SsoTabComponent implements OnDestroy, OnInit {
     return this.domains.filter((domain) => !domain.disabled).length > 0;
   }
 
-  downloadFile(isInternalProvider: boolean, url: string): void {
-    if (!isInternalProvider) {
-      this.providerApi.getFileByUrl(url).subscribe((response: any) => DownloadUtils.loadFromBlob(response, response.body.type));
-    }
+  canDownloadIdpMetadata(provider: IdentityProvider): boolean {
+    return !provider?.internal && !!provider?.hasIdpMetadata;
+  }
+
+  canDownloadSpMetadata(provider: IdentityProvider): boolean {
+    return !provider?.internal && !!provider?.hasSpMetadata;
+  }
+
+  downloadFile(url: string): void {
+    this.providerApi.getFileByUrl(url).subscribe((response: any) => DownloadUtils.loadFromBlob(response, response.body.type));
   }
 
   private refreshAvailableDomains() {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/customer/identity-provider.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/customer/identity-provider.interface.ts
@@ -50,6 +50,8 @@ export interface IdentityProvider extends Id {
   enabled: boolean;
   idpMetadataUrl?: string;
   spMetadataUrl?: string;
+  hasIdpMetadata?: boolean;
+  hasSpMetadata?: boolean;
   readonly: boolean;
   mailAttribute?: string;
   identifierAttribute?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear availability indicators for identity provider and service provider metadata.
  - Enabled metadata downloads for eligible external providers when the corresponding metadata is available.
  - Download links now reflect metadata availability and are disabled when unavailable.

- **Bug Fixes**
  - Preserved metadata availability information when metadata content is masked.
  - Improved SSO metadata download behavior for supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->