### PR TITLE
Bug #16754: Preservation scenario : import issue

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/preservation/preservation-preview/preservation-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/preservation/preservation-preview/preservation-preview.component.ts
@@ -92,7 +92,7 @@ export class PreservationPreviewComponent {
   }
 
   downloadScenario() {
-    const blob = new Blob([JSON.stringify(this.selectedElement(), null, 2)], { type: 'octet/stream' });
+    const blob = new Blob([JSON.stringify([this.selectedElement()], null, 2)], { type: 'octet/stream' });
     download(blob, 'PreservationScenario.json');
   }
 


### PR DESCRIPTION
## Description

L'import d'un scénario de préservation fraîchement exporté finissait en échec. Le scénario exporté ne l'était pas sous forme de tableau, ce qui causait l'erreur


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scenario downloads now use the expected single-item JSON array format.
  * Download filenames and file types remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->