### PR TITLE
Bug #16747: Logbook : reports download issue

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-download.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-download.service.ts
@@ -73,6 +73,7 @@ export class LogbookDownloadService extends SearchService<IEvent> {
     'IMPORT_PRESERVATION_SCENARIO',
     'IMPORT_GRIFFIN',
     'STP_IMPORT_GRIFFIN',
+    'STP_IMPORT_PRESERVATION_SCENARIO',
     'PRESERVATION',
     'INGEST_CLEANUP',
     'COLLECT_DELETION_ACTION',
@@ -155,6 +156,8 @@ export class LogbookDownloadService extends SearchService<IEvent> {
           case 'IMPORT_ONTOLOGY':
           case 'STP_REFERENTIAL_FORMAT_IMPORT':
           case 'IMPORT_GRIFFIN':
+          case 'STP_IMPORT_GRIFFIN':
+          case 'STP_IMPORT_PRESERVATION_SCENARIO':
           case 'IMPORT_PRESERVATION_SCENARIO':
             return DOWNLOAD_TYPE_REPORT;
           case 'HOLDINGSCHEME':


### PR DESCRIPTION
## Description

Problèmes de téléchargement des rapports pour l'import de griffons et l'import de scénarios de préservation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading reports associated with STP Griffin imports.
  * Added support for downloading reports associated with STP preservation scenario imports.
  * These event types are now recognized in master data downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->