### PR TITLE
Bug #16755: [External Configuration Profiles App] Fix 403 error when loading access contracts and external configuration profiles.

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/AccessContractController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/AccessContractController.java
@@ -94,7 +94,7 @@ public class AccessContractController {
 
     @GetMapping("/accesscontracts")
     @Operation(operationId = "accessContracts_getAll", summary = "Get all access contracts")
-    @Secured(ServicesData.ROLE_GET_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE)
+    @Secured(ServicesData.ROLE_SEARCH_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE)
     public List<AccessContractDto> getAll() {
         final RequestResponse<AccessContractModel> requestResponse;
         final VitamContext vitamContext = securityService.buildVitamContext(securityService.getTenantIdentifier());


### PR DESCRIPTION
Bug : GET /accesscontracts exigeait ROLE_GET_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE, un rôle mal nommé depuis 2021 qui pointe en fait vers ROLE_CREATE_EXTERNAL_PARAM_PROFILE (erreur de préfixe : CREATE_ROLE_PREFIX au lieu de GET_ROLE_PREFIX).

 Conséquence : un utilisateur en simple consultation (ROLE_SEARCH_EXTERNAL_PARAM_PROFILE, sans droit de création) obtenait un 403 sur cet endpoint, alors qu'il en a besoin juste pour consulter un profil existant.

 Correctif : rôle requis changé pour ROLE_SEARCH_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE, aligné sur le rôle qui protège déjà la liste des profils. Sans risque : ce endpoint getAll() n'est utilisé que par le module Paramétrages externes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access contract search permissions to use the appropriate security role.
  * Users with the correct search permission can now access the endpoint as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->