### PR TITLE
Bug #15767: Cancel popup - bug design

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-create/access-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/access-contract/access-contract-create/access-contract-create.component.ts
@@ -174,7 +174,7 @@ export class AccessContractCreateComponent implements OnInit, OnDestroy {
 
   onCancel(): void {
     if (this.form.dirty) {
-      this.confirmDialogService.confirmBeforeClosing(this.dialogRef, { subTitle: 'ACCESS_CONTRACT.CREATE_DIALOG.TITLE' });
+      this.confirmDialogService.confirmBeforeClosing(this.dialogRef);
     } else {
       this.dialogRef.close();
     }

--- a/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ingest-contract/ingest-contract-create/ingest-contract-create.component.ts
@@ -245,7 +245,7 @@ export class IngestContractCreateComponent implements OnInit, OnDestroy {
 
   onCancel() {
     if (this.form.dirty) {
-      this.confirmDialogService.confirmBeforeClosing(this.dialogRef, { subTitle: 'INGEST_CONTRACT.CREATE_DIALOG.TITLE' });
+      this.confirmDialogService.confirmBeforeClosing(this.dialogRef);
     } else {
       this.dialogRef.close();
     }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/common-confirm-dialog/close-popup-dialog.component.html
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/common-confirm-dialog/close-popup-dialog.component.html
@@ -1,8 +1,7 @@
 <vitamui-common-confirm-dialog
-  [dialogTitle]="'COMMON.UNDO_MODAL.TITLE' | translate"
-  [dialogSubTitle]="data?.subTitle | translate"
+  [dialogTitle]="'COMMON.UNDO_MODAL.UNDO_MESSAGE' | translate"
+  [dialogSubTitle]="'COMMON.UNDO_MODAL.TITLE' | translate"
   [confirmLabel]="'COMMON.CLOSE' | translate"
   [cancelLabel]="'COMMON.UNDO' | translate"
 >
-  {{ 'COMMON.UNDO_MODAL.UNDO_MESSAGE' | translate }}
 </vitamui-common-confirm-dialog>

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/common-confirm-dialog/confirm-dialog.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/common-confirm-dialog/confirm-dialog.service.ts
@@ -36,13 +36,12 @@
  */
 import { hasModifierKey } from '@angular/cdk/keycodes';
 import { ComponentType } from '@angular/cdk/portal';
-import { Injectable, TemplateRef, inject } from '@angular/core';
+import { inject, Injectable, TemplateRef } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 
 import { ClosePopupDialogComponent } from './close-popup-dialog.component';
-import { DialogInputData } from './dialog-input-data.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -50,9 +49,9 @@ import { DialogInputData } from './dialog-input-data.interface';
 export class ConfirmDialogService {
   private matDialog = inject(MatDialog);
 
-  public confirm(componentOrTemplateRef: TemplateRef<unknown> | ComponentType<unknown>, data?: DialogInputData): Observable<boolean> {
+  public confirm(componentOrTemplateRef: TemplateRef<unknown> | ComponentType<unknown>): Observable<boolean> {
     return this.matDialog
-      .open(componentOrTemplateRef, { panelClass: 'small', data })
+      .open(componentOrTemplateRef)
       .afterClosed()
       .pipe(filter((result) => !!result));
   }
@@ -66,7 +65,7 @@ export class ConfirmDialogService {
   }
 
   // Opens a confirmation dialog before closing the dialog
-  public confirmBeforeClosing(matDialogRef: MatDialogRef<unknown>, data?: DialogInputData): void {
-    this.confirm(ClosePopupDialogComponent, data).subscribe(() => matDialogRef.close());
+  public confirmBeforeClosing(matDialogRef: MatDialogRef<unknown>): void {
+    this.confirm(ClosePopupDialogComponent).subscribe(() => matDialogRef.close());
   }
 }


### PR DESCRIPTION
## Description

Correction effectuée sur une pop-up de confirmation de fermeture de dialog :
- Modification de l'emplacement des messages
- Changement de la taille de la pop-up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the close-popup dialog’s title and undo-message translations.
  - Removed outdated inline undo-message content.
  - Updated confirmation dialogs to display consistently without small-panel styling.
  - Improved cancellation behavior in contract creation forms, including clearer confirmation prompts when unsaved changes are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->