### PR TITLE
Bug #16723: Adding a management rule - end date miscalculation

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/add-management-rules/add-management-rules.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/management-rules/archive-unit-rules/add-management-rules/add-management-rules.component.ts
@@ -34,7 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, TemplateRef, ViewChild, inject } from '@angular/core';
+import { Component, EventEmitter, inject, Input, OnDestroy, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
@@ -50,8 +50,8 @@ import {
   RuleService,
   SearchCriteriaDto,
   SearchCriteriaEltDto,
-  VitamuiSelectOptions,
   VitamTenantConfigService,
+  VitamuiSelectOptions,
 } from 'vitamui-library';
 import { ManagementRulesSharedDataService } from '../../../../../../core/management-rules-shared-data.service';
 import { ArchiveService } from '../../../../../archive.service';
@@ -341,7 +341,7 @@ export class AddManagementRulesComponent implements OnDestroy, OnInit {
           startDateSelected.setMonth(startDateSelected.getMonth() + Number(this.rule.ruleDuration));
           break;
         case 'DAY':
-          startDateSelected.setDate(startDateSelected.getDay() + Number(this.rule.ruleDuration));
+          startDateSelected.setDate(startDateSelected.getDate() + Number(this.rule.ruleDuration));
           break;
       }
 


### PR DESCRIPTION
## Description

Lors de l'ajout d'une règle de gestion à une UA, la date calculée est incorrecte si la durée de validité se compte en jours

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected end-date calculations for day-based management rules, ensuring dates are calculated from the calendar date rather than the weekday.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->