### PR TITLE
Story #16764: Move discussion collections in a dedicated database

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/DiscussionMongoConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/DiscussionMongoConfig.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2020)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package fr.gouv.vitamui.iam.server.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import fr.gouv.vitamui.commons.mongo.repository.impl.VitamUIRepositoryImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.mongodb.autoconfigure.MongoProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+/**
+ * MongoDB configuration routing the {@code discussion} package to a dedicated database.
+ *
+ * <p>All repositories under {@code fr.gouv.vitamui.iam.server.discussion.dao} are bound to the
+ * {@value #DISCUSSION_DB} database (same Mongo server, different database name). Every other
+ * repository keeps using the default {@code iam} database.</p>
+ *
+ * <p>Because Spring Boot auto-configures the default {@code MongoDatabaseFactory}/{@code MongoTemplate}
+ * conditionally on the absence of such a bean, declaring the discussion factory suppresses the
+ * auto-configured default. We therefore declare both explicitly: the default iam beans are marked
+ * {@code @Primary} so all pre-existing unqualified injections (index setup, {@code CasService},
+ * {@code ExternalParamProfileRepository}, commons transaction manager) keep targeting iam.</p>
+ */
+@Configuration
+@EnableMongoRepositories(
+    basePackages = "fr.gouv.vitamui.iam.server.discussion.dao",
+    mongoTemplateRef = "discussionMongoTemplate",
+    repositoryBaseClass = VitamUIRepositoryImpl.class
+)
+public class DiscussionMongoConfig {
+
+    static final String DISCUSSION_DB = "discussions";
+
+    @Bean
+    @Primary
+    public MongoClient mongoClient(MongoProperties properties) {
+        return MongoClients.create(properties.getUri());
+    }
+
+    @Bean
+    @Primary
+    public com.mongodb.reactivestreams.client.MongoClient reactiveMongoClient(MongoProperties properties) {
+        return com.mongodb.reactivestreams.client.MongoClients.create(properties.getUri());
+    }
+
+    @Bean
+    @Primary
+    public MongoDatabaseFactory mongoDatabaseFactory(MongoClient mongoClient, MongoProperties properties) {
+        return new SimpleMongoClientDatabaseFactory(mongoClient, properties.getMongoClientDatabase());
+    }
+
+    @Bean
+    @Primary
+    public ReactiveMongoDatabaseFactory reactiveMongoDatabaseFactory(
+        com.mongodb.reactivestreams.client.MongoClient client,
+        MongoProperties properties
+    ) {
+        return new SimpleReactiveMongoDatabaseFactory(client, properties.getMongoClientDatabase());
+    }
+
+    @Bean
+    @Primary
+    public MongoTemplate mongoTemplate(MongoDatabaseFactory factory, MongoConverter converter) {
+        return new MongoTemplate(factory, converter);
+    }
+
+    @Bean
+    @Primary
+    public ReactiveMongoTemplate reactiveMongoTemplate(ReactiveMongoDatabaseFactory factory, MongoConverter converter) {
+        return new ReactiveMongoTemplate(factory, converter);
+    }
+
+    @Bean
+    public MongoDatabaseFactory discussionMongoDatabaseFactory(MongoClient mongoClient) {
+        return new SimpleMongoClientDatabaseFactory(mongoClient, DISCUSSION_DB);
+    }
+
+    @Bean
+    public ReactiveMongoDatabaseFactory discussionReactiveMongoDatabaseFactory(
+        com.mongodb.reactivestreams.client.MongoClient reactiveClient
+    ) {
+        return new SimpleReactiveMongoDatabaseFactory(reactiveClient, DISCUSSION_DB);
+    }
+
+    @Bean
+    public MongoTemplate discussionMongoTemplate(
+        @Qualifier("discussionMongoDatabaseFactory") MongoDatabaseFactory factory,
+        MongoConverter converter
+    ) {
+        return new MongoTemplate(factory, converter);
+    }
+
+    @Bean
+    public ReactiveMongoTemplate discussionReactiveMongoTemplate(
+        @Qualifier("discussionReactiveMongoDatabaseFactory") ReactiveMongoDatabaseFactory factory,
+        MongoConverter converter
+    ) {
+        return new ReactiveMongoTemplate(factory, converter);
+    }
+}

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/MongoDbConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/MongoDbConfig.java
@@ -44,7 +44,9 @@ import fr.gouv.vitamui.iam.server.common.domain.MongoDbCollections;
 import jakarta.annotation.PostConstruct;
 import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
@@ -58,6 +60,11 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
     basePackages = {
         "fr.gouv.vitamui.commons.mongo.repository", "fr.gouv.vitamui.commons.mongo.dao", "fr.gouv.vitamui.iam.server",
     },
+    // We exclude the discussion package as it should use a "discussion" database instead of the "iam" database. It is temporary until the discussion-related code is moved outside the IAM application
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.REGEX,
+        pattern = "fr\\.gouv\\.vitamui\\.iam\\.server\\.discussion\\..*"
+    ),
     repositoryBaseClass = VitamUIRepositoryImpl.class
 )
 public class MongoDbConfig {

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/discussion/service/DiscussionService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/discussion/service/DiscussionService.java
@@ -13,6 +13,7 @@ import fr.gouv.vitamui.iam.server.user.dao.UserRepository;
 import fr.gouv.vitamui.iam.server.user.domain.User;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.mongodb.core.ChangeStreamEvent;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.stereotype.Service;
@@ -42,7 +43,7 @@ public class DiscussionService {
     public DiscussionService(
         DiscussionRepository discussionRepository,
         DiscussionReadRepository discussionReadRepository,
-        ReactiveMongoTemplate reactiveMongoTemplate,
+        @Qualifier("discussionReactiveMongoTemplate") ReactiveMongoTemplate reactiveMongoTemplate,
         SecurityService securityService,
         UserRepository userRepository
     ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discussion data is now stored in a dedicated MongoDB database, separate from other IAM data.
  * Discussion services use the dedicated database connection for improved data isolation.

* **Bug Fixes**
  * Prevented discussion repositories from being assigned to the default IAM database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->