### PR TITLE
Bug #16755: [External Configuration Profiles App] Fix 403 error when loading access contracts and external configuration profiles.

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/AccessContractController.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/rest/AccessContractController.java
@@ -94,7 +94,9 @@ public class AccessContractController {
 
     @GetMapping("/accesscontracts")
     @Operation(operationId = "accessContracts_getAll", summary = "Get all access contracts")
-    @Secured(ServicesData.ROLE_SEARCH_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE)
+    @Secured(
+        { ServicesData.ROLE_GET_ACCESS_CONTRACTS, ServicesData.ROLE_SEARCH_ACCESS_CONTRACT_EXTERNAL_PARAM_PROFILE }
+    )
     public List<AccessContractDto> getAll() {
         final RequestResponse<AccessContractModel> requestResponse;
         final VitamContext vitamContext = securityService.buildVitamContext(securityService.getTenantIdentifier());

--- a/deployment/scripts/mongod/1.0.0/314_security_ref.js
+++ b/deployment/scripts/mongod/1.0.0/314_security_ref.js
@@ -13,7 +13,7 @@ dbSecurity.contexts.updateOne(
     }
 );
 
-dbSecurity.contexts.updateOne(
+dbSecurity.contexts.updateMany(
     {
         "_id": {
             $in: [


### PR DESCRIPTION
utliser le bon rôle pour GET EXTERNAL_PARAMS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated access-contract retrieval permissions to require the appropriate authorization permissions.
  - Improved security configuration updates so designated roles are applied consistently across all matching identity contexts.
  - Existing retrieval behavior and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->