### PR TITLE
Story #16764: Deduplicate "discussion" root element in yaml config

### DIFF
--- a/api/api-iam/iam/src/main/resources/application-dev.yml
+++ b/api/api-iam/iam/src/main/resources/application-dev.yml
@@ -24,6 +24,10 @@ spring:
 discussion:
   mongodb:
     uri: mongodb://mongod_dbuser_discussions:mongod_dbpwd_discussions@localhost:27018/discussions?connectTimeoutMS=2000
+  scheduling:
+    purgeTransactionDiscussions:
+      enabled: true
+      cronExpression: 0 */5 * ? * *
 
 server:
   host:
@@ -96,12 +100,6 @@ logbook:
     enabled: false
     sendEventToVitamTasks:
       delay: 10000
-
-discussion:
-  scheduling:
-    purgeTransactionDiscussions:
-      enabled: true
-      cronExpression: 0 */5 * ? * *
 
 vitam.tenant.init.mandatory: true
 

--- a/deployment/roles/vitamui/templates/iam/application.yml.j2
+++ b/deployment/roles/vitamui/templates/iam/application.yml.j2
@@ -22,6 +22,10 @@ spring:
 discussion:
   mongodb:
     uri: "mongodb://{{ mongodb.discussions.user }}:{{ mongodb.discussions.password }}@{{ mongodb.host }}:{{ mongodb.mongod_port }}/{{ mongodb.discussions.db }}?replicaSet={{ mongod_replicaset_name }}&connectTimeoutMS={{ mongod_client_connect_timeout_ms }}"
+  scheduling:
+    purgeTransactionDiscussions:
+      enabled: {{ vitamui_struct.discussion.enabled | default('true') | lower }}
+      cronExpression: {{ vitamui_struct.discussion.cron_expression | default('0 0 * ? * *') }}
 
 logging:
   config: {{ vitamui_folder_conf }}/logback.xml
@@ -128,12 +132,6 @@ logbook:
     enabled: {{ vitamui_struct.logbook.enabled | default('true') | lower }}
     sendEventToVitamTasks:
       delay: {{ vitamui_struct.logbook.delay | default(60000) }}
-
-discussion:
-  scheduling:
-    purgeTransactionDiscussions:
-      enabled: {{ vitamui_struct.discussion.enabled | default('true') | lower }}
-      cronExpression: {{ vitamui_struct.discussion.cron_expression | default('0 0 * ? * *') }}
 
 customer.init.config.file: {{ vitamui_folder_conf }}/customer-init.yml
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the discussion transaction purge scheduling configuration in development and deployment settings.
  * Scheduling behavior remains unchanged, including its enabled status and five-minute interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->