### PR TITLE
Bug #16792: fix case-sensitive comparison of the email returned by the Idp

### DIFF
--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolver.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolver.java
@@ -332,7 +332,7 @@ public class UserPrincipalResolver implements PrincipalResolver {
             sessionStore.set(webContext, Constants.FLOW_LOGIN_CUSTOMER_ID, null);
 
             Assert.isTrue(
-                email.equals(loginEmailFromSession),
+                email.equalsIgnoreCase(loginEmailFromSession),
                 String.format("Invalid user from Idp : Expected: '%s', actual: '%s'", loginEmailFromSession, email)
             );
 

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolverTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolverTest.java
@@ -288,6 +288,46 @@ public final class UserPrincipalResolverTest extends BaseWebflowActionTest {
     }
 
     @Test
+    public void testResolveAuthnDelegationIsCaseInsensitiveOnTheEmailReturnedByTheIdp() throws Throwable {
+        // the user typed "user@test.com" in the login form: the webflow stored it in lower case in the session
+        givenLoginInfoInSessionForDeleguatedAuthn();
+
+        final var provider = new IdentityProviderDto();
+        provider.setId(PROVIDER_ID);
+        provider.setMailAttribute(MAIL);
+        when(
+            identityProviderHelper.findByTechnicalName(eq(providersService.getProviders()), eq(PROVIDER_NAME))
+        ).thenReturn(Optional.of(provider));
+
+        //  the IdP returns "USER@test.com"
+        final var princAttributes = new HashMap<String, List<Object>>();
+        princAttributes.put(MAIL, Collections.singletonList(USERNAME_EMAIL_WITH_OTHER_CASE));
+
+        // the user must be loaded from the lower case email of the session, not from the one of the IdP:
+        // this mock only answers to that value.
+        when(
+            casApi.getUser(
+                eq(USERNAME),
+                eq(CUSTOMER_ID),
+                eq(PROVIDER_ID),
+                eq("fake"),
+                eq(CommonConstants.AUTH_TOKEN_PARAMETER)
+            )
+        ).thenReturn(userProfile(UserStatusEnum.ENABLED));
+
+        final var principal = resolver.resolve(
+            new ClientCredential(null, PROVIDER_NAME),
+            Optional.of(principalFactory.createPrincipal("fake", princAttributes)),
+            Optional.empty(),
+            Optional.empty()
+        );
+
+        // the authentication succeeds despite the difference of case
+        assertEquals(USERNAME_ID, principal.getId());
+        assertEquals(USERNAME, principal.getAttributes().get(CommonConstants.EMAIL_ATTRIBUTE).getFirst());
+    }
+
+    @Test
     public void testResolveAuthnDelegationIdentifierAttribute() throws Throwable {
         final var provider = new IdentityProviderDto();
         provider.setId(PROVIDER_ID);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email matching during delegated authentication is now case-insensitive.
  * Users can authenticate successfully when the identity provider returns an email with different capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->