### PR TITLE
Story #16725: remove temporary FIXME on Discussion garbage collector

### DIFF
--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/discussion/scheduler/PurgeTransactionDiscussionsTask.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/discussion/scheduler/PurgeTransactionDiscussionsTask.java
@@ -39,7 +39,6 @@ package fr.gouv.vitamui.iam.server.discussion.scheduler;
 import com.fasterxml.jackson.databind.JsonNode;
 import fr.gouv.vitam.collect.common.dto.TransactionDto;
 import fr.gouv.vitam.collect.common.enums.TransactionStatus;
-import fr.gouv.vitam.collect.external.exception.CollectExternalClientInvalidRequestException;
 import fr.gouv.vitam.collect.external.exception.CollectExternalClientNotFoundException;
 import fr.gouv.vitam.common.client.VitamContext;
 import fr.gouv.vitam.common.exception.InvalidParseOperationException;
@@ -183,20 +182,13 @@ public class PurgeTransactionDiscussionsTask {
                     );
                     discussionRepository.deleteAll(discussions);
                 }
-            } catch (CollectExternalClientNotFoundException | CollectExternalClientInvalidRequestException e) {
-                // FIXME: Expected exception should be CollectExternalClientNotFoundException, but current API returns a 400 (instead of 404), throwing a CollectExternalClientInvalidRequestException instead. We temporarily catch also CollectExternalClientInvalidRequestException and check the code and message to handle "not found" with current API misbehaviour.
-                if (
-                    e instanceof CollectExternalClientNotFoundException ||
-                    (e.getVitamError().getHttpCode() == 400 &&
-                        e.getVitamError().getMessage().startsWith("No such transaction"))
-                ) {
-                    LOGGER.debug(
-                        "Transaction {} does not exist. Deleting {} discussions related to that transaction",
-                        transactionId,
-                        discussions.size()
-                    );
-                    discussionRepository.deleteAll(discussions);
-                }
+            } catch (CollectExternalClientNotFoundException e) {
+                LOGGER.debug(
+                    "Transaction {} does not exist. Deleting {} discussions related to that transaction",
+                    transactionId,
+                    discussions.size()
+                );
+                discussionRepository.deleteAll(discussions);
             } catch (VitamClientException | InvalidParseOperationException e) {
                 LOGGER.error("Couldn't retrieve transaction with id {} on tenant {}", transactionId, tenant, e);
             }

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/discussion/scheduler/PurgeTransactionDiscussionsTaskTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/discussion/scheduler/PurgeTransactionDiscussionsTaskTest.java
@@ -179,23 +179,6 @@ class PurgeTransactionDiscussionsTaskTest {
     }
 
     @Test
-    void deletesDiscussionsWhenTransactionNoLongerExistsViaInvalidRequestException() throws Exception {
-        final Discussion discussion = transactionDiscussion(TRANSACTION_ID);
-        when(discussionRepository.findByEntitiesEntityType(EntityType.TRANSACTION)).thenReturn(Stream.of(discussion));
-        when(collectService.getTransactionById(any(VitamContext.class), anyString())).thenThrow(
-            new CollectExternalClientInvalidRequestException(
-                "bad request",
-                new VitamError<>("0").setHttpCode(400).setMessage("No such transaction with id " + TRANSACTION_ID)
-            )
-        );
-
-        task.run();
-
-        verify(discussionRepository).deleteAll(discussionsCaptor.capture());
-        assertThat(discussionsCaptor.getValue()).containsExactly(discussion);
-    }
-
-    @Test
     void doesNotDeleteDiscussionsWhenInvalidRequestExceptionIsNotANotFound() throws Exception {
         final Discussion discussion = transactionDiscussion(TRANSACTION_ID);
         when(discussionRepository.findByEntitiesEntityType(EntityType.TRANSACTION)).thenReturn(Stream.of(discussion));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of discussions linked to closed or unavailable transactions.
  * Discussions are now reliably removed when their associated transaction no longer exists.
  * Simplified error handling for missing transactions during scheduled cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->