### PR TITLE
Story #16471: clean naming object review post spring boot migration PR

### DIFF
--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/config/ApiArchiveServerConfig.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/config/ApiArchiveServerConfig.java
@@ -55,7 +55,7 @@ import fr.gouv.vitamui.commons.vitam.api.administration.ConfigurationService;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAccessConfig;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAdministrationConfig;
 import fr.gouv.vitamui.iam.openapiclient.ExternalParametersApi;
-import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactoryVitamui;
+import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactory;
 import fr.gouv.vitamui.iam.openapiclient.UsersApi;
 import fr.gouv.vitamui.iam.security.config.ExternalParametersCommonConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
@@ -66,7 +66,7 @@ import fr.gouv.vitamui.iam.security.service.IamClientUserAuthenticationService;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.security.service.UserAuthenticationService;
 import fr.gouv.vitamui.security.openapiclient.ContextsApi;
-import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactoryVitamui;
+import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -101,18 +101,15 @@ public class ApiArchiveServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public SecurityApiClientsFactoryVitamui securityApiClientsFactory(
+    public SecurityApiClientsFactory securityApiClientsFactory(
         final ApiArchiveApplicationProperties apiArchiveApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new SecurityApiClientsFactoryVitamui(
-            apiArchiveApplicationProperties.getSecurityClient(),
-            restClientBuilder
-        );
+        return new SecurityApiClientsFactory(apiArchiveApplicationProperties.getSecurityClient(), restClientBuilder);
     }
 
     @Bean
-    public ContextsApi contextsApi(final SecurityApiClientsFactoryVitamui securityApiClientsFactory) {
+    public ContextsApi contextsApi(final SecurityApiClientsFactory securityApiClientsFactory) {
         return securityApiClientsFactory.getContextsApi();
     }
 
@@ -163,20 +160,20 @@ public class ApiArchiveServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public IamApiClientsFactoryVitamui iamApiClientsFactory(
+    public IamApiClientsFactory iamApiClientsFactory(
         final ApiArchiveApplicationProperties apiArchiveApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new IamApiClientsFactoryVitamui(apiArchiveApplicationProperties.getIamClient(), restClientBuilder);
+        return new IamApiClientsFactory(apiArchiveApplicationProperties.getIamClient(), restClientBuilder);
     }
 
     @Bean
-    public UsersApi usersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public UsersApi usersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getUsersApi();
     }
 
     @Bean
-    public ExternalParametersApi externalParametersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public ExternalParametersApi externalParametersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getExternalParametersApi();
     }
 

--- a/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/config/ApiCollectServerConfig.java
+++ b/api/api-collect/collect/src/main/java/fr/gouv/vitamui/collect/server/config/ApiCollectServerConfig.java
@@ -43,7 +43,7 @@ import fr.gouv.vitamui.commons.vitam.api.config.VitamAccessConfig;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAdministrationConfig;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamCollectConfig;
 import fr.gouv.vitamui.iam.openapiclient.ExternalParametersApi;
-import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactoryVitamui;
+import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactory;
 import fr.gouv.vitamui.iam.openapiclient.UsersApi;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
 import fr.gouv.vitamui.iam.security.provider.ExternalApiAuthenticationProvider;
@@ -52,7 +52,7 @@ import fr.gouv.vitamui.iam.security.service.IamClientUserAuthenticationService;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
 import fr.gouv.vitamui.iam.security.service.UserAuthenticationService;
 import fr.gouv.vitamui.security.openapiclient.ContextsApi;
-import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactoryVitamui;
+import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -78,18 +78,15 @@ public class ApiCollectServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public SecurityApiClientsFactoryVitamui securityApiClientsFactory(
+    public SecurityApiClientsFactory securityApiClientsFactory(
         final ApiCollectApplicationProperties apiCollectApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new SecurityApiClientsFactoryVitamui(
-            apiCollectApplicationProperties.getSecurityClient(),
-            restClientBuilder
-        );
+        return new SecurityApiClientsFactory(apiCollectApplicationProperties.getSecurityClient(), restClientBuilder);
     }
 
     @Bean
-    public ContextsApi contextsApi(final SecurityApiClientsFactoryVitamui securityApiClientsFactory) {
+    public ContextsApi contextsApi(final SecurityApiClientsFactory securityApiClientsFactory) {
         return securityApiClientsFactory.getContextsApi();
     }
 
@@ -140,15 +137,15 @@ public class ApiCollectServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public IamApiClientsFactoryVitamui iamApiClientsFactory(
+    public IamApiClientsFactory iamApiClientsFactory(
         final ApiCollectApplicationProperties apiCollectApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new IamApiClientsFactoryVitamui(apiCollectApplicationProperties.getIamClient(), restClientBuilder);
+        return new IamApiClientsFactory(apiCollectApplicationProperties.getIamClient(), restClientBuilder);
     }
 
     @Bean
-    public UsersApi usersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public UsersApi usersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getUsersApi();
     }
 
@@ -158,7 +155,7 @@ public class ApiCollectServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public ExternalParametersApi externalParametersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public ExternalParametersApi externalParametersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getExternalParametersApi();
     }
 

--- a/api/api-iam/iam-client/src/main/java/fr/gouv/vitamui/iam/openapiclient/IamApiClientsFactory.java
+++ b/api/api-iam/iam-client/src/main/java/fr/gouv/vitamui/iam/openapiclient/IamApiClientsFactory.java
@@ -27,14 +27,14 @@
 
 package fr.gouv.vitamui.iam.openapiclient;
 
-import fr.gouv.vitamui.commons.rest.client.BaseVitamuiRestClientFactory;
+import fr.gouv.vitamui.commons.rest.client.BaseRestClientFactory;
 import fr.gouv.vitamui.commons.rest.client.configuration.RestClientConfiguration;
 import fr.gouv.vitamui.iam.openapiclient.invoker.ApiClient;
 import org.springframework.web.client.RestClient;
 
-public class IamApiClientsFactoryVitamui extends BaseVitamuiRestClientFactory {
+public class IamApiClientsFactory extends BaseRestClientFactory {
 
-    public IamApiClientsFactoryVitamui(
+    public IamApiClientsFactory(
         final RestClientConfiguration restClientConfiguration,
         final RestClient.Builder restClientBuilder
     ) {

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/ApiIamServerConfig.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/config/ApiIamServerConfig.java
@@ -44,7 +44,7 @@ import fr.gouv.vitamui.commons.api.download.SignedDownloadTokenService;
 import fr.gouv.vitamui.commons.mongo.dao.CustomSequenceRepository;
 import fr.gouv.vitamui.commons.mongo.service.SequenceGeneratorService;
 import fr.gouv.vitamui.commons.rest.RestExceptionHandler;
-import fr.gouv.vitamui.commons.rest.client.BaseVitamuiRestClientFactory;
+import fr.gouv.vitamui.commons.rest.client.BaseRestClientFactory;
 import fr.gouv.vitamui.commons.rest.client.configuration.RestClientConfiguration;
 import fr.gouv.vitamui.commons.rest.config.Jackson2CompatibilityConfig;
 import fr.gouv.vitamui.commons.rest.config.Jackson2ObjectMapperFactory;
@@ -111,7 +111,7 @@ import fr.gouv.vitamui.iam.server.user.service.UserExportService;
 import fr.gouv.vitamui.iam.server.user.service.UserInfoService;
 import fr.gouv.vitamui.iam.server.user.service.UserService;
 import fr.gouv.vitamui.security.openapiclient.ContextsApi;
-import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactoryVitamui;
+import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -207,15 +207,15 @@ public class ApiIamServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public SecurityApiClientsFactoryVitamui securityApiClientsFactory(
+    public SecurityApiClientsFactory securityApiClientsFactory(
         final RestClient.Builder restClientBuilder,
         final ApiIamApplicationProperties apiIamApplicationProperties
     ) {
-        return new SecurityApiClientsFactoryVitamui(apiIamApplicationProperties.getSecurityClient(), restClientBuilder);
+        return new SecurityApiClientsFactory(apiIamApplicationProperties.getSecurityClient(), restClientBuilder);
     }
 
     @Bean
-    public ContextsApi contextsApi(final SecurityApiClientsFactoryVitamui securityApiClientsFactory) {
+    public ContextsApi contextsApi(final SecurityApiClientsFactory securityApiClientsFactory) {
         return securityApiClientsFactory.getContextsApi();
     }
 
@@ -520,10 +520,7 @@ public class ApiIamServerConfig extends AbstractContextConfiguration {
         final RestClient.Builder restClientBuilder,
         final RestClientConfiguration casClientProperties
     ) {
-        final BaseVitamuiRestClientFactory factory = new BaseVitamuiRestClientFactory(
-            casClientProperties,
-            restClientBuilder
-        );
+        final BaseRestClientFactory factory = new BaseRestClientFactory(casClientProperties, restClientBuilder);
         return new UserEmailService(factory);
     }
 

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/provisioning/client/ProvisioningWebClient.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/provisioning/client/ProvisioningWebClient.java
@@ -34,10 +34,11 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.iam.server.provisioning.client;
 
-import fr.gouv.vitamui.commons.rest.client.BaseCrudWebClientVitamui;
-import fr.gouv.vitamui.commons.rest.client.BaseWebClientVitamui;
+import fr.gouv.vitamui.commons.rest.client.BaseCrudWebClient;
+import fr.gouv.vitamui.commons.rest.client.BaseWebClient;
 import fr.gouv.vitamui.commons.rest.client.HttpContext;
 import fr.gouv.vitamui.iam.common.dto.ProvidedUserDto;
 import org.apache.commons.lang3.StringUtils;
@@ -49,11 +50,11 @@ import org.springframework.web.reactive.function.client.WebClient;
 /**
  * External WebClient for Customer operations.
  */
-public class ProvisioningWebClientVitamui extends BaseWebClientVitamui<HttpContext> {
+public class ProvisioningWebClient extends BaseWebClient<HttpContext> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProvisioningWebClientVitamui.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProvisioningWebClient.class);
 
-    public ProvisioningWebClientVitamui(final WebClient webClient, final String baseUrl) {
+    public ProvisioningWebClient(final WebClient webClient, final String baseUrl) {
         super(webClient, baseUrl);
     }
 
@@ -88,7 +89,7 @@ public class ProvisioningWebClientVitamui extends BaseWebClientVitamui<HttpConte
             .uri(buildUriBuilder(builder))
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(ProvidedUserDto.class)
             .block();
     }

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/provisioning/service/ProvisioningService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/provisioning/service/ProvisioningService.java
@@ -42,7 +42,7 @@ import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.rest.client.BaseWebClientFactory;
 import fr.gouv.vitamui.iam.common.dto.ProvidedUserDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
-import fr.gouv.vitamui.iam.server.provisioning.client.ProvisioningWebClientVitamui;
+import fr.gouv.vitamui.iam.server.provisioning.client.ProvisioningWebClient;
 import fr.gouv.vitamui.iam.server.provisioning.config.IdPProvisioningClientConfiguration;
 import fr.gouv.vitamui.iam.server.provisioning.config.ProvisioningClientConfiguration;
 import jakarta.validation.constraints.NotNull;
@@ -140,9 +140,7 @@ public class ProvisioningService {
      * @param idpProvisioningClient
      * @return
      */
-    protected ProvisioningWebClientVitamui buildWebClient(
-        final IdPProvisioningClientConfiguration idpProvisioningClient
-    ) {
+    protected ProvisioningWebClient buildWebClient(final IdPProvisioningClientConfiguration idpProvisioningClient) {
         final BaseWebClientFactory clientFactory = new BaseWebClientFactory(
             idpProvisioningClient.getClient(),
             null,
@@ -150,6 +148,6 @@ public class ProvisioningService {
             idpProvisioningClient.getUri()
         );
 
-        return new ProvisioningWebClientVitamui(clientFactory.getWebClient(), idpProvisioningClient.getUri());
+        return new ProvisioningWebClient(clientFactory.getWebClient(), idpProvisioningClient.getUri());
     }
 }

--- a/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserEmailService.java
+++ b/api/api-iam/iam/src/main/java/fr/gouv/vitamui/iam/server/user/service/UserEmailService.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.iam.server.user.service;
 
 import fr.gouv.vitamui.commons.api.domain.LanguageDto;
@@ -41,7 +42,7 @@ import fr.gouv.vitamui.commons.api.domain.UserDto;
 import fr.gouv.vitamui.commons.api.domain.UserInfoDto;
 import fr.gouv.vitamui.commons.api.enums.UserStatusEnum;
 import fr.gouv.vitamui.commons.api.enums.UserTypeEnum;
-import fr.gouv.vitamui.commons.rest.client.VitamuiRestClientFactory;
+import fr.gouv.vitamui.commons.rest.client.RestClientFactory;
 import fr.gouv.vitamui.iam.common.dto.IdentityProviderDto;
 import fr.gouv.vitamui.iam.common.utils.IdentityProviderHelper;
 import fr.gouv.vitamui.iam.server.idp.service.IdentityProviderService;
@@ -79,10 +80,10 @@ public class UserEmailService {
     @Autowired
     private IdentityProviderService internalIdentityProviderService;
 
-    private final VitamuiRestClientFactory vitamuiRestClientFactory;
+    private final RestClientFactory restClientFactory;
 
-    public UserEmailService(final VitamuiRestClientFactory vitamuiRestClientFactory) {
-        this.vitamuiRestClientFactory = vitamuiRestClientFactory;
+    public UserEmailService(final RestClientFactory restClientFactory) {
+        this.restClientFactory = restClientFactory;
     }
 
     public void sendCreationEmail(final UserDto userDto) {
@@ -104,11 +105,11 @@ public class UserEmailService {
             ) {
                 LOGGER.debug("Sending mail after creating  user: {}", userDto.getEmail());
                 final UserInfoDto userInfoDto = userInfoService.getOne(userDto.getUserInfoId());
-                vitamuiRestClientFactory
+                restClientFactory
                     .getRestClient()
                     .get()
                     .uri(
-                        vitamuiRestClientFactory.getBaseUrl() + casResetPasswordUrl,
+                        restClientFactory.getBaseUrl() + casResetPasswordUrl,
                         userDto.getEmail(),
                         userDto.getFirstname(),
                         userDto.getLastname(),

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/provisioning/client/ProvisioningWebClientTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/provisioning/client/ProvisioningWebClientTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.when;
 class ProvisioningWebClientTest {
 
     @InjectMocks
-    private ProvisioningWebClientVitamui provisioningWebClient;
+    private ProvisioningWebClient provisioningWebClient;
 
     @Mock
     private WebClient webClientMock;

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/provisioning/service/ProvisioningServiceTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/provisioning/service/ProvisioningServiceTest.java
@@ -42,7 +42,7 @@ import fr.gouv.vitamui.commons.api.exception.NotFoundException;
 import fr.gouv.vitamui.commons.rest.client.configuration.RestClientConfiguration;
 import fr.gouv.vitamui.iam.common.dto.ProvidedUserDto;
 import fr.gouv.vitamui.iam.security.service.SecurityService;
-import fr.gouv.vitamui.iam.server.provisioning.client.ProvisioningWebClientVitamui;
+import fr.gouv.vitamui.iam.server.provisioning.client.ProvisioningWebClient;
 import fr.gouv.vitamui.iam.server.provisioning.config.IdPProvisioningClientConfiguration;
 import fr.gouv.vitamui.iam.server.provisioning.config.ProvisioningClientConfiguration;
 import org.junit.jupiter.api.Assertions;
@@ -115,7 +115,7 @@ class ProvisioningServiceTest {
         );
 
         // Do
-        ProvisioningWebClientVitamui webClient = service.buildWebClient(idpConfiguration);
+        ProvisioningWebClient webClient = service.buildWebClient(idpConfiguration);
 
         // Verify
         Assertions.assertNotNull(webClient);
@@ -125,7 +125,7 @@ class ProvisioningServiceTest {
     void getUserInformation_whenCall_thenUserIsReturned() {
         // Prepare
         var provisioningInternalServiceSpy = Mockito.spy(service);
-        var provisioningWebClient = Mockito.mock(ProvisioningWebClientVitamui.class);
+        var provisioningWebClient = Mockito.mock(ProvisioningWebClient.class);
         var providedUserDtoStub = new ProvidedUserDto();
         providedUserDtoStub.setFirstname("youyou");
 
@@ -171,7 +171,7 @@ class ProvisioningServiceTest {
     @Test
     void getUserInformation_whenAddressReturned_isTooLong() {
         var provisioningInternalServiceSpy = Mockito.spy(service);
-        var provisioningWebClient = Mockito.mock(ProvisioningWebClientVitamui.class);
+        var provisioningWebClient = Mockito.mock(ProvisioningWebClient.class);
         var providedUserDtoStub = new ProvidedUserDto();
         providedUserDtoStub.setFirstname("youyou");
         AddressDto addressDto = new AddressDto();

--- a/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/user/service/UserEmailServiceTest.java
+++ b/api/api-iam/iam/src/test/java/fr/gouv/vitamui/iam/server/user/service/UserEmailServiceTest.java
@@ -4,7 +4,7 @@ import fr.gouv.vitamui.commons.api.domain.UserDto;
 import fr.gouv.vitamui.commons.api.domain.UserInfoDto;
 import fr.gouv.vitamui.commons.api.enums.UserStatusEnum;
 import fr.gouv.vitamui.commons.api.enums.UserTypeEnum;
-import fr.gouv.vitamui.commons.rest.client.VitamuiRestClientFactory;
+import fr.gouv.vitamui.commons.rest.client.RestClientFactory;
 import fr.gouv.vitamui.iam.common.dto.IdentityProviderDto;
 import fr.gouv.vitamui.iam.common.utils.IdentityProviderHelper;
 import fr.gouv.vitamui.iam.server.idp.service.IdentityProviderService;
@@ -42,7 +42,7 @@ final class UserEmailServiceTest {
 
     private IdentityProviderService identityProviderService;
 
-    private VitamuiRestClientFactory vitamuiRestClientFactory;
+    private RestClientFactory restClientFactory;
 
     private RestClient restClient;
 
@@ -62,19 +62,19 @@ final class UserEmailServiceTest {
         identityProviderHelper = mock(IdentityProviderHelper.class);
         userInfoService = mock(UserInfoService.class);
         identityProviderService = mock(IdentityProviderService.class);
-        vitamuiRestClientFactory = mock(VitamuiRestClientFactory.class);
+        restClientFactory = mock(RestClientFactory.class);
         restClient = mock(RestClient.class);
         uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
         responseSpec = mock(RestClient.ResponseSpec.class);
 
-        when(vitamuiRestClientFactory.getRestClient()).thenReturn(restClient);
-        when(vitamuiRestClientFactory.getBaseUrl()).thenReturn(BASE_URL);
+        when(restClientFactory.getRestClient()).thenReturn(restClient);
+        when(restClientFactory.getBaseUrl()).thenReturn(BASE_URL);
         when(restClient.get()).thenReturn(uriSpec);
         when(uriSpec.uri(any(String.class), any(), any(), any(), any(), any())).thenReturn(uriSpec);
         when(uriSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(Boolean.class)).thenReturn(true);
 
-        userEmailService = new UserEmailService(vitamuiRestClientFactory);
+        userEmailService = new UserEmailService(restClientFactory);
         userEmailService.setInternalIdentityProviderService(identityProviderService);
         userEmailService.setIdentityProviderHelper(identityProviderHelper);
         userEmailService.setUserInfoService(userInfoService);

--- a/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/config/ApiIngestServerConfig.java
+++ b/api/api-ingest/ingest/src/main/java/fr/gouv/vitamui/ingest/server/config/ApiIngestServerConfig.java
@@ -47,7 +47,7 @@ import fr.gouv.vitamui.commons.vitam.api.config.VitamAdministrationConfig;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamIngestConfig;
 import fr.gouv.vitamui.iam.openapiclient.CustomersApi;
 import fr.gouv.vitamui.iam.openapiclient.ExternalParametersApi;
-import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactoryVitamui;
+import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactory;
 import fr.gouv.vitamui.iam.openapiclient.UsersApi;
 import fr.gouv.vitamui.iam.security.config.ExternalParametersCommonConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
@@ -62,7 +62,7 @@ import fr.gouv.vitamui.ingest.server.service.IngestAccessContractService;
 import fr.gouv.vitamui.ingest.server.service.IngestGeneratorODTFile;
 import fr.gouv.vitamui.ingest.server.service.IngestService;
 import fr.gouv.vitamui.security.openapiclient.ContextsApi;
-import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactoryVitamui;
+import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -91,18 +91,15 @@ public class ApiIngestServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public SecurityApiClientsFactoryVitamui securityApiClientsFactory(
+    public SecurityApiClientsFactory securityApiClientsFactory(
         final ApiIngestApplicationProperties apiIngestApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new SecurityApiClientsFactoryVitamui(
-            apiIngestApplicationProperties.getSecurityClient(),
-            restClientBuilder
-        );
+        return new SecurityApiClientsFactory(apiIngestApplicationProperties.getSecurityClient(), restClientBuilder);
     }
 
     @Bean
-    public ContextsApi contextsApi(final SecurityApiClientsFactoryVitamui securityApiClientsFactory) {
+    public ContextsApi contextsApi(final SecurityApiClientsFactory securityApiClientsFactory) {
         return securityApiClientsFactory.getContextsApi();
     }
 
@@ -178,15 +175,15 @@ public class ApiIngestServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public IamApiClientsFactoryVitamui iamApiClientsFactory(
+    public IamApiClientsFactory iamApiClientsFactory(
         final ApiIngestApplicationProperties ingestApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new IamApiClientsFactoryVitamui(ingestApplicationProperties.getIamClient(), restClientBuilder);
+        return new IamApiClientsFactory(ingestApplicationProperties.getIamClient(), restClientBuilder);
     }
 
     @Bean
-    public UsersApi usersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public UsersApi usersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getUsersApi();
     }
 
@@ -213,7 +210,7 @@ public class ApiIngestServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public CustomersApi customersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public CustomersApi customersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getCustomersApi();
     }
 
@@ -223,7 +220,7 @@ public class ApiIngestServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public ExternalParametersApi externalParametersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public ExternalParametersApi externalParametersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getExternalParametersApi();
     }
 

--- a/api/api-pastis/pastis/src/main/java/fr/gouv/vitamui/pastis/server/config/ApiPastisServerConfig.java
+++ b/api/api-pastis/pastis/src/main/java/fr/gouv/vitamui/pastis/server/config/ApiPastisServerConfig.java
@@ -49,7 +49,7 @@ import fr.gouv.vitamui.commons.vitam.api.administration.VitamProfileCommonServic
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAccessConfig;
 import fr.gouv.vitamui.iam.openapiclient.CustomersApi;
 import fr.gouv.vitamui.iam.openapiclient.ExternalParametersApi;
-import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactoryVitamui;
+import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactory;
 import fr.gouv.vitamui.iam.openapiclient.UsersApi;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
 import fr.gouv.vitamui.iam.security.provider.ExternalApiAuthenticationProvider;
@@ -62,7 +62,7 @@ import fr.gouv.vitamui.pastis.common.service.PuaFromJSON;
 import fr.gouv.vitamui.pastis.common.service.PuaPastisValidator;
 import fr.gouv.vitamui.pastis.server.security.WebSecurityConfig;
 import fr.gouv.vitamui.security.openapiclient.ContextsApi;
-import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactoryVitamui;
+import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactory;
 import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -87,18 +87,15 @@ public class ApiPastisServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public SecurityApiClientsFactoryVitamui securityApiClientsFactory(
+    public SecurityApiClientsFactory securityApiClientsFactory(
         final ApiPastisApplicationProperties apiPastisApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new SecurityApiClientsFactoryVitamui(
-            apiPastisApplicationProperties.getSecurityClient(),
-            restClientBuilder
-        );
+        return new SecurityApiClientsFactory(apiPastisApplicationProperties.getSecurityClient(), restClientBuilder);
     }
 
     @Bean
-    public ContextsApi contextsApi(final SecurityApiClientsFactoryVitamui securityApiClientsFactory) {
+    public ContextsApi contextsApi(final SecurityApiClientsFactory securityApiClientsFactory) {
         return securityApiClientsFactory.getContextsApi();
     }
 
@@ -124,25 +121,25 @@ public class ApiPastisServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public IamApiClientsFactoryVitamui iamApiClientsFactory(
+    public IamApiClientsFactory iamApiClientsFactory(
         final ApiPastisApplicationProperties apiPastisApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new IamApiClientsFactoryVitamui(apiPastisApplicationProperties.getIamClient(), restClientBuilder);
+        return new IamApiClientsFactory(apiPastisApplicationProperties.getIamClient(), restClientBuilder);
     }
 
     @Bean
-    public UsersApi usersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public UsersApi usersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getUsersApi();
     }
 
     @Bean
-    public CustomersApi customersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public CustomersApi customersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getCustomersApi();
     }
 
     @Bean
-    public ExternalParametersApi externalParametersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public ExternalParametersApi externalParametersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getExternalParametersApi();
     }
 

--- a/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/config/ApiReferentialServerConfig.java
+++ b/api/api-referential/referential/src/main/java/fr/gouv/vitamui/referential/server/config/ApiReferentialServerConfig.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.referential.server.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,7 +53,7 @@ import fr.gouv.vitamui.commons.vitam.api.config.VitamAccessConfig;
 import fr.gouv.vitamui.commons.vitam.api.config.VitamAdministrationConfig;
 import fr.gouv.vitamui.iam.openapiclient.ApplicationsApi;
 import fr.gouv.vitamui.iam.openapiclient.ExternalParametersApi;
-import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactoryVitamui;
+import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactory;
 import fr.gouv.vitamui.iam.openapiclient.UsersApi;
 import fr.gouv.vitamui.iam.security.config.ExternalParametersCommonConfig;
 import fr.gouv.vitamui.iam.security.provider.ApiAuthenticationProvider;
@@ -77,7 +78,7 @@ import fr.gouv.vitamui.referential.common.service.VitamUIAccessContractCommonSer
 import fr.gouv.vitamui.referential.common.service.VitamUIManagementContractCommonService;
 import fr.gouv.vitamui.referential.server.security.WebSecurityConfig;
 import fr.gouv.vitamui.security.openapiclient.ContextsApi;
-import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactoryVitamui;
+import fr.gouv.vitamui.security.openapiclient.SecurityApiClientsFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -124,18 +125,18 @@ public class ApiReferentialServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public SecurityApiClientsFactoryVitamui securityApiClientsFactory(
+    public SecurityApiClientsFactory securityApiClientsFactory(
         final ApiReferentialApplicationProperties apiReferentialApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new SecurityApiClientsFactoryVitamui(
+        return new SecurityApiClientsFactory(
             apiReferentialApplicationProperties.getSecurityClient(),
             restClientBuilder
         );
     }
 
     @Bean
-    public ContextsApi contextsApi(final SecurityApiClientsFactoryVitamui securityApiClientsFactory) {
+    public ContextsApi contextsApi(final SecurityApiClientsFactory securityApiClientsFactory) {
         return securityApiClientsFactory.getContextsApi();
     }
 
@@ -263,15 +264,15 @@ public class ApiReferentialServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public IamApiClientsFactoryVitamui iamApiClientsFactory(
+    public IamApiClientsFactory iamApiClientsFactory(
         final ApiReferentialApplicationProperties apiReferentialApplicationProperties,
         final RestClient.Builder restClientBuilder
     ) {
-        return new IamApiClientsFactoryVitamui(apiReferentialApplicationProperties.getIamClient(), restClientBuilder);
+        return new IamApiClientsFactory(apiReferentialApplicationProperties.getIamClient(), restClientBuilder);
     }
 
     @Bean
-    public ApplicationsApi applicationsApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public ApplicationsApi applicationsApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getApplicationsApi();
     }
 
@@ -286,12 +287,12 @@ public class ApiReferentialServerConfig extends AbstractContextConfiguration {
     }
 
     @Bean
-    public ExternalParametersApi externalParametersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public ExternalParametersApi externalParametersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getExternalParametersApi();
     }
 
     @Bean
-    public UsersApi usersApi(final IamApiClientsFactoryVitamui iamApiClientsFactory) {
+    public UsersApi usersApi(final IamApiClientsFactory iamApiClientsFactory) {
         return iamApiClientsFactory.getUsersApi();
     }
 

--- a/api/api-security/security-client/src/main/java/fr/gouv/vitamui/security/openapiclient/SecurityApiClientsFactory.java
+++ b/api/api-security/security-client/src/main/java/fr/gouv/vitamui/security/openapiclient/SecurityApiClientsFactory.java
@@ -27,14 +27,14 @@
 
 package fr.gouv.vitamui.security.openapiclient;
 
-import fr.gouv.vitamui.commons.rest.client.BaseVitamuiRestClientFactory;
+import fr.gouv.vitamui.commons.rest.client.BaseRestClientFactory;
 import fr.gouv.vitamui.commons.rest.client.configuration.RestClientConfiguration;
 import fr.gouv.vitamui.security.openapiclient.invoker.ApiClient;
 import org.springframework.web.client.RestClient;
 
-public class SecurityApiClientsFactoryVitamui extends BaseVitamuiRestClientFactory {
+public class SecurityApiClientsFactory extends BaseRestClientFactory {
 
-    public SecurityApiClientsFactoryVitamui(
+    public SecurityApiClientsFactory(
         final RestClientConfiguration restClientConfiguration,
         final RestClient.Builder restClientBuilder
     ) {

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/AppConfig.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/AppConfig.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.cas.config;
 
 import fr.gouv.vitamui.cas.authentication.LoginPwdAuthenticationHandler;
@@ -53,7 +54,7 @@ import fr.gouv.vitamui.iam.common.utils.IdentityProviderHelper;
 import fr.gouv.vitamui.iam.common.utils.Pac4jClientBuilder;
 import fr.gouv.vitamui.iam.openapiclient.CasApi;
 import fr.gouv.vitamui.iam.openapiclient.CustomersApi;
-import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactoryVitamui;
+import fr.gouv.vitamui.iam.openapiclient.IamApiClientsFactory;
 import fr.gouv.vitamui.iam.openapiclient.IdentityProvidersApi;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.validation.constraints.NotNull;
@@ -259,14 +260,14 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
     }
 
     @Bean
-    public IamApiClientsFactoryVitamui iamApiClientsFactory(
+    public IamApiClientsFactory iamApiClientsFactory(
         final IamClientConfigurationProperties iamClientProperties,
         final RestClient.Builder restClientBuilder,
         @Qualifier(CasBeans.REST_CLIENT_CUSTOMIZER) final RestClientCustomizer restClientCustomizer
     ) {
         restClientCustomizer.customize(restClientBuilder);
 
-        return new IamApiClientsFactoryVitamui(iamClientProperties, restClientBuilder);
+        return new IamApiClientsFactory(iamClientProperties, restClientBuilder);
     }
 
     @Bean
@@ -275,16 +276,13 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
     }
 
     @Bean
-    public CasApi casApi(
-        final IamApiClientsFactoryVitamui iamApiClientsFactory,
-        final IamApiDecorator iamApiDecorator
-    ) {
+    public CasApi casApi(final IamApiClientsFactory iamApiClientsFactory, final IamApiDecorator iamApiDecorator) {
         return iamApiDecorator.decorate(iamApiClientsFactory.getCasApi());
     }
 
     @Bean
     public CustomersApi customersApi(
-        final IamApiClientsFactoryVitamui iamApiClientsFactory,
+        final IamApiClientsFactory iamApiClientsFactory,
         final IamApiDecorator iamApiDecorator
     ) {
         return iamApiDecorator.decorate(iamApiClientsFactory.getCustomersApi());
@@ -292,7 +290,7 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
 
     @Bean
     public IdentityProvidersApi identityProvidersApi(
-        final IamApiClientsFactoryVitamui iamApiClientsFactory,
+        final IamApiClientsFactory iamApiClientsFactory,
         final IamApiDecorator iamApiDecorator
     ) {
         return iamApiDecorator.decorate(iamApiClientsFactory.getIdentityProvidersApi());

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseClient.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseClient.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client;
 
 import fr.gouv.vitamui.commons.api.CommonConstants;
@@ -60,13 +61,13 @@ import java.util.List;
  */
 @EqualsAndHashCode
 @ToString
-public abstract class BaseClientVitamui<C extends HttpContext> implements VitamuiRestClient {
+public abstract class BaseClient<C extends HttpContext> implements RestClient {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseClientVitamui.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
 
     protected String baseUrl;
 
-    public BaseClientVitamui(final String baseUrl) {
+    public BaseClient(final String baseUrl) {
         this.baseUrl = baseUrl;
     }
 

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseCrudWebClient.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseCrudWebClient.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client;
 
 import fr.gouv.vitamui.commons.api.CommonConstants;
@@ -56,13 +57,13 @@ import java.util.Optional;
  * @param <C>
  * @param <D>
  */
-public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends IdDto> extends BaseWebClientVitamui<C> {
+public abstract class BaseCrudWebClient<C extends HttpContext, D extends IdDto> extends BaseWebClient<C> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseCrudWebClientVitamui.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseCrudWebClient.class);
 
     private static final String CRITERIA_QUERY_PARAM = "criteria";
 
-    public BaseCrudWebClientVitamui(final WebClient webClient, final String baseUrl) {
+    public BaseCrudWebClient(final WebClient webClient, final String baseUrl) {
         super(webClient, baseUrl);
     }
 
@@ -80,7 +81,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .bodyValue(dto)
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(getDtoClass())
             .block();
     }
@@ -98,7 +99,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .uri(getPathUrl() + "/" + id)
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(getDtoClass())
             .block();
     }
@@ -120,7 +121,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .uri(buildUriBuilder(builder))
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(getDtoClass())
             .block();
     }
@@ -137,7 +138,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .uri(getPathUrl())
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(getDtoListClass())
             .block();
     }
@@ -158,7 +159,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .uri(buildUriBuilder(builder))
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(getDtoListClass())
             .block();
     }
@@ -176,7 +177,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .bodyValue(partialDto)
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(getDtoClass())
             .block();
     }
@@ -194,7 +195,7 @@ public abstract class BaseCrudWebClientVitamui<C extends HttpContext, D extends 
             .uri(getPathUrl() + "/" + id)
             .headers(headersConsumer -> headersConsumer.addAll(buildHeaders(context)))
             .retrieve()
-            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClientVitamui::createResponseException)
+            .onStatus(status -> !status.is2xxSuccessful(), BaseCrudWebClient::createResponseException)
             .bodyToMono(Void.class)
             .block();
     }

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseRestClientFactory.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseRestClientFactory.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client;
 
 import fr.gouv.vitamui.commons.api.ParameterChecker;
@@ -91,9 +92,9 @@ import java.util.UUID;
  * object and handles SSL via x509 certificates.
  */
 
-public class BaseVitamuiRestClientFactory implements VitamuiRestClientFactory {
+public class BaseRestClientFactory implements RestClientFactory {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseVitamuiRestClientFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseRestClientFactory.class);
 
     private final String baseUrl;
     private final RestClient restClient;
@@ -102,14 +103,14 @@ public class BaseVitamuiRestClientFactory implements VitamuiRestClientFactory {
     protected int connectionRequestTimeout = 500000;
     protected int socketTimeout = 500000;
 
-    public BaseVitamuiRestClientFactory(
+    public BaseRestClientFactory(
         final RestClientConfiguration restClientConfiguration,
         final RestClient.Builder restClientBuilder
     ) {
         this(restClientConfiguration, null, restClientBuilder);
     }
 
-    public BaseVitamuiRestClientFactory(
+    public BaseRestClientFactory(
         final RestClientConfiguration restClientConfig,
         final HttpPoolConfiguration httpPoolConfig,
         final RestClient.Builder restClientBuilder
@@ -284,10 +285,10 @@ public class BaseVitamuiRestClientFactory implements VitamuiRestClientFactory {
     }
 
     public void setRestClientInterceptor(final List<ClientHttpRequestInterceptor> interceptors) {
-        // VitamuiRestClient is immutable — interceptors must be set at build time
-        // This method should be removed and interceptors passed via VitamuiRestClient.Builder instead
+        // RestClient is immutable — interceptors must be set at build time
+        // This method should be removed and interceptors passed via RestClient.Builder instead
         throw new UnsupportedOperationException(
-            "VitamuiRestClient is immutable. Pass interceptors via VitamuiRestClient.Builder at construction time."
+            "RestClient is immutable. Pass interceptors via RestClient.Builder at construction time."
         );
     }
 }

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseWebClient.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/BaseWebClient.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -56,13 +57,13 @@ import java.io.IOException;
  * with identifier.
  */
 @ToString
-public abstract class BaseWebClientVitamui<C extends HttpContext> extends BaseClientVitamui<C> {
+public abstract class BaseWebClient<C extends HttpContext> extends BaseClient<C> {
 
     protected WebClient webClient;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseWebClientVitamui.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseWebClient.class);
 
-    public BaseWebClientVitamui(final WebClient webClient, final String baseUrl) {
+    public BaseWebClient(final WebClient webClient, final String baseUrl) {
         super(baseUrl);
         this.webClient = webClient;
     }

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/RestClient.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/RestClient.java
@@ -34,19 +34,28 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client;
 
-import org.springframework.web.client.RestClient;
+import fr.gouv.vitamui.commons.utils.VitamUIAutoClosable;
 
 /**
- * The base interface for all Rest Client Factories
+ * The Rest client interface
  */
 
-public interface VitamuiRestClientFactory {
-    RestClient getRestClient();
-
+public interface RestClient extends VitamUIAutoClosable {
     /**
      * @return the base url (ie. http[s]://server:port)
      */
     String getBaseUrl();
+
+    /**
+     * @return the path of the url (ie. /api/v1/user/)
+     */
+    String getPathUrl();
+
+    @Override
+    default void close() {
+        // default is nothing to close
+    }
 }

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/RestClientFactory.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/RestClientFactory.java
@@ -34,27 +34,20 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client;
 
-import fr.gouv.vitamui.commons.utils.VitamUIAutoClosable;
+import org.springframework.web.client.RestClient;
 
 /**
- * The Rest client interface
+ * The base interface for all Rest Client Factories
  */
 
-public interface VitamuiRestClient extends VitamUIAutoClosable {
+public interface RestClientFactory {
+    RestClient getRestClient();
+
     /**
      * @return the base url (ie. http[s]://server:port)
      */
     String getBaseUrl();
-
-    /**
-     * @return the path of the url (ie. /api/v1/user/)
-     */
-    String getPathUrl();
-
-    @Override
-    default void close() {
-        // default is nothing to close
-    }
 }

--- a/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/configuration/RestClientConfiguration.java
+++ b/commons/commons-rest/src/main/java/fr/gouv/vitamui/commons/rest/client/configuration/RestClientConfiguration.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.rest.client.configuration;
 
 import jakarta.validation.Valid;
@@ -46,7 +47,7 @@ import lombok.experimental.Accessors;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * The RestClientConfiguration stores properties used in the VitamuiRestClient
+ * The RestClientConfiguration stores properties used in the RestClient
  */
 
 @Getter

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/util/VitamRestUtils.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/util/VitamRestUtils.java
@@ -34,6 +34,7 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
+
 package fr.gouv.vitamui.commons.vitam.api.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -223,7 +224,7 @@ public class VitamRestUtils {
      *
      * @param response Response of which the status is checked
      * @param acceptedStatus Statuses accepted
-     * TODO(refacto): commonize with BaseClientVitamui.checkResponse
+     * TODO(refacto): commonize with BaseClient.checkResponse
      */
     public static void checkResponse(final RequestResponse<?> response, final Integer... acceptedStatus) {
         Assert.notNull(response, "The server response cannot be null");


### PR DESCRIPTION
## Description

Rename classes by removing vitamui Suffix

 
## Contributeur

* VAS (Vitam Accessible en Service)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized REST client and API factory naming across archive, collect, IAM, ingest, Pastis, referential, security, and authentication services.
  - Simplified public client interfaces and supporting components by removing legacy product-specific naming.
  - Updated service configuration and integrations to use the standardized client types without changing functionality.

- **Tests**
  - Updated automated tests to reflect the standardized REST client names and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->