### PR TITLE
Story #16347: upgrade to CAS 7.3.8

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,7 +17,7 @@
         <apache.commons.codec.version>1.22.0</apache.commons.codec.version>
         <apache.pdfbox.version>2.0.31</apache.pdfbox.version>
         <bouncycastle.version>1.85.2</bouncycastle.version>
-        <cas.version>7.0.10.1</cas.version>
+        <cas.version>7.3.8</cas.version>
         <commons.beanutils.version>1.11.0</commons.beanutils.version>
         <commons.collections4.version>4.5.0</commons.collections4.version>
         <commons.compress.version>1.26.1</commons.compress.version>

--- a/cas/cas-server/pom.xml
+++ b/cas/cas-server/pom.xml
@@ -19,12 +19,11 @@
         <maven.compiler.release>21</maven.compiler.release>
 
         <!-- Spring & Spring Cloud Versions -->
-        <spring.boot.version>3.2.1</spring.boot.version>
+        <spring.boot.version>3.5.6</spring.boot.version>
 
         <!-- CAS & Security Versions -->
-        <cas.version>7.0.10.1</cas.version>
+        <cas.version>7.3.8</cas.version>
         <pac4j.version>6.3.3</pac4j.version>
-        <spring-webmvc-pac4j.version>6.0.3</spring-webmvc-pac4j.version>
 
         <!-- Logger & Utils Versions -->
         <slf4j.version>2.0.9</slf4j.version>
@@ -37,14 +36,12 @@
         <reactor.version>3.6.2</reactor.version>
         <micrometer.version>1.12.1</micrometer.version>
         <swagger.version>2.2.2</swagger.version>
-        <font-awesome.version>6.5.1</font-awesome.version>
         <jquery-ui.version>1.14.2</jquery-ui.version>
-        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <commons-io.version>2.15.1</commons-io.version>
         <inspektr.version>1.8.20.GA</inspektr.version>
 
         <!-- Test Versions -->
-        <junit-vintage-engine.version>5.7.2</junit-vintage-engine.version>
+        <junit.version>5.12.2</junit.version>
         <mockito.version>5.2.0</mockito.version>
         <assertj-core.version>3.11.1</assertj-core.version>
 
@@ -65,6 +62,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+                Declared first so it wins: the root parent (Spring Boot 4) manages junit-platform at 6.x while this
+                module pins Spring Boot 3.5, which manages junit at 5.12. Mixing the two breaks test discovery.
+            -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- CAS BOM -->
             <dependency>
                 <groupId>org.apereo.cas</groupId>
@@ -97,22 +106,12 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- HTTP Client 5 (External) -->
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>5.2.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.core5</groupId>
-                <artifactId>httpcore5</artifactId>
-                <version>5.2.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.core5</groupId>
-                <artifactId>httpcore5-h2</artifactId>
-                <version>5.2.4</version>
-            </dependency>
+            <!--
+                HTTP Client 5, hibernate-validator and font-awesome used to be pinned here. The CAS overlay WAR
+                ships its own, newer copies, and the war plugin keeps both files: two versions of the same library
+                then sit on the runtime classpath. Let the CAS BOM decide so the names collide and only one jar
+                survives.
+            -->
         </dependencies>
     </dependencyManagement>
 
@@ -144,6 +143,15 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <!--
+                    OpenSAML 5.2 (CAS 7.3) configures its parser pool with jdk.xml.maxElementDepth, which the
+                    Xerces implementation pulled in transitively does not recognise, and SAML2Client then fails
+                    to initialise. The JDK parser supports it, so keep Xerces off this classpath.
+                -->
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
@@ -349,10 +357,11 @@
             <groupId>org.apereo.cas</groupId>
             <artifactId>cas-server-support-oauth-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apereo.cas</groupId>
-            <artifactId>cas-server-support-oauth-core</artifactId>
-        </dependency>
+        <!--
+            cas-server-support-oauth-core was removed in CAS 7.3: its only class,
+            CasOAuth20ProtocolTicketCatalogConfiguration, was folded into CasOAuth20Configuration,
+            which cas-server-support-oauth already brings in.
+        -->
         <dependency>
             <groupId>org.apereo.cas</groupId>
             <artifactId>cas-server-support-oauth-core-api</artifactId>
@@ -503,11 +512,16 @@
         <!-- ========================================================== -->
         <!-- Security Libraries (pac4j, etc.)                           -->
         <!-- ========================================================== -->
-        <dependency>
-            <groupId>org.pac4j</groupId>
-            <artifactId>pac4j-javaee</artifactId>
-            <version>${pac4j.version}</version>
-        </dependency>
+        <!--
+            pac4j-javaee is deliberately absent. It carries the same class as pac4j-jakartaee,
+            org.pac4j.jee.context.JEEContext, built against javax.servlet instead of jakarta.servlet. Both jars
+            ended up in the WAR, the javax one won at class loading, and any request reaching the OIDC throttling
+            filter died on:
+                NoSuchMethodError: org.pac4j.jee.context.JEEContext.<init>(
+                    jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse)
+            The code here builds a JEEContext from CAS's jakarta request and response, so it compiles against
+            pac4j-jakartaee, which CAS brings in — the two copies simply disagreed at runtime.
+        -->
         <dependency>
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-http</artifactId>
@@ -543,11 +557,11 @@
             <artifactId>pac4j-oidc</artifactId>
             <version>${pac4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.pac4j</groupId>
-            <artifactId>spring-webmvc-pac4j</artifactId>
-            <version>${spring-webmvc-pac4j.version}</version>
-        </dependency>
+        <!--
+            spring-webmvc-pac4j is deliberately absent too. Nothing here imports org.pac4j.springframework, CAS 7.3
+            does not ship it in its overlay, and it is a javax-era artifact whose only effect was to drag
+            pac4j-javaee 5.4.3 onto a Jakarta classpath.
+        -->
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
@@ -655,7 +669,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate-validator.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -678,7 +691,6 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>font-awesome</artifactId>
-            <version>${font-awesome.version}</version>
         </dependency>
 
         <!-- ========================================================== -->
@@ -821,26 +833,19 @@
                                 <exclude>WEB-INF/lib/cas-server-core-logging-api-*.jar</exclude>
                                 <exclude>WEB-INF/lib/commons-io-*.jar</exclude>
                                 <exclude>WEB-INF/lib/jackson-*.jar</exclude>
-                                <exclude>WEB-INF/lib/jcl-over-slf4j-*.jar</exclude>
-                                <exclude>WEB-INF/lib/json-20160810.jar</exclude>
                                 <exclude>WEB-INF/lib/jul-to-slf4j-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-api-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-core-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-jcl-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-jul-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-layout-template-json-*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-slf4j-impl-*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-slf4j18-impl-*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-web-*.jar</exclude>
                                 <exclude>WEB-INF/lib/oauth2-oidc-sdk-*.jar</exclude>
                                 <exclude>WEB-INF/lib/pac4j-*.jar</exclude>
                                 <exclude>WEB-INF/lib/slf4j-api-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-boot-starter-log4j2-*.jar</exclude>
                                 <exclude>WEB-INF/lib/spring-expression-*.jar</exclude>
-                                <exclude>WEB-INF/lib/spring-webmvc-pac4j-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-slf4j2-impl-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-jakarta-web-*.jar</exclude>
-                                <exclude>WEB-INF/lib/log4j-spring-boot-*.jar</exclude>
                                 <exclude>WEB-INF/lib/log4j-spring-cloud-config-client-*.jar</exclude>
                                 <exclude>WEB-INF/lib/httpclient5-*.jar</exclude>
                                 <exclude>WEB-INF/lib/httpclient-*.jar</exclude>
@@ -848,36 +853,14 @@
                             </excludes>
                         </overlay>
                     </overlays>
-                    <packagingExcludes>
-                        WEB-INF/lib/slf4j-simple-1.7.31.jar,
-                        WEB-INF/lib/log4j-api-*.jar,
-                        WEB-INF/lib/log4j-jul-*.jar,
-                        WEB-INF/lib/log4j-core-*.jar,
-                        WEB-INF/lib/log4j-jcl-*.jar,
-                        WEB-INF/lib/log4j-web-*.jar,
-                        WEB-INF/lib/log4j-slf4j-impl-*.jar,
-                        WEB-INF/lib/log4j-slf4j18-impl-*.jar,
-                        WEB-INF/lib/log4j-layout-template-json-*.jar,
-                        WEB-INF/lib/spring-boot-starter-log4j2-*.jar,
-                        WEB-INF/lib/slf4j-api-1.8.0-beta4.jar,
-                        WEB-INF/lib/jcl-over-slf4j-1.8.0-beta4.jar,
-                        WEB-INF/lib/jul-to-slf4j-1.8.0-beta4.jar,
-                        WEB-INF/lib/jackson-core-2.8.10.jar,
-                        WEB-INF/lib/jackson-databind-2.8.10.jar,
-                        WEB-INF/lib/jackson-dataformat-yaml-2.8.10.jar,
-                        WEB-INF/lib/cas-server-core-logging-api-*.jar,
-                        WEB-INF/lib/slf4j-api-*.jar,
-                        WEB-INF/lib/oauth2-oidc-sdk-*.jar,
-                        WEB-INF/lib/pac4j-*.jar,
-                        WEB-INF/lib/spring-webmvc-pac4j-*.jar,
-                        WEB-INF/lib/log4j-slf4j2-impl-*.jar,
-                        WEB-INF/lib/log4j-jakarta-web-*.jar,
-                        WEB-INF/lib/log4j-spring-boot-*.jar,
-                        WEB-INF/lib/log4j-spring-cloud-config-client-*.jar,
-                        WEB-INF/lib/httpclient5-*.jar,
-                        WEB-INF/lib/httpclient-*.jar,
-                        WEB-INF/lib/httpcore-*.jar
-                    </packagingExcludes>
+                    <!--
+                        There used to be a packagingExcludes block here, listing 28 patterns. It never applied:
+                        the entries were written one per line, and the plugin keeps the surrounding whitespace when
+                        it splits the value on commas, so none of them ever matched. pac4j and slf4j-api are proof —
+                        both are listed there and both ship in the WAR, and the application needs them. Repairing
+                        the block would strip required jars, so it is removed rather than fixed. The overlay
+                        excludes above are the ones that actually do the work.
+                    -->
                 </configuration>
             </plugin>
 
@@ -896,7 +879,7 @@
                     </excludes>
                     <arguments>
                         <argument>
-                            --spring.config.additional-location=file:${basedir}/src/main/config/cas-server-application-dev.yml
+                            --spring.config.additional-location=file:${basedir}/src/main/config/application-dev.yml
                         </argument>
                     </arguments>
                 </configuration>

--- a/cas/cas-server/src/main/config/application-dev.yml
+++ b/cas/cas-server/src/main/config/application-dev.yml
@@ -38,7 +38,8 @@ server:
 # Root: management - Spring Boot Actuator endpoints and monitoring
 management:
   endpoints:
-    enabled-by-default: true
+    access:
+      default: unrestricted
     web:
       exposure:
         include: health,metrics,prometheus,info,status,configurationMetadata
@@ -47,6 +48,12 @@ management:
     ssl:
       enabled: false
   prometheus:
+    metrics:
+      export:
+        enabled: false
+  # No OTLP collector runs in a dev setup, and the exporter otherwise retries every step and
+  # logs a full connection stack trace each time.
+  otlp:
     metrics:
       export:
         enabled: false
@@ -68,20 +75,20 @@ cas:
         - login-url: https://dev.vitamui.com/cas/login
       core.session-replication.cookie:
         crypto:
-          encryption.key: T4LxS93IaaD-F-7kz66VEc2BD3g8uGGYKPECFkV9vBU
+          encryption.key: 2eO_ft6D83MxFDEmNxCz4Hy51eIqRC9JLBGVJBeIKwnGY2HpnTrEw3o7wvvyaA34GrfXyb0EW_mGmy-iGQaUfg
           signing.key: fRYHy2_3_qApascjXEaXuTL5o52nrohztttpiGKFkWpXYUHaV85lS8Ph10OGfkpUUZlkyhhq6oPOXOlGIAQbiQ
     pm.reset.crypto:
-      encryption.key: w7ZxSCZsGix3Xl6pFg-1viJIeFIWdrwEjxUvDyyVCM8
+      encryption.key: Pn9G5O9-oXBHt0Jl1uiad0VNTVq8vagzwLori3eSHzaVyjNKDggff5mr6ns2ofo5rgYKee-K4dORTEkZ4Ho3OQ
       signing.key: TIUaCcEAjUW_HV-1hJRrcVobZ3CCEwJC8u60vPH2nspslA3TkRFjAsceEUugp9mb6rGQiFj1IY2HJuf3FmXM5w
     oauth:
       access-token.crypto:
-        encryption.key: RGAYHpTTKJ-YMbh7Yrt3Xd6VQH_myXYISwThfo-9OKI
+        encryption.key: 35p4Z2bJcae-N2Ar5Op9YGQAZi9tGK24xdmIFXTu9RbWm30oABQKEeitG_W2hIBUIg--lZOeF9l452Botoq7Tg
         signing.key: j8AZtUo6i4BI2n3bu2Elr9d3aIOL35vec0AjUBubP6rgj5arKWB9lRcWq9bjxGIwoAbFv-1MRmiScXlIIX0BGg
       crypto:
-        encryption.key: 0mfCTGphgW6sLEG2xsmnb-dzQZ-9wQfjOWDrXdUg4lg
+        encryption.key: L_nqrNYEAUMveny7NRAmSCh6fC3WcfZgXT9Kdq13Rxe7Nnko369ffJzCWKowIMmQCAM2Sf1etQsOIJ6jVqOJQA
         signing.key: kSs5OT5bTV6E9Ba0biGZ3taVlmlBFmoMyvG4JB0pSiZJml3CqyfHlexueJAv2BT4YG9gQ1IP_hvu1leejdFzng
       session-replication.cookie.crypto:
-        encryption.key: 2macKckIM22PrUn9cHkyVe1lB4jc12hXsbUa8e7Ih8Q
+        encryption.key: A9bQP1zZO9KYQcv2Yondqo2QWyvHcPaoxC9UM5VPCXFu_KY7bmfOcKM-B2S4jqzFOlre-e9J-AxAiLEfxf3FRg
         signing.key: vhnibDmTxFA0q_jO3XedyoHgKkPQPmfVeWLVj9byRfLiVFqZi38ZsEy4Qt0Vu2rZFXceBgp5nb55iWgxo2EzCQ
     oidc.jwks.file-system.jwks-file: file:./src/main/config/keystore.jwks
   monitor.endpoints.endpoint.defaults.access: PERMIT

--- a/cas/cas-server/src/main/config/application-recette.yml
+++ b/cas/cas-server/src/main/config/application-recette.yml
@@ -35,7 +35,8 @@ server:
 # Root: management - Spring Boot Actuator endpoints and monitoring
 management:
   endpoints:
-    enabled-by-default: true
+    access:
+      default: unrestricted
     web:
       exposure:
         include: health,metrics,prometheus,info,status,configurationMetadata

--- a/cas/cas-server/src/main/config/application.yml
+++ b/cas/cas-server/src/main/config/application.yml
@@ -35,6 +35,11 @@ cas:
         crypto.enabled: true
         security-questions-enabled: false
         include-server-ip-address: false
+        # CAS 7.3 implements this property, which 7.0 declared but ignored: InitPasswordResetAction now sends the
+        # user through MFA before letting them reset, picking any registered provider rather than honouring the
+        # computedOtp trigger. With the simple SMS provider registered, every reset demanded an SMS, and accounts
+        # without a mobile number — which VitamUI allows — could no longer reset at all.
+        multifactor-authentication-enabled: false
     oauth:
       access-token:
         max-time-to-live-in-seconds: 28800 # 8 hours in seconds

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/LoginPwdAuthenticationHandler.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/LoginPwdAuthenticationHandler.java
@@ -55,7 +55,6 @@ import org.apereo.cas.authentication.exceptions.AccountPasswordMustChangeExcepti
 import org.apereo.cas.authentication.handler.support.AbstractUsernamePasswordAuthenticationHandler;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
-import org.apereo.cas.services.ServicesManager;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.RequestContextHolder;
 
@@ -86,12 +85,12 @@ public class LoginPwdAuthenticationHandler extends AbstractUsernamePasswordAuthe
     private final String ipHeaderName;
 
     public LoginPwdAuthenticationHandler(
-        final ServicesManager servicesManager,
         final PrincipalFactory principalFactory,
         final CasApi casApi,
         final String ipHeaderName
     ) {
-        super(LoginPwdAuthenticationHandler.class.getSimpleName(), servicesManager, principalFactory, 1);
+        // CAS 7.3 dropped the ServicesManager argument from AbstractAuthenticationHandler.
+        super(LoginPwdAuthenticationHandler.class.getSimpleName(), principalFactory, 1);
         this.casApi = casApi;
         this.ipHeaderName = ipHeaderName;
     }

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolver.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/authentication/UserPrincipalResolver.java
@@ -62,7 +62,6 @@ import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.web.support.WebUtils;
-import org.apereo.services.persondir.IPersonAttributeDao;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.jee.context.JEEContext;
@@ -474,11 +473,6 @@ public class UserPrincipalResolver implements PrincipalResolver {
             credential instanceof ClientCredential ||
             credential instanceof X509CertificateCredential
         );
-    }
-
-    @Override
-    public IPersonAttributeDao getAttributeRepository() {
-        return null;
     }
 
     private boolean isTrueAuthUserDtoInstance(AuthUserDto authUser) {

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/AppConfig.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/AppConfig.java
@@ -63,6 +63,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
+import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
@@ -84,6 +85,7 @@ import org.apereo.cas.pac4j.client.DelegatedClientNameExtractor;
 import org.apereo.cas.pac4j.client.DelegatedIdentityProviders;
 import org.apereo.cas.pm.PasswordHistoryService;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.services.RegisteredServicePrincipalAccessStrategyEnforcer;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.BaseTicketCatalogConfigurer;
 import org.apereo.cas.ticket.ExpirationPolicyBuilder;
@@ -114,6 +116,8 @@ import org.pac4j.core.context.session.SessionStore;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestClientCustomizer;
@@ -122,22 +126,31 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.core.Ordered;
 import org.springframework.data.mongodb.observability.ContextProviderFactory;
 import org.springframework.data.mongodb.observability.MongoObservationCommandListener;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.web.client.RestClient;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static fr.gouv.vitamui.commons.api.CommonConstants.X_ORIGIN_HEADER_EXTERNAL;
 import static fr.gouv.vitamui.commons.api.CommonConstants.X_ORIGIN_HEADER_NAME;
+import static fr.gouv.vitamui.commons.api.CommonConstants.X_USER_TOKEN_HEADER;
+import static fr.gouv.vitamui.commons.api.CommonConstants.X_XSRF_TOKEN_HEADER;
 
 /**
  * Configure all beans to customize the CAS server.
@@ -145,7 +158,13 @@ import static fr.gouv.vitamui.commons.api.CommonConstants.X_ORIGIN_HEADER_NAME;
 @Slf4j
 @Configuration
 @EnableConfigurationProperties(
-    { CasConfigurationProperties.class, IamClientConfigurationProperties.class, PasswordConfiguration.class }
+    {
+        CasConfigurationProperties.class,
+        IamClientConfigurationProperties.class,
+        PasswordConfiguration.class,
+        // MailSenderAutoConfiguration normally registers these; CAS 7.3 excludes it, see javaMailSender below.
+        MailProperties.class,
+    }
 )
 public class AppConfig extends BaseTicketCatalogConfigurer {
 
@@ -158,6 +177,36 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
         return null;
     }
 
+    /**
+     * CAS 7.3 added MailSenderAutoConfiguration to the list its CasWebApplication excludes, so Spring Boot no
+     * longer builds a JavaMailSender from spring.mail.* and the context fails on Utils, which needs one. This
+     * rebuilds it the way MailSenderPropertiesConfiguration used to.
+     *
+     * <p>Utils tolerates a null sender and simply logs, so leaving the dependency optional would have turned every
+     * password reset and MFA message into a silent no-op instead of a startup failure.
+     */
+    @Bean
+    @ConditionalOnMissingBean(JavaMailSender.class)
+    public JavaMailSender javaMailSender(final MailProperties mailProperties) {
+        final var sender = new JavaMailSenderImpl();
+        sender.setHost(mailProperties.getHost());
+        if (mailProperties.getPort() != null) {
+            sender.setPort(mailProperties.getPort());
+        }
+        sender.setUsername(mailProperties.getUsername());
+        sender.setPassword(mailProperties.getPassword());
+        sender.setProtocol(mailProperties.getProtocol());
+        if (mailProperties.getDefaultEncoding() != null) {
+            sender.setDefaultEncoding(mailProperties.getDefaultEncoding().name());
+        }
+        if (!mailProperties.getProperties().isEmpty()) {
+            final var javaMailProperties = new Properties();
+            javaMailProperties.putAll(mailProperties.getProperties());
+            sender.setJavaMailProperties(javaMailProperties);
+        }
+        return sender;
+    }
+
     @Bean
     public PasswordValidator passwordValidator() {
         return new PasswordValidator();
@@ -167,10 +216,9 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
     public LoginPwdAuthenticationHandler loginPwdAuthenticationHandler(
         final CasApi casApi,
         @Value("${ip.header}") final String ipHeaderName,
-        @Qualifier(CasBeans.PRINCIPAL_FACTORY) final PrincipalFactory principalFactory,
-        @Qualifier(CasBeans.SERVICES_MANAGER) final ServicesManager servicesManager
+        @Qualifier(CasBeans.PRINCIPAL_FACTORY) final PrincipalFactory principalFactory
     ) {
-        return new LoginPwdAuthenticationHandler(servicesManager, principalFactory, casApi, ipHeaderName);
+        return new LoginPwdAuthenticationHandler(principalFactory, casApi, ipHeaderName);
     }
 
     @Bean
@@ -183,7 +231,13 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
         @Value("${vitamui.authn.x509.identifierAttributeParsing:}") final String x509IdentifierAttributeParsing,
         @Value("${vitamui.authn.x509.identifierAttributeExpansion:}") final String x509IdentifierAttributeExpansion,
         @Value("${vitamui.authn.x509.defaultDomain:}") final String x509DefaultDomain,
-        @Qualifier(
+        // In CAS 7.3 accessTokenJwtBuilder depends on the principal resolver, which closes a cycle:
+        //   accessTokenJwtBuilder -> defaultPrincipalResolver -> delegatedClientDistributedSessionStore
+        //     -> defaultTicketFactory -> defaultAccessTokenFactoryConfigurer -> defaultAccessTokenFactory
+        //       -> accessTokenJwtBuilder
+        // The session store is only read while resolving a principal, never during construction, so injecting it
+        // lazily breaks the cycle where it costs nothing.
+        @Lazy @Qualifier(
             CasBeans.DELEGATED_CLIENT_DISTRIBUTED_SESSION_STORE
         ) final SessionStore delegatedClientDistributedSessionStore,
         @Qualifier(CasBeans.PRINCIPAL_FACTORY) PrincipalFactory principalFactory,
@@ -214,7 +268,9 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
 
     @Bean
     public AuthenticationEventExecutionPlanConfigurer registerInternalHandler(
-        final LoginPwdAuthenticationHandler loginPwdAuthenticationHandler,
+        // Injected as the interface: CAS 7.3 advises authentication handlers, so this arrives as a JDK dynamic
+        // proxy that cannot be cast back to the implementation class.
+        @Qualifier("loginPwdAuthenticationHandler") final AuthenticationHandler loginPwdAuthenticationHandler,
         @Qualifier(PrincipalResolver.BEAN_NAME_PRINCIPAL_RESOLVER) final PrincipalResolver defaultPrincipalResolver
     ) {
         return plan ->
@@ -240,20 +296,57 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
         return defaultPrincipalResolver;
     }
 
+    private static final String MASKED_HEADER_VALUE = "***";
+
+    /**
+     * Headers whose value is a credential and must never reach the logs. The IAM service account token is
+     * long-lived, so a single DEBUG line is enough to leak a credential that stays replayable.
+     */
+    private static final Set<String> SENSITIVE_HEADERS = sensitiveHeaders();
+
+    private static Set<String> sensitiveHeaders() {
+        // HTTP header names are case-insensitive, so the lookup must be too.
+        final Set<String> names = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        names.addAll(List.of(X_USER_TOKEN_HEADER, X_XSRF_TOKEN_HEADER, HttpHeaders.AUTHORIZATION, HttpHeaders.COOKIE));
+        return Collections.unmodifiableSet(names);
+    }
+
+    /**
+     * Copies the headers, replacing the value of every credential-bearing one. The remaining headers
+     * (tenant, application, identity, trace) are what makes the log line useful, so they are kept as is.
+     *
+     * @param headers the outgoing request headers.
+     * @return a copy safe to log.
+     */
+    private static HttpHeaders maskSensitiveHeaders(final HttpHeaders headers) {
+        final HttpHeaders masked = new HttpHeaders();
+        headers.forEach(
+            (name, values) ->
+                masked.addAll(name, SENSITIVE_HEADERS.contains(name) ? List.of(MASKED_HEADER_VALUE) : values)
+        );
+        return masked;
+    }
+
     /**
      * We must define our customizer to replace X_ORIGIN header from
      * IamApiClient.java for CAS usage.
      *
-     * @return a rest client customizer.
+     * <p>Deliberately not a bean: Spring Boot applies every RestClientCustomizer bean to the auto-configured
+     * RestClient.Builder, so exposing it made the interceptor run twice on each IAM call and forced the
+     * EXTERNAL origin on every other rest client built from that builder.
+     *
+     * @return a rest client customizer for the IAM clients.
      */
-    @Bean
-    @Qualifier(CasBeans.REST_CLIENT_CUSTOMIZER)
-    public RestClientCustomizer restClientCustomizer() {
+    private RestClientCustomizer iamRestClientCustomizer() {
         return builder ->
             builder.requestInterceptor((request, body, execution) -> {
                 request.getHeaders().set(X_ORIGIN_HEADER_NAME, X_ORIGIN_HEADER_EXTERNAL);
 
-                LOGGER.debug("Final request URI: {}, headers: {}", request.getURI(), request.getHeaders());
+                LOGGER.debug(
+                    "Final request URI: {}, headers: {}",
+                    request.getURI(),
+                    maskSensitiveHeaders(request.getHeaders())
+                );
 
                 return execution.execute(request, body);
             });
@@ -262,10 +355,9 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
     @Bean
     public IamApiClientsFactory iamApiClientsFactory(
         final IamClientConfigurationProperties iamClientProperties,
-        final RestClient.Builder restClientBuilder,
-        @Qualifier(CasBeans.REST_CLIENT_CUSTOMIZER) final RestClientCustomizer restClientCustomizer
+        final RestClient.Builder restClientBuilder
     ) {
-        restClientCustomizer.customize(restClientBuilder);
+        iamRestClientCustomizer().customize(restClientBuilder);
 
         return new IamApiClientsFactory(iamClientProperties, restClientBuilder);
     }
@@ -360,7 +452,7 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     public OAuth20AccessTokenFactory defaultAccessTokenFactory(
-        @Qualifier(CasBeans.ACCESS_TOKEN_ID_GENERATOR) final UniqueTicketIdGenerator accessTokenIdGenerator,
+        @Qualifier(CasBeans.TICKET_REGISTRY) final TicketRegistry ticketRegistry,
         @Qualifier(CasBeans.ACCESS_TOKEN_EXPIRATION_POLICY) final ExpirationPolicyBuilder accessTokenExpirationPolicy,
         @Qualifier(CasBeans.SERVICES_MANAGER) final ServicesManager servicesManager,
         @Qualifier(CasBeans.ACCESS_TOKEN_JWT_BUILDER) final JwtBuilder accessTokenJwtBuilder,
@@ -369,7 +461,7 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
         ) final TicketTrackingPolicy descendantTicketsTrackingPolicy
     ) {
         return new CustomOAuth20DefaultAccessTokenFactory(
-            accessTokenIdGenerator,
+            ticketRegistry,
             accessTokenExpirationPolicy,
             accessTokenJwtBuilder,
             servicesManager,
@@ -400,9 +492,20 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
     @SneakyThrows
     public SurrogateAuthenticationService surrogateAuthenticationService(
         final CasApi casApi,
-        @Qualifier(CasBeans.SERVICES_MANAGER) final ServicesManager servicesManager
+        @Qualifier(CasBeans.SERVICES_MANAGER) final ServicesManager servicesManager,
+        final CasConfigurationProperties casProperties,
+        @Qualifier(
+            RegisteredServicePrincipalAccessStrategyEnforcer.BEAN_NAME
+        ) final RegisteredServicePrincipalAccessStrategyEnforcer principalAccessStrategyEnforcer,
+        final ConfigurableApplicationContext applicationContext
     ) {
-        return new IamSurrogateAuthenticationService(casApi, servicesManager);
+        return new IamSurrogateAuthenticationService(
+            casApi,
+            servicesManager,
+            casProperties,
+            principalAccessStrategyEnforcer,
+            applicationContext
+        );
     }
 
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -423,9 +526,8 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
         final PasswordConfiguration passwordConfiguration
     ) {
         return new IamPasswordManagementService(
-            casProperties.getAuthn().getPm(),
+            casProperties,
             passwordManagementCipherExecutor,
-            casProperties.getServer().getPrefix(),
             passwordHistoryService,
             casApi,
             providersService,
@@ -551,7 +653,8 @@ public class AppConfig extends BaseTicketCatalogConfigurer {
         final var authorizers = delegatedClientIdentityProviderAuthorizers;
 
         return DelegatedClientAuthenticationConfigurationContext.builder()
-            .credentialExtractor(delegatedAuthenticationCredentialExtractor)
+            // CAS 7.3 accepts a list of credential extractors instead of a single one.
+            .credentialExtractors(List.of(delegatedAuthenticationCredentialExtractor))
             .initialAuthenticationAttemptWebflowEventResolver(initialAuthenticationAttemptWebflowEventResolver)
             .serviceTicketRequestWebflowEventResolver(serviceTicketRequestWebflowEventResolver)
             .adaptiveAuthenticationPolicy(adaptiveAuthenticationPolicy)

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/CasBeans.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/CasBeans.java
@@ -67,9 +67,6 @@ public final class CasBeans {
     public static final String PROTOCOL_TICKET_CIPHER_EXECUTOR = "protocolTicketCipherExecutor";
     public static final String PASSWORD_MANAGEMENT_CIPHER_EXECUTOR = "passwordManagementCipherExecutor";
 
-    // === Spring / REST ===
-    public static final String REST_CLIENT_CUSTOMIZER = "restClientCustomizer";
-
     // === Spring / Web ===
     public static final String MESSAGE_SOURCE = "messageSource";
     public static final String CORS_HTTP_WEB_REQUEST_CONFIGURATION_SOURCE = "corsHttpWebRequestConfigurationSource";
@@ -113,10 +110,12 @@ public final class CasBeans {
         "registeredServiceAuthenticationPolicyWebflowEventResolver";
 
     // === Webflow / Definitions ===
-    public static final String LOGIN_FLOW_DEFINITION_REGISTRY =
-        CasWebflowConstants.BEAN_NAME_LOGIN_FLOW_DEFINITION_REGISTRY;
-    public static final String LOGOUT_FLOW_DEFINITION_REGISTRY =
-        CasWebflowConstants.BEAN_NAME_LOGOUT_FLOW_DEFINITION_REGISTRY;
+    /**
+     * CAS 7.3 merged the separate login and logout flow definition registries into a single registry, so the
+     * former BEAN_NAME_LOGIN_FLOW_DEFINITION_REGISTRY and BEAN_NAME_LOGOUT_FLOW_DEFINITION_REGISTRY are gone.
+     */
+    public static final String FLOW_DEFINITION_REGISTRY = CasWebflowConstants.BEAN_NAME_FLOW_DEFINITION_REGISTRY;
+
     public static final String FLOW_BUILDER_SERVICES = CasWebflowConstants.BEAN_NAME_FLOW_BUILDER_SERVICES;
     public static final String MFA_SIMPLE_AUTHENTICATOR_FLOW_REGISTRY = "mfaSimpleAuthenticatorFlowRegistry";
 

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/WebConfig.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/WebConfig.java
@@ -64,8 +64,11 @@ import org.pac4j.core.client.Client;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
+import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.HierarchicalMessageSource;
 import org.springframework.context.annotation.Bean;
@@ -170,14 +173,18 @@ public class WebConfig {
         final ObjectProvider<PathMappedEndpoints> pathMappedEndpoints,
         final List<CasWebSecurityConfigurer> configurersList,
         final WebEndpointProperties webEndpointProperties,
+        final ManagementServerProperties managementServerProperties,
+        final WebProperties webProperties,
         final CasConfigurationProperties casProperties
     ) {
         val adapter = new CustomCasWebSecurityConfigurerAdapter(
             casProperties,
             webEndpointProperties,
+            managementServerProperties,
             pathMappedEndpoints,
             configurersList,
-            securityContextRepository
+            securityContextRepository,
+            webProperties
         );
         return adapter::configureWebSecurity;
     }
@@ -189,15 +196,21 @@ public class WebConfig {
         final ObjectProvider<PathMappedEndpoints> pathMappedEndpoints,
         final List<CasWebSecurityConfigurer> configurersList,
         final WebEndpointProperties webEndpointProperties,
-        final CasConfigurationProperties casProperties
+        final ManagementServerProperties managementServerProperties,
+        final WebProperties webProperties,
+        final CasConfigurationProperties casProperties,
+        final ApplicationContext applicationContext
     ) throws Exception {
         val adapter = new CustomCasWebSecurityConfigurerAdapter(
             casProperties,
             webEndpointProperties,
+            managementServerProperties,
             pathMappedEndpoints,
             configurersList,
-            securityContextRepository
+            securityContextRepository,
+            webProperties
         );
-        return adapter.configureHttpSecurity(http).build();
+        // CAS 7.3 passes the application context to configureHttpSecurity.
+        return adapter.configureHttpSecurity(http, applicationContext).build();
     }
 }

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/WebflowConfig.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/config/WebflowConfig.java
@@ -62,12 +62,16 @@ import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.MultifactorAuthenticationProviderSelector;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
+import org.apereo.cas.authentication.principal.ServiceFactory;
+import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.bucket4j.consumer.BucketConsumer;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.logout.LogoutConfirmationResolver;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.logout.slo.SingleLogoutRequestExecutor;
 import org.apereo.cas.mfa.simple.CasSimpleMultifactorTokenCommunicationStrategy;
 import org.apereo.cas.mfa.simple.validation.CasSimpleMultifactorAuthenticationService;
+import org.apereo.cas.multitenancy.TenantExtractor;
 import org.apereo.cas.notifications.CommunicationsManager;
 import org.apereo.cas.pac4j.client.DelegatedClientAuthenticationFailureEvaluator;
 import org.apereo.cas.pac4j.client.DelegatedIdentityProviders;
@@ -181,6 +185,7 @@ public class WebflowConfig {
         @Qualifier(CasBeans.PRINCIPAL_RESOLVER) final PrincipalResolver defaultPrincipalResolver,
         @Qualifier(CasBeans.COMMUNICATIONS_MANAGER) final CommunicationsManager communicationsManager,
         @Qualifier(CasBeans.PASSWORD_RESET_URL_BUILDER) final PasswordResetUrlBuilder passwordResetUrlBuilder,
+        @Qualifier(CasBeans.SERVICES_MANAGER) final ServicesManager servicesManager,
         final ProvidersService providersService,
         final IdentityProviderHelper identityProviderHelper,
         final Utils utils,
@@ -200,7 +205,7 @@ public class WebflowConfig {
             passwordResetUrlBuilder,
             multifactorAuthenticationProviderSelector,
             authenticationSystemSupport,
-            applicationContext,
+            servicesManager,
             messageSource,
             providersService,
             identityProviderHelper,
@@ -223,17 +228,17 @@ public class WebflowConfig {
     public CasWebflowConfigurer defaultWebflowConfigurer(
         final ConfigurableApplicationContext applicationContext,
         final CasConfigurationProperties casProperties,
-        @Qualifier(CasBeans.LOGIN_FLOW_DEFINITION_REGISTRY) final FlowDefinitionRegistry loginFlowRegistry,
-        @Qualifier(CasBeans.LOGOUT_FLOW_DEFINITION_REGISTRY) final FlowDefinitionRegistry logoutFlowRegistry,
+        @Qualifier(CasBeans.FLOW_DEFINITION_REGISTRY) final FlowDefinitionRegistry flowDefinitionRegistry,
         @Qualifier(CasBeans.FLOW_BUILDER_SERVICES) final FlowBuilderServices flowBuilderServices
     ) {
+        // Since CAS 7.3 a single registry holds both the login and the logout flows, so there is no separate
+        // logout registry to hand over any more.
         final var c = new VitamLoginWebflowConfigurer(
             flowBuilderServices,
-            loginFlowRegistry,
+            flowDefinitionRegistry,
             applicationContext,
             casProperties
         );
-        c.setLogoutFlowDefinitionRegistry(logoutFlowRegistry);
         c.setOrder(Ordered.HIGHEST_PRECEDENCE);
         return c;
     }
@@ -299,7 +304,13 @@ public class WebflowConfig {
         @Qualifier(CasBeans.FRONT_CHANNEL_LOGOUT_ACTION) final Action frontChannelLogoutAction,
         @Qualifier(
             CasBeans.SINGLE_LOGOUT_REQUEST_EXECUTOR
-        ) final SingleLogoutRequestExecutor defaultSingleLogoutRequestExecutor
+        ) final SingleLogoutRequestExecutor defaultSingleLogoutRequestExecutor,
+        @Qualifier(
+            LogoutConfirmationResolver.DEFAULT_BEAN_NAME
+        ) final LogoutConfirmationResolver logoutConfirmationResolver,
+        @Qualifier("webApplicationServiceFactory") final ServiceFactory<
+            WebApplicationService
+        > webApplicationServiceFactory
     ) {
         return WebflowActionBeanSupplier.builder()
             .withApplicationContext(applicationContext)
@@ -312,14 +323,15 @@ public class WebflowConfig {
                         warnCookieGenerator,
                         casProperties.getLogout(),
                         logoutManager,
-                        applicationContext,
                         utils,
                         casApi,
                         servicesManager,
                         casProperties,
                         frontChannelLogoutAction,
                         ticketRegistry,
-                        defaultSingleLogoutRequestExecutor
+                        defaultSingleLogoutRequestExecutor,
+                        logoutConfirmationResolver,
+                        webApplicationServiceFactory
                     )
             )
             .withId(CasWebflowConstants.ACTION_ID_TERMINATE_SESSION)
@@ -346,6 +358,7 @@ public class WebflowConfig {
         @Qualifier(
             CasBeans.MFA_SIMPLE_MULTIFACTOR_BUCKET_CONSUMER
         ) final BucketConsumer mfaSimpleMultifactorBucketConsumer,
+        @Qualifier(TenantExtractor.BEAN_NAME) final TenantExtractor tenantExtractor,
         final CasConfigurationProperties casProperties,
         final Utils utils
     ) {
@@ -360,6 +373,7 @@ public class WebflowConfig {
                     simple,
                     mfaSimpleMultifactorTokenCommunicationStrategy,
                     mfaSimpleMultifactorBucketConsumer,
+                    tenantExtractor,
                     utils
                 );
             })
@@ -375,14 +389,14 @@ public class WebflowConfig {
         @Qualifier(
             CasBeans.MFA_SIMPLE_AUTHENTICATOR_FLOW_REGISTRY
         ) final FlowDefinitionRegistry mfaSimpleAuthenticatorFlowRegistry,
-        @Qualifier(CasBeans.LOGIN_FLOW_DEFINITION_REGISTRY) final FlowDefinitionRegistry loginFlowRegistry,
+        @Qualifier(CasBeans.FLOW_DEFINITION_REGISTRY) final FlowDefinitionRegistry flowDefinitionRegistry,
         @Qualifier(CasBeans.FLOW_BUILDER_SERVICES) final FlowBuilderServices flowBuilderServices,
         final CasConfigurationProperties casProperties,
         final ConfigurableApplicationContext applicationContext
     ) {
         final var cfg = new VitamMfaWebflowConfigurer(
             flowBuilderServices,
-            loginFlowRegistry,
+            flowDefinitionRegistry,
             mfaSimpleAuthenticatorFlowRegistry,
             applicationContext,
             casProperties,
@@ -406,6 +420,10 @@ public class WebflowConfig {
         @Qualifier(
             CasBeans.DELEGATED_CLIENT_DISTRIBUTED_SESSION_STORE
         ) final SessionStore delegatedClientDistributedSessionStore,
+        @Qualifier(CasBeans.TICKET_REGISTRY) final TicketRegistry ticketRegistry,
+        @Qualifier(
+            LogoutConfirmationResolver.DEFAULT_BEAN_NAME
+        ) final LogoutConfirmationResolver logoutConfirmationResolver,
         final ProvidersService providersService,
         final IdentityProviderHelper identityProviderHelper
     ) {
@@ -426,6 +444,9 @@ public class WebflowConfig {
                                 new CustomDelegatedAuthenticationClientLogoutAction(
                                     identityProviders,
                                     delegatedClientDistributedSessionStore,
+                                    ticketRegistry,
+                                    casProperties,
+                                    logoutConfirmationResolver,
                                     providersService,
                                     identityProviderHelper
                                 )

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/delegation/CustomDelegatedIdentityProviders.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/delegation/CustomDelegatedIdentityProviders.java
@@ -31,25 +31,33 @@
 package fr.gouv.vitamui.cas.delegation;
 
 import lombok.RequiredArgsConstructor;
+import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.pac4j.client.DelegatedIdentityProviders;
 import org.pac4j.core.client.Client;
+import org.pac4j.core.context.WebContext;
 
 import java.util.List;
 import java.util.Optional;
 
-/** Wrapper of the ProvidersService for the CAS DelegatedIdentityProviders */
+/**
+ * Wrapper of the ProvidersService for the CAS DelegatedIdentityProviders.
+ *
+ * <p>CAS 7.3 hands a Service and a WebContext to both lookups so that providers can be filtered per service. We
+ * keep returning every configured provider, which is what this wrapper did before, since VitamUI selects the
+ * provider from the user's organisation rather than from the requested service.
+ */
 @RequiredArgsConstructor
 public class CustomDelegatedIdentityProviders implements DelegatedIdentityProviders {
 
     private final ProvidersService providerService;
 
     @Override
-    public List<Client> findAllClients() {
+    public List<? extends Client> findAllClients(final Service service, final WebContext webContext) {
         return providerService.getClients().findAllClients();
     }
 
     @Override
-    public Optional<Client> findClient(final String name) {
+    public Optional<? extends Client> findClient(final String name, final WebContext webContext) {
         return providerService.getClients().findClient(name);
     }
 }

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/logout/CustomDelegatedAuthenticationClientLogoutAction.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/logout/CustomDelegatedAuthenticationClientLogoutAction.java
@@ -31,9 +31,13 @@ import fr.gouv.vitamui.cas.delegation.ProvidersService;
 import fr.gouv.vitamui.iam.common.utils.IdentityProviderHelper;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.logout.LogoutConfirmationResolver;
 import org.apereo.cas.pac4j.client.DelegatedIdentityProviders;
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.actions.logout.DelegatedAuthenticationClientLogoutAction;
 import org.pac4j.core.client.Client;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.profile.UserProfile;
 
@@ -49,22 +53,30 @@ public class CustomDelegatedAuthenticationClientLogoutAction extends DelegatedAu
 
     private final IdentityProviderHelper identityProviderHelper;
 
+    // CAS 7.3 added the ticket registry, the CAS properties and the logout confirmation resolver to the parent
+    // constructor, and hands a WebContext to findCurrentClient so providers can be resolved per request.
     public CustomDelegatedAuthenticationClientLogoutAction(
         final DelegatedIdentityProviders identityProviders,
         final SessionStore sessionStore,
+        final TicketRegistry ticketRegistry,
+        final CasConfigurationProperties casProperties,
+        final LogoutConfirmationResolver logoutConfirmationResolver,
         final ProvidersService providersService,
         final IdentityProviderHelper identityProviderHelper
     ) {
-        super(identityProviders, sessionStore);
+        super(identityProviders, sessionStore, ticketRegistry, casProperties, logoutConfirmationResolver);
         this.providersService = providersService;
         this.identityProviderHelper = identityProviderHelper;
     }
 
     @Override
-    protected Optional<Client> findCurrentClient(final UserProfile currentProfile) {
+    protected Optional<? extends Client> findCurrentClient(
+        final UserProfile currentProfile,
+        final WebContext webContext
+    ) {
         val optClient = currentProfile == null
             ? Optional.<Client>empty()
-            : identityProviders.findClient(currentProfile.getClientName());
+            : identityProviders.findClient(currentProfile.getClientName(), webContext);
 
         LOGGER.debug("optClient: {}", optClient);
         if (optClient.isEmpty()) {

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/logout/TerminateApiSessionAction.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/logout/TerminateApiSessionAction.java
@@ -42,10 +42,11 @@ import org.apereo.cas.authentication.DefaultAuthenticationBuilder;
 import org.apereo.cas.authentication.DefaultAuthenticationResultBuilder;
 import org.apereo.cas.authentication.principal.DefaultPrincipalElectionStrategy;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
-import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.logout.LogoutProperties;
+import org.apereo.cas.logout.LogoutConfirmationResolver;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.logout.slo.SingleLogoutExecutionRequest;
 import org.apereo.cas.logout.slo.SingleLogoutRequestContext;
@@ -59,7 +60,6 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
 import org.apereo.cas.web.flow.logout.TerminateSessionAction;
 import org.apereo.cas.web.support.WebUtils;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.webflow.execution.Action;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
@@ -84,30 +84,36 @@ public class TerminateApiSessionAction extends TerminateSessionAction {
     private final Action frontChannelLogoutAction;
     private final TicketRegistry ticketRegistry;
 
+    private final ServiceFactory<WebApplicationService> webApplicationServiceFactory;
+
     public TerminateApiSessionAction(
         final CentralAuthenticationService centralAuthenticationService,
         final CasCookieBuilder ticketGrantingTicketCookieGenerator,
         final CasCookieBuilder warnCookieGenerator,
         final LogoutProperties logoutProperties,
         final LogoutManager logoutManager,
-        final ConfigurableApplicationContext applicationContext,
         final Utils utils,
         final CasApi casApi,
         final ServicesManager servicesManager,
         final CasConfigurationProperties casProperties,
         final Action frontChannelLogoutAction,
         final TicketRegistry ticketRegistry,
-        final SingleLogoutRequestExecutor singleLogoutRequestExecutor
+        final SingleLogoutRequestExecutor singleLogoutRequestExecutor,
+        final LogoutConfirmationResolver logoutConfirmationResolver,
+        final ServiceFactory<WebApplicationService> webApplicationServiceFactory
     ) {
+        // CAS 7.3 dropped the ApplicationContext from the parent constructor and added the logout
+        // confirmation resolver.
         super(
             centralAuthenticationService,
             ticketGrantingTicketCookieGenerator,
             warnCookieGenerator,
             logoutProperties,
             logoutManager,
-            applicationContext,
-            singleLogoutRequestExecutor
+            singleLogoutRequestExecutor,
+            logoutConfirmationResolver
         );
+        this.webApplicationServiceFactory = webApplicationServiceFactory;
         this.utils = utils;
         this.casApi = casApi;
         this.servicesManager = servicesManager;
@@ -183,18 +189,21 @@ public class TerminateApiSessionAction extends TerminateSessionAction {
                 .build();
 
             // 2️⃣ Crée un AuthenticationResult factice à partir de l'authentication
-            AuthenticationResult authenticationResult = new DefaultAuthenticationResultBuilder()
+            // CAS 7.3 : la PrincipalElectionStrategy passe au constructeur, build() prend le service.
+            AuthenticationResult authenticationResult = new DefaultAuthenticationResultBuilder(
+                new DefaultPrincipalElectionStrategy()
+            )
                 .collect(fakeAuthentication)
-                .build(new DefaultPrincipalElectionStrategy()); // PrincipalElectionStrategy trivial
+                .build(null);
 
             // 3️⃣ Crée le TGT factice via l'API CAS 7
-            TicketGrantingTicket fakeTgt = centralAuthenticationService.createTicketGrantingTicket(
-                authenticationResult
-            );
+            TicketGrantingTicket fakeTgt =
+                (TicketGrantingTicket) centralAuthenticationService.createTicketGrantingTicket(authenticationResult);
 
             Collection<RegisteredService> registeredServices = servicesManager.getAllServices();
-            // Préparer le factory de services CAS
-            WebApplicationServiceFactory serviceFactory = new WebApplicationServiceFactory();
+            // CAS 7.3 : WebApplicationServiceFactory n'a plus de constructeur sans argument, on réutilise
+            // le bean fourni par CAS.
+            ServiceFactory<WebApplicationService> serviceFactory = webApplicationServiceFactory;
 
             for (RegisteredService registeredService : registeredServices) {
                 if (!(registeredService instanceof BaseRegisteredService baseService)) continue;

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/password/CustomCasWebSecurityConfigurerAdapter.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/password/CustomCasWebSecurityConfigurerAdapter.java
@@ -36,7 +36,9 @@ import org.apereo.cas.web.CasWebSecurityConfigurer;
 import org.apereo.cas.web.security.CasWebSecurityConfigurerAdapter;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
+import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.security.web.context.SecurityContextRepository;
 
 import java.util.List;
@@ -44,19 +46,24 @@ import java.util.List;
 /** Exclude the URL /extras from security. */
 public class CustomCasWebSecurityConfigurerAdapter extends CasWebSecurityConfigurerAdapter {
 
+    // CAS 7.3 added managementServerProperties and webProperties to the parent constructor.
     public CustomCasWebSecurityConfigurerAdapter(
         final CasConfigurationProperties casProperties,
         final WebEndpointProperties webEndpointProperties,
+        final ManagementServerProperties managementServerProperties,
         final ObjectProvider<PathMappedEndpoints> pathMappedEndpoints,
         final List<CasWebSecurityConfigurer> webSecurityConfigurers,
-        final SecurityContextRepository securityContextRepository
+        final SecurityContextRepository securityContextRepository,
+        final WebProperties webProperties
     ) {
         super(
             casProperties,
             webEndpointProperties,
+            managementServerProperties,
             pathMappedEndpoints,
             webSecurityConfigurers,
-            securityContextRepository
+            securityContextRepository,
+            webProperties
         );
     }
 

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/password/IamPasswordManagementService.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/password/IamPasswordManagementService.java
@@ -59,7 +59,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.PreventedException;
 import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
-import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
+import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.pm.InvalidPasswordException;
 import org.apereo.cas.pm.PasswordChangeRequest;
 import org.apereo.cas.pm.PasswordHistoryService;
@@ -107,10 +107,11 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
 
     private final PasswordConfiguration passwordConfiguration;
 
+    // CAS 7.3 takes the whole CasConfigurationProperties and derives the issuer from it, so the
+    // PasswordManagementProperties and issuer arguments are gone.
     public IamPasswordManagementService(
-        final PasswordManagementProperties passwordManagementProperties,
+        final CasConfigurationProperties casProperties,
         final CipherExecutor<Serializable, String> cipherExecutor,
-        final String issuer,
         final PasswordHistoryService passwordHistoryService,
         final CasApi casApi,
         final ProvidersService providersService,
@@ -121,7 +122,7 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
         final PasswordValidator passwordValidator,
         final PasswordConfiguration passwordConfiguration
     ) {
-        super(passwordManagementProperties, cipherExecutor, issuer, passwordHistoryService);
+        super(casProperties, cipherExecutor, passwordHistoryService);
         this.casApi = casApi;
         this.providersService = providersService;
         this.identityProviderHelper = identityProviderHelper;
@@ -171,7 +172,9 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
             throw new PasswordConfirmException();
         }
 
-        if (!passwordValidator.isValid(getProperties().getCore().getPasswordPolicyPattern(), password)) {
+        if (
+            !passwordValidator.isValid(casProperties.getAuthn().getPm().getCore().getPasswordPolicyPattern(), password)
+        ) {
             throw new PasswordNotMatchRegexException();
         }
 
@@ -301,7 +304,21 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
     @Override
     public String findEmail(final PasswordManagementQuery query) {
         final var username = query.getUsername().toLowerCase().trim();
-        final String customerId = (String) query.getRecord().getFirst(Constants.RESET_PWD_CUSTOMER_ID_ATTR);
+        final var record = query.getRecord();
+        final String customerId = record == null
+            ? null
+            : (String) record.getFirst(Constants.RESET_PWD_CUSTOMER_ID_ATTR);
+
+        // CAS 7.3 calls this a second time, from PasswordChangeAction, to send a password reset confirmation
+        // email that did not exist before — cas.authn.pm.reset.confirmation-mail is new in 7.3. It builds the
+        // query from the username alone, with no record, so there is no customer id to identify the user by, and
+        // the lookup below would fail. The failure surfaced well after the password had already been changed:
+        // PasswordChangeAction catches it and shows "password could not be changed" on a change that succeeded.
+        // Returning null leaves the email unresolved, which is how CAS skips that confirmation message.
+        if (StringUtils.isBlank(customerId)) {
+            LOGGER.debug("No customer id in the query for {}: no email to resolve", username);
+            return null;
+        }
 
         try {
             UserDto user = findUserByEmailAndCustomerId(username, customerId);
@@ -329,7 +346,14 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
         private static final long serialVersionUID = -8981663363751187075L;
 
         public PasswordAlreadyUsedException() {
-            super(".alreadyUsed", null, null);
+            super(null, null);
+        }
+
+        // CAS 7.3 hardcodes the exception code, but PasswordChangeAction still appends it to
+        // "pm.validationFailure" to build the message key, so the suffix has to come from here instead.
+        @Override
+        public String getCode() {
+            return ".alreadyUsed";
         }
 
         @Override
@@ -343,7 +367,12 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
         private static final long serialVersionUID = -8981663363751187076L;
 
         public PasswordNotMatchRegexException() {
-            super(".invalidPassword", null, null);
+            super(null, null);
+        }
+
+        @Override
+        public String getCode() {
+            return ".invalidPassword";
         }
 
         @Override
@@ -357,7 +386,12 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
         private static final long serialVersionUID = -8981663363751187076L;
 
         public PasswordConfirmException() {
-            super(".pwdNotConfirm", null, null);
+            super(null, null);
+        }
+
+        @Override
+        public String getCode() {
+            return ".pwdNotConfirm";
         }
 
         @Override
@@ -371,7 +405,12 @@ public class IamPasswordManagementService extends BasePasswordManagementService 
         private static final long serialVersionUID = -8981663363751187075L;
 
         public PasswordContainsUserDictionaryException(String message) {
-            super(".invalidPwdDictionary", message, null);
+            super(message, null);
+        }
+
+        @Override
+        public String getCode() {
+            return ".invalidPwdDictionary";
         }
 
         @Override

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/surrogation/IamSurrogateAuthenticationService.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/surrogation/IamSurrogateAuthenticationService.java
@@ -34,7 +34,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.surrogate.BaseSurrogateAuthenticationService;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.services.RegisteredServicePrincipalAccessStrategyEnforcer;
 import org.apereo.cas.services.ServicesManager;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.util.Assert;
 import org.springframework.webflow.execution.RequestContextHolder;
 
@@ -49,8 +52,14 @@ public class IamSurrogateAuthenticationService extends BaseSurrogateAuthenticati
 
     private final CasApi casApi;
 
-    public IamSurrogateAuthenticationService(final CasApi casApi, final ServicesManager servicesManager) {
-        super(servicesManager);
+    public IamSurrogateAuthenticationService(
+        final CasApi casApi,
+        final ServicesManager servicesManager,
+        final CasConfigurationProperties casProperties,
+        final RegisteredServicePrincipalAccessStrategyEnforcer principalAccessStrategyEnforcer,
+        final ConfigurableApplicationContext applicationContext
+    ) {
+        super(servicesManager, casProperties, principalAccessStrategyEnforcer, applicationContext);
         this.casApi = casApi;
     }
 
@@ -58,7 +67,7 @@ public class IamSurrogateAuthenticationService extends BaseSurrogateAuthenticati
     public boolean canImpersonateInternal(
         final String surrogate,
         final Principal principal,
-        final Optional<Service> service
+        final Optional<? extends Service> service
     ) {
         final var requestContext = RequestContextHolder.getRequestContext();
         final var flowScope = requestContext.getFlowScope();
@@ -103,12 +112,19 @@ public class IamSurrogateAuthenticationService extends BaseSurrogateAuthenticati
     }
 
     @Override
-    public boolean isWildcardedAccount(final String surrogate, final Principal principal) {
+    public boolean isWildcardedAccount(
+        final String surrogate,
+        final Principal principal,
+        final Optional<? extends Service> service
+    ) {
         return false;
     }
 
     @Override
-    public Collection<String> getImpersonationAccounts(String username) {
+    public Collection<String> getImpersonationAccounts(
+        final String username,
+        final Optional<? extends Service> service
+    ) {
         throw new UnsupportedOperationException("Not allowed to choose the surrogate");
     }
 }

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/ticket/CustomOAuth20DefaultAccessTokenFactory.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/ticket/CustomOAuth20DefaultAccessTokenFactory.java
@@ -45,9 +45,9 @@ import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.ExpirationPolicyBuilder;
-import org.apereo.cas.ticket.UniqueTicketIdGenerator;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.ticket.accesstoken.OAuth20DefaultAccessTokenFactory;
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.tracking.TicketTrackingPolicy;
 import org.apereo.cas.token.JwtBuilder;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -65,20 +65,16 @@ import java.util.Objects;
 @Slf4j
 public class CustomOAuth20DefaultAccessTokenFactory extends OAuth20DefaultAccessTokenFactory {
 
+    // CAS 7.3 replaced the leading UniqueTicketIdGenerator argument with the TicketRegistry. This factory
+    // overrides generateAccessTokenId anyway, so it never used the generator.
     public CustomOAuth20DefaultAccessTokenFactory(
-        final UniqueTicketIdGenerator accessTokenIdGenerator,
+        final TicketRegistry ticketRegistry,
         final ExpirationPolicyBuilder<OAuth20AccessToken> expirationPolicyBuilder,
         final JwtBuilder jwtBuilder,
         final ServicesManager servicesManager,
         final TicketTrackingPolicy descendantTicketsTrackingPolicy
     ) {
-        super(
-            accessTokenIdGenerator,
-            expirationPolicyBuilder,
-            jwtBuilder,
-            servicesManager,
-            descendantTicketsTrackingPolicy
-        );
+        super(ticketRegistry, expirationPolicyBuilder, jwtBuilder, servicesManager, descendantTicketsTrackingPolicy);
     }
 
     @Override

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/ticket/DynamicTicketGrantingTicketFactory.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/ticket/DynamicTicketGrantingTicketFactory.java
@@ -82,21 +82,21 @@ public class DynamicTicketGrantingTicketFactory extends DefaultTicketGrantingTic
         this.utils = utils;
     }
 
+    // CAS 7.3 dropped the Class<T> argument and the generic return type from produceTicket.
     @Override
-    protected <T extends TicketGrantingTicket> T produceTicket(
+    protected TicketGrantingTicket produceTicket(
         final Authentication authentication,
         final String tgtId,
-        final Service service,
-        final Class<T> clazz
+        final Service service
     ) {
         final Principal principal = authentication.getPrincipal();
         final Map<String, List<Object>> attributes = principal.getAttributes();
         final String superUser = (String) utils.getAttributeValue(attributes, SUPER_USER_ATTRIBUTE);
         final UserTypeEnum type = (UserTypeEnum) utils.getAttributeValue(attributes, TYPE_ATTRIBUTE);
         if (superUser != null && type == UserTypeEnum.GENERIC) {
-            return (T) new TicketGrantingTicketImpl(tgtId, authentication, new HardTimeoutExpirationPolicy(170 * 60));
+            return new TicketGrantingTicketImpl(tgtId, authentication, new HardTimeoutExpirationPolicy(170 * 60));
         } else {
-            return super.produceTicket(authentication, tgtId, service, clazz);
+            return super.produceTicket(authentication, tgtId, service);
         }
     }
 }

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/web/CustomOidcRevocationEndpointController.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/web/CustomOidcRevocationEndpointController.java
@@ -7,10 +7,8 @@ import org.apereo.cas.oidc.web.controllers.token.OidcRevocationEndpointControlle
 import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.apereo.cas.ticket.OAuth20Token;
-import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshToken;
 import org.apereo.cas.util.function.FunctionUtils;
-import org.jooq.lambda.Unchecked;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
@@ -60,18 +58,5 @@ public class CustomOidcRevocationEndpointController extends OidcRevocationEndpoi
         final var mv = new ModelAndView(new MappingJackson2JsonView());
         mv.setStatus(HttpStatus.OK);
         return mv;
-    }
-
-    private void revokeToken(final OAuth20RefreshToken token) throws Exception {
-        this.revokeToken(token.getId());
-        token.getAccessTokens().forEach(Unchecked.consumer(this::revokeToken));
-    }
-
-    private boolean isRefreshToken(final OAuth20Token token) {
-        return token instanceof OAuth20RefreshToken;
-    }
-
-    private boolean isAccessToken(final OAuth20Token token) {
-        return token instanceof OAuth20AccessToken;
     }
 }

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/webflow/login/actions/I18NSendPasswordResetInstructionsAction.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/webflow/login/actions/I18NSendPasswordResetInstructionsAction.java
@@ -50,11 +50,11 @@ import org.apereo.cas.pm.PasswordManagementQuery;
 import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.pm.PasswordResetUrlBuilder;
 import org.apereo.cas.pm.web.flow.actions.SendPasswordResetInstructionsAction;
+import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.support.WebUtils;
 import org.apereo.inspektr.audit.annotation.Audit;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.HierarchicalMessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.util.LinkedMultiValueMap;
@@ -92,7 +92,7 @@ public class I18NSendPasswordResetInstructionsAction extends SendPasswordResetIn
         final PasswordResetUrlBuilder passwordResetUrlBuilder,
         final MultifactorAuthenticationProviderSelector multifactorAuthenticationProviderSelector,
         final AuthenticationSystemSupport authenticationSystemSupport,
-        final ApplicationContext applicationContext,
+        final ServicesManager servicesManager,
         final HierarchicalMessageSource messageSource,
         final ProvidersService providersService,
         final IdentityProviderHelper identityProviderHelper,
@@ -109,7 +109,8 @@ public class I18NSendPasswordResetInstructionsAction extends SendPasswordResetIn
             passwordResetUrlBuilder,
             multifactorAuthenticationProviderSelector,
             authenticationSystemSupport,
-            applicationContext
+            // CAS 7.3 expects the ServicesManager here, where the ApplicationContext used to go.
+            servicesManager
         );
         this.messageSource = messageSource;
         this.providersService = providersService;

--- a/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/webflow/mfa/actions/CustomSendTokenAction.java
+++ b/cas/cas-server/src/main/java/fr/gouv/vitamui/cas/webflow/mfa/actions/CustomSendTokenAction.java
@@ -33,8 +33,10 @@ import org.apereo.cas.configuration.model.support.mfa.simple.CasSimpleMultifacto
 import org.apereo.cas.mfa.simple.CasSimpleMultifactorTokenCommunicationStrategy;
 import org.apereo.cas.mfa.simple.validation.CasSimpleMultifactorAuthenticationService;
 import org.apereo.cas.mfa.simple.web.flow.CasSimpleMultifactorSendTokenAction;
+import org.apereo.cas.multitenancy.TenantExtractor;
 import org.apereo.cas.notifications.CommunicationsManager;
 import org.apereo.cas.web.flow.CasWebflowConstants;
+import org.apereo.cas.web.flow.util.MultifactorAuthenticationWebflowUtils;
 import org.apereo.cas.web.support.WebUtils;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
@@ -57,6 +59,7 @@ public class CustomSendTokenAction extends CasSimpleMultifactorSendTokenAction {
         final CasSimpleMultifactorAuthenticationProperties properties,
         final CasSimpleMultifactorTokenCommunicationStrategy tokenCommunicationStrategy,
         final BucketConsumer bucketConsumer,
+        final TenantExtractor tenantExtractor,
         final Utils utils
     ) {
         super(
@@ -64,13 +67,14 @@ public class CustomSendTokenAction extends CasSimpleMultifactorSendTokenAction {
             multifactorAuthenticationService,
             properties,
             tokenCommunicationStrategy,
-            bucketConsumer
+            bucketConsumer,
+            tenantExtractor
         );
         this.utils = utils;
     }
 
     @Override
-    protected Event doExecuteInternal(final RequestContext requestContext) {
+    protected Event doExecuteInternal(final RequestContext requestContext) throws Throwable {
         var authentication = WebUtils.getInProgressAuthentication();
         var principal = resolvePrincipal(authentication.getPrincipal(), requestContext);
 
@@ -82,8 +86,8 @@ public class CustomSendTokenAction extends CasSimpleMultifactorSendTokenAction {
             return getEventFactorySupport().event(this, "missingPhone");
         }
 
-        // remove token
-        WebUtils.removeSimpleMultifactorAuthenticationToken(requestContext);
+        // remove token (moved out of WebUtils into MultifactorAuthenticationWebflowUtils in CAS 7.3)
+        MultifactorAuthenticationWebflowUtils.removeSimpleMultifactorAuthenticationToken(requestContext);
 
         var event = super.doExecuteInternal(requestContext);
 

--- a/cas/cas-server/src/main/resources/application.properties
+++ b/cas/cas-server/src/main/resources/application.properties
@@ -86,17 +86,17 @@ spring.cloud.config.override-none=false
 ##
 # CAS Web Application Endpoints Security
 #
-management.endpoints.enabled-by-default=false
+management.endpoints.access.default=none
 
-management.endpoint.shutdown.enabled=false
-management.endpoint.restart.enabled=false
+management.endpoint.shutdown.access=none
+management.endpoint.restart.access=none
 
 management.endpoints.web.base-path=/actuator
 
 management.endpoints.web.exposure.include=health,metrics,prometheus
-management.endpoint.health.enabled=true
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
+management.endpoint.health.access=unrestricted
+management.endpoint.metrics.access=unrestricted
+management.endpoint.prometheus.access=unrestricted
 management.endpoints.jmx.exposure.exclude=*
 
 # management.endpoints.web.exposure.include=*
@@ -175,7 +175,6 @@ management.influx.metrics.export.enabled=false
 management.jmx.metrics.export.enabled=false
 management.newrelic.metrics.export.enabled=false
 management.prometheus.metrics.export.enabled=true
-management.signalfx.metrics.export.enabled=false
 management.simple.metrics.export.enabled=true
 management.statsd.metrics.export.enabled=false
 management.wavefront.metrics.export.enabled=false
@@ -196,7 +195,18 @@ springdoc.writer-with-default-pretty-printer=true
 springdoc.swagger-ui.display-request-duration=true
 
 # CORS Configuration
-spring.autoconfigure.exclude=org.apereo.cas.config.CasFiltersConfiguration
+#
+# This used to exclude org.apereo.cas.config.CasFiltersConfiguration, to keep CAS from registering its own CORS
+# filter over the VitamUI one. CAS 7.3 folded that class into CasWebAppAutoConfiguration, so it is no longer an
+# auto-configuration and Spring Boot refuses to start when asked to exclude it.
+#
+# CORS is unaffected: WebConfig declares corsFilter and corsHttpWebRequestConfigurationSource under the same names
+# CAS uses, so the VitamUI beans still replace them.
+#
+# The exclusion also happened to disable four other filters that ship in the same class — characterEncodingFilter,
+# responseHeadersFilter, responseHeadersSecurityFilter and requestParameterSecurityFilter. They are now active.
+# That is a behaviour change and belongs to the functional validation, in particular
+# RequestParameterPolicyEnforcementFilter, which rejects requests carrying repeated or encoded parameters.
 
 ##
 # CAS AspectJ Configuration

--- a/cas/cas-server/src/main/resources/overriden_messages_de.properties
+++ b/cas/cas-server/src/main/resources/overriden_messages_de.properties
@@ -46,3 +46,4 @@ cas.welcome.button.back=ZURÜCK
 cas.welcome.button.next=WEITER
 cas.welcome.button.validate=BESTÄTIGEN
 cas.welcome.header.msg=Willkommen
+screen.pm.currentpsw=Aktuelles Passwort:

--- a/cas/cas-server/src/main/resources/templates/fragments/pwdupdateform.html
+++ b/cas/cas-server/src/main/resources/templates/fragments/pwdupdateform.html
@@ -17,6 +17,26 @@
         th:object="${password}">
     <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
     <input type="hidden" name="_eventId" value="submit"/>
+    <!--
+      Since CAS 7.3, PasswordChangeAction rejects the change when the login flow submits no current password, or
+      one that does not match the credential, before the password management service is ever called. The field is
+      shown under the same condition CAS applies, so the reset flow, where there is no credential to compare
+      against, is left untouched.
+    -->
+    <div class="form-line" th:if="${activeFlowId} == 'login'">
+      <input required
+             id="currentPassword"
+             type="password"
+             name="currentPassword"
+             class="required"
+             size="25"
+             tabindex="2"
+             autocomplete="off"
+             th:field="*{currentPassword}"/>
+      <label for="currentPassword" th:text="#{screen.pm.currentpsw}">
+        Mot de passe actuel *
+      </label>
+    </div>
     <div class="form-line">
       <input required
              id="password"

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/BaseWebflowActionTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/BaseWebflowActionTest.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpSession;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
@@ -45,6 +46,8 @@ public abstract class BaseWebflowActionTest {
 
     protected HttpServletResponse response;
 
+    protected ApplicationContext applicationContext;
+
     @Before
     public void setUp() throws FileNotFoundException {
         context = mock(RequestContext.class);
@@ -58,6 +61,10 @@ public abstract class BaseWebflowActionTest {
 
         final var flow = mock(Flow.class);
         when(flow.getVariable("credential")).thenReturn(mock(FlowVariable.class));
+        // CAS 7.3 publishes a CasWebflowActionExecutingEvent from BaseCasWebflowAction#doExecute, which reads
+        // the application context off the active flow.
+        applicationContext = mock(ApplicationContext.class);
+        when(flow.getApplicationContext()).thenReturn(applicationContext);
 
         when(context.getActiveFlow()).thenReturn(flow);
         when(context.getRequestScope()).thenReturn(flowParameters);

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/IamSurrogateAuthenticationServiceTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/IamSurrogateAuthenticationServiceTest.java
@@ -7,11 +7,14 @@ import fr.gouv.vitamui.iam.common.enums.SubrogationStatusEnum;
 import fr.gouv.vitamui.iam.openapiclient.CasApi;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.services.RegisteredServicePrincipalAccessStrategyEnforcer;
 import org.apereo.cas.services.ServicesManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -49,7 +52,13 @@ public final class IamSurrogateAuthenticationServiceTest {
     @Before
     public void setUp() {
         casApi = mock(CasApi.class);
-        service = new IamSurrogateAuthenticationService(casApi, mock(ServicesManager.class));
+        service = new IamSurrogateAuthenticationService(
+            casApi,
+            mock(ServicesManager.class),
+            new CasConfigurationProperties(),
+            mock(RegisteredServicePrincipalAccessStrategyEnforcer.class),
+            mock(ConfigurableApplicationContext.class)
+        );
     }
 
     @After
@@ -102,7 +111,7 @@ public final class IamSurrogateAuthenticationServiceTest {
             casApi.getSubrogationsBySuperUserIdOrEmailAndCustomerId(eq(null), eq(SU_EMAIL), eq(SU_CUSTOMER_ID))
         ).thenReturn(List.of(surrogation()));
 
-        service.getImpersonationAccounts(SU_EMAIL);
+        service.getImpersonationAccounts(SU_EMAIL, Optional.empty());
     }
 
     private Principal principal() {

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/LoginPwdAuthenticationHandlerTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/authentication/LoginPwdAuthenticationHandlerTest.java
@@ -68,7 +68,7 @@ public final class LoginPwdAuthenticationHandlerTest {
     @Before
     public void setUp() {
         casApi = mock(CasApi.class);
-        handler = new LoginPwdAuthenticationHandler(null, new DefaultPrincipalFactory(), casApi, IP_HEADER_NAME);
+        handler = new LoginPwdAuthenticationHandler(new DefaultPrincipalFactory(), casApi, IP_HEADER_NAME);
         credential = new UsernamePasswordCredential("ignored", PASSWORD);
 
         RequestContext requestContext = mock(RequestContext.class);

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasBeanNamesTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasBeanNamesTest.java
@@ -1,0 +1,92 @@
+package fr.gouv.vitamui.cas.config;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks that every bean name written as a string literal still designates a bean that exists.
+ *
+ * <p>Two families of literals are covered:
+ *
+ * <ul>
+ *   <li>{@link CasBeans} — about thirty CAS bean names injected by {@code @Qualifier}. Roughly half are plain
+ *       strings, with no compiler help: {@code WebflowConfig} alone rebuilds the CAS authentication resolver chain
+ *       from fourteen of them. A qualifier pointing at a name CAS no longer declares fails at context startup, in
+ *       production, not at build time.
+ *   <li>The action bean names passed to {@code createActionState} / {@code createEvaluateAction} by the webflow
+ *       configurers. These are resolved lazily, when a user walks through that part of the flow — a typo or a
+ *       rename in {@code WebflowConfig} stays invisible until someone hits the state.
+ * </ul>
+ */
+public class CasBeanNamesTest {
+
+    /**
+     * CAS bean names that CAS does not declare through a plain {@code @Bean} method, so {@link CasBeanRegistry}
+     * cannot see them (both are present in the CAS jars, registered another way).
+     *
+     * <p>Both are derived from CAS constants — {@code LogoutManager.DEFAULT_BEAN_NAME} and
+     * {@code SingleLogoutRequestExecutor.BEAN_NAME} — so a rename breaks the compilation instead of the runtime.
+     * That is why leaving them unchecked here is acceptable.
+     */
+    private static final Set<String> NOT_DECLARED_VIA_BEAN_METHOD = Set.of(
+        "logoutManager",
+        "defaultSingleLogoutRequestExecutor"
+    );
+
+    /** Action beans referenced by name from {@code VitamLoginWebflowConfigurer} and {@code VitamMfaWebflowConfigurer}. */
+    private static final List<String> WEBFLOW_ACTION_BEANS = List.of(
+        "checkSubrogationAction",
+        "triggerChangePasswordAction",
+        "dispatcherAction",
+        "listCustomersAction",
+        "customerSelectedAction",
+        "checkMfaTokenAction"
+    );
+
+    @Test
+    public void everyQualifierConstantDesignatesAnExistingBean() throws Exception {
+        final TreeMap<String, String> unresolved = new TreeMap<>();
+
+        for (final Field field : CasBeans.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers()) || field.getType() != String.class) {
+                continue;
+            }
+            field.setAccessible(true);
+            final String beanName = (String) field.get(null);
+            final boolean known =
+                CasBeanRegistry.casDeclares(beanName) ||
+                CasBeanRegistry.vitamuiBeanNames().contains(beanName) ||
+                NOT_DECLARED_VIA_BEAN_METHOD.contains(beanName);
+            if (!known) {
+                unresolved.put(field.getName(), beanName);
+            }
+        }
+
+        assertThat(unresolved)
+            .as(
+                "CasBeans constants pointing at a bean nobody declares any more. Every one of them is a " +
+                "@Qualifier that will fail at context startup."
+            )
+            .isEmpty();
+    }
+
+    @Test
+    public void everyWebflowActionBeanIsDeclared() {
+        for (final String beanName : WEBFLOW_ACTION_BEANS) {
+            assertThat(CasBeanRegistry.vitamuiBeanNames().contains(beanName) || CasBeanRegistry.casDeclares(beanName))
+                .as(
+                    "The webflow configurers wire the action state '%s' by name, but no @Bean declares it. The " +
+                    "flow would fail when a user reaches that state.",
+                    beanName
+                )
+                .isTrue();
+        }
+    }
+}

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasBeanOverridesTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasBeanOverridesTest.java
@@ -1,0 +1,137 @@
+package fr.gouv.vitamui.cas.config;
+
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the set of CAS beans that {@code AppConfig}, {@code WebConfig} and {@code WebflowConfig} replace by name.
+ *
+ * <p>These replacements only work because {@code spring.main.allow-bean-definition-overriding=true}. That flag also
+ * makes them fail quietly: when a CAS upgrade renames a bean, the VitamUI definition no longer replaces anything, it
+ * is simply registered next to the CAS one. Nothing throws. For the beans we deliberately neutralise —
+ * {@code passwordManagementAuthenticationExecutionPlanConfigurer} and {@code loadSurrogatesListAction} are no-ops,
+ * {@code yamlHttpMessageConverter} returns {@code null} — the CAS behaviour we removed silently comes back.
+ *
+ * <p>So this test compares the override surface against a pinned list. After a CAS upgrade, a bean that disappears
+ * from {@link CasBeanRegistry#overriddenBeanNames()} is a bean we stopped overriding, and the failure names it.
+ */
+public class CasBeanOverridesTest {
+
+    /**
+     * CAS beans replaced by VitamUI, as of CAS 7.0.10.1.
+     *
+     * <p>Do not edit this list to make the build pass again. Each removal is a functional regression to investigate
+     * first: find the new CAS bean name, then rename ours to match.
+     */
+    private static final Set<String> EXPECTED_OVERRIDES = new TreeSet<>(
+        Set.of(
+            "casWebSecurityConfigurerAdapter",
+            "casWebSecurityCustomizer",
+            "corsFilter",
+            "corsHttpWebRequestConfigurationSource",
+            "defaultAccessTokenFactory",
+            "defaultPrincipalResolver",
+            "defaultTicketGrantingTicketFactory",
+            "defaultWebflowConfigurer",
+            "delegatedAuthenticationAction",
+            "delegatedAuthenticationClientLogoutAction",
+            "delegatedAuthenticationCredentialExtractor",
+            "delegatedClientAuthenticationConfigurationContext",
+            "delegatedIdentityProviders",
+            "initialAuthenticationAttemptWebflowEventResolver",
+            "loadSurrogatesListAction",
+            "mfaSimpleMultifactorSendTokenAction",
+            "mfaSimpleMultifactorTokenCommunicationStrategy",
+            "mfaSimpleMultifactorWebflowConfigurer",
+            "oidcCasClientRedirectActionBuilder",
+            "oidcRevocationEndpointController",
+            "passwordChangeService",
+            "passwordManagementAuthenticationExecutionPlanConfigurer",
+            "sendPasswordResetInstructionsAction",
+            "surrogateAuthenticationService",
+            "surrogateDelegatedAuthenticationPreProcessor",
+            "surrogateInitialAuthenticationAction",
+            "surrogatePrincipalResolver",
+            "terminateSessionAction",
+            "x509Check",
+            "x509SubjectDNPrincipalResolver",
+            "yamlHttpMessageConverter"
+        )
+    );
+
+    /**
+     * VitamUI beans whose name looks like a CAS bean but matches nothing in CAS 7.0.10.1.
+     *
+     * <p>{@code builtClients} was the pac4j client holder up to CAS 7.0, replaced by
+     * {@code delegatedIdentityProviders}; {@code AppConfig#builtClients} therefore overrides nothing and is dead
+     * code. {@code surrogateDelegatedAuthenticationCredentialExtractor} is the second name of the aliased
+     * {@code @Bean} in {@code AppConfig}, and only the first alias matches a CAS bean. {@code pmTicketFactory} is
+     * consumed by our own {@code sendPasswordResetInstructionsAction}, not by CAS.
+     *
+     * <p>Pinned so that a future CAS version reintroducing one of these names surfaces as a failure rather than as
+     * an accidental override.
+     */
+    private static final Set<String> EXPECTED_NON_OVERRIDES = new TreeSet<>(
+        Set.of("builtClients", "pmTicketFactory", "surrogateDelegatedAuthenticationCredentialExtractor")
+    );
+
+    @Test
+    public void overrideSurfaceIsUnchanged() {
+        assertThat(CasBeanRegistry.overriddenBeanNames())
+            .as(
+                "VitamUI beans that replace a CAS bean by name. A missing entry means CAS renamed the bean and our " +
+                "override became a silently inert extra bean definition."
+            )
+            .containsExactlyInAnyOrderElementsOf(EXPECTED_OVERRIDES);
+    }
+
+    @Test
+    public void beansThatLookLikeOverridesStillOverrideNothing() {
+        for (final String beanName : EXPECTED_NON_OVERRIDES) {
+            assertThat(CasBeanRegistry.vitamuiBeanNames())
+                .as("%s is expected to be declared by VitamUI", beanName)
+                .contains(beanName);
+            assertThat(CasBeanRegistry.casDeclares(beanName))
+                .as("CAS now declares a bean named '%s': our definition silently became an override", beanName)
+                .isFalse();
+        }
+    }
+
+    @Test
+    public void overriddenBeansKeepACompatibleType() {
+        for (final String beanName : EXPECTED_OVERRIDES) {
+            final Set<String> casTypes = CasBeanRegistry.casReturnTypes(beanName);
+            final Set<String> ourTypes = CasBeanRegistry.vitamuiReturnTypes(beanName);
+            assertThat(casTypes).as("CAS no longer declares '%s'", beanName).isNotEmpty();
+            assertThat(ourTypes).as("VitamUI no longer declares '%s'", beanName).isNotEmpty();
+
+            for (final String ourType : ourTypes) {
+                assertThat(casTypes.stream().anyMatch(casType -> isCompatible(ourType, casType)))
+                    .as(
+                        "Bean '%s' is declared as %s by VitamUI but as %s by CAS: the override would be rejected " +
+                        "or would break every CAS injection point expecting the CAS type",
+                        beanName,
+                        ourType,
+                        casTypes
+                    )
+                    .isTrue();
+            }
+        }
+    }
+
+    /** Our declared type must be the CAS type or a subtype of it, so CAS injection points keep resolving. */
+    private static boolean isCompatible(final String ourType, final String casType) {
+        if (ourType.equals(casType)) {
+            return true;
+        }
+        try {
+            return Class.forName(casType).isAssignableFrom(Class.forName(ourType));
+        } catch (final ClassNotFoundException | LinkageError e) {
+            return false;
+        }
+    }
+}

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasBeanRegistry.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasBeanRegistry.java
@@ -1,0 +1,123 @@
+package fr.gouv.vitamui.cas.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.MethodMetadata;
+import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Index of the bean names declared through {@code @Bean} methods, built by reading class metadata with ASM.
+ *
+ * <p>No class is loaded and no application context is started: this only reads the bytecode that is on the test
+ * classpath. It exists so that the tests in this package can answer one question cheaply and deterministically —
+ * <em>does Apereo CAS still declare a bean under this exact name?</em>
+ *
+ * <p>That question matters because {@code AppConfig}, {@code WebConfig} and {@code WebflowConfig} replace roughly
+ * thirty CAS beans <em>by name</em>, under {@code spring.main.allow-bean-definition-overriding=true}. When a CAS
+ * upgrade renames one of them, the VitamUI definition stops replacing anything and is silently registered
+ * alongside the original — no error, and the CAS behaviour we meant to neutralise comes back.
+ */
+public final class CasBeanRegistry {
+
+    private static final String BEAN_ANNOTATION = Bean.class.getName();
+
+    private static final String CAS_CLASSES = "classpath*:org/apereo/cas/**/*.class";
+    private static final String VITAMUI_CONFIG_CLASSES = "classpath*:fr/gouv/vitamui/cas/config/*.class";
+
+    /** Bean name -&gt; declared return type(s) of the CAS {@code @Bean} methods producing it. */
+    private static final Map<String, Set<String>> CAS_BEANS = scan(CAS_CLASSES);
+
+    /** Bean name -&gt; declared return type(s) of the VitamUI {@code @Bean} methods producing it. */
+    private static final Map<String, Set<String>> VITAMUI_BEANS = scan(VITAMUI_CONFIG_CLASSES);
+
+    private CasBeanRegistry() {}
+
+    public static boolean casDeclares(final String beanName) {
+        return CAS_BEANS.containsKey(beanName);
+    }
+
+    public static Set<String> casBeanNames() {
+        return Collections.unmodifiableSet(CAS_BEANS.keySet());
+    }
+
+    public static Set<String> vitamuiBeanNames() {
+        return Collections.unmodifiableSet(VITAMUI_BEANS.keySet());
+    }
+
+    /** Return types CAS declares for {@code beanName}; empty when CAS does not declare it at all. */
+    public static Set<String> casReturnTypes(final String beanName) {
+        return Collections.unmodifiableSet(CAS_BEANS.getOrDefault(beanName, Set.of()));
+    }
+
+    /** Return types VitamUI declares for {@code beanName}; empty when VitamUI does not declare it at all. */
+    public static Set<String> vitamuiReturnTypes(final String beanName) {
+        return Collections.unmodifiableSet(VITAMUI_BEANS.getOrDefault(beanName, Set.of()));
+    }
+
+    /** Names declared on both sides, i.e. the beans VitamUI actually takes over from CAS. */
+    public static Set<String> overriddenBeanNames() {
+        final Set<String> intersection = new TreeSet<>(VITAMUI_BEANS.keySet());
+        intersection.retainAll(CAS_BEANS.keySet());
+        return intersection;
+    }
+
+    private static Map<String, Set<String>> scan(final String locationPattern) {
+        final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        final MetadataReaderFactory readerFactory = new CachingMetadataReaderFactory(resolver);
+        final Map<String, Set<String>> index = new TreeMap<>();
+
+        final Resource[] resources;
+        try {
+            resources = resolver.getResources(locationPattern);
+        } catch (final IOException e) {
+            throw new IllegalStateException("Cannot scan the classpath for " + locationPattern, e);
+        }
+
+        for (final Resource resource : resources) {
+            if (!resource.isReadable()) {
+                continue;
+            }
+            final MetadataReader reader;
+            try {
+                reader = readerFactory.getMetadataReader(resource);
+            } catch (final IOException | RuntimeException | LinkageError e) {
+                // Not every entry under these packages is a class file we can parse (module-info, newer bytecode
+                // levels, resources renamed to .class). Those cannot declare beans, so skipping them is safe.
+                continue;
+            }
+            for (final MethodMetadata method : reader.getAnnotationMetadata().getAnnotatedMethods(BEAN_ANNOTATION)) {
+                for (final String beanName : beanNamesOf(method)) {
+                    index.computeIfAbsent(beanName, key -> new TreeSet<>()).add(method.getReturnTypeName());
+                }
+            }
+        }
+        return index;
+    }
+
+    /**
+     * Bean names produced by a {@code @Bean} method: the explicit {@code name}/{@code value} attribute when set
+     * (a method may register several aliases), the method name otherwise.
+     */
+    private static Set<String> beanNamesOf(final MethodMetadata method) {
+        final Map<String, Object> attributes = method.getAnnotationAttributes(BEAN_ANNOTATION);
+        if (attributes != null) {
+            final Object declared = attributes.get("name");
+            if (declared instanceof String[] names && names.length > 0) {
+                return new LinkedHashSet<>(Arrays.asList(names));
+            }
+        }
+        return Set.of(method.getMethodName());
+    }
+}

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasWebflowConstantsTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/CasWebflowConstantsTest.java
@@ -1,0 +1,93 @@
+package fr.gouv.vitamui.cas.config;
+
+import org.apereo.cas.web.flow.CasWebflowConstants;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * Pins the <em>values</em> of the {@link CasWebflowConstants} the webflow configurers rely on.
+ *
+ * <p>These constants are {@code static final String}, so javac inlines them into our class files. A CAS upgrade that
+ * changes a value while keeping the field name is therefore invisible: {@code VitamLoginWebflowConfigurer} keeps
+ * wiring transitions to the value captured at compile time, the module still compiles, and the flow silently points
+ * at states CAS no longer knows. Recompiling hides the problem rather than revealing it.
+ *
+ * <p>Reading the fields reflectively bypasses inlining and returns what the CAS jar actually holds today, so
+ * comparing against pinned literals turns that class of change into a build failure.
+ */
+public class CasWebflowConstantsTest {
+
+    /** Field name -&gt; value, as of CAS 7.0.10.1. */
+    private static final Map<String, String> EXPECTED_VALUES = Map.ofEntries(
+        entry("ACTION_ID_DELEGATED_AUTHENTICATION", "delegatedAuthenticationAction"),
+        entry("ACTION_ID_DELEGATED_AUTHENTICATION_CLIENT_LOGOUT", "delegatedAuthenticationClientLogoutAction"),
+        entry("ACTION_ID_FRONT_CHANNEL_LOGOUT", "frontChannelLogoutAction"),
+        entry("ACTION_ID_INITIAL_FLOW_SETUP", "initialFlowSetupAction"),
+        entry("ACTION_ID_INIT_LOGIN_ACTION", "initializeLoginAction"),
+        entry("ACTION_ID_MFA_SIMPLE_SEND_TOKEN", "mfaSimpleMultifactorSendTokenAction"),
+        entry("ACTION_ID_OTP_AUTHENTICATION_ACTION", "oneTimeTokenAuthenticationWebflowAction"),
+        entry("ACTION_ID_SURROGATE_INITIAL_AUTHENTICATION", "surrogateInitialAuthenticationAction"),
+        entry("ACTION_ID_TERMINATE_SESSION", "terminateSessionAction"),
+        entry("ACTION_ID_TICKET_GRANTING_TICKET_CHECK", "ticketGrantingTicketCheckAction"),
+        entry("BEAN_NAME_FLOW_BUILDER_SERVICES", "flowBuilderServices"),
+        // CAS 7.3 replaced the separate login/logout registries with a single one.
+        entry("BEAN_NAME_FLOW_DEFINITION_REGISTRY", "flowDefinitionRegistry"),
+        entry("STATE_ID_ACCOUNT_DISABLED", "casAccountDisabledView"),
+        entry("STATE_ID_GATEWAY_REQUEST_CHECK", "gatewayRequestCheck"),
+        entry("STATE_ID_HAS_SERVICE_CHECK", "hasServiceCheck"),
+        entry("STATE_ID_INIT_LOGIN_FORM", "initializeLoginForm"),
+        entry("STATE_ID_MUST_CHANGE_PASSWORD", "casMustChangePassView"),
+        entry("STATE_ID_REAL_SUBMIT", "realSubmit"),
+        entry("STATE_ID_SEND_RESET_PASSWORD_ACCT_INFO", "casResetPasswordSendInstructionsView"),
+        entry("STATE_ID_SIMPLE_MFA_SEND_TOKEN", "sendSimpleToken"),
+        entry("STATE_ID_STOP_WEBFLOW", "stopWebflow"),
+        entry("STATE_ID_SUCCESS", "success"),
+        entry("STATE_ID_TERMINATE_SESSION", "terminateSession"),
+        entry("STATE_ID_TICKET_GRANTING_TICKET_CHECK", "ticketGrantingTicketCheck"),
+        entry("STATE_ID_UNAVAILABLE", "unavailable"),
+        entry("STATE_ID_VIEW_LOGIN_FORM", "viewLoginForm"),
+        entry("TRANSITION_ID_ERROR", "error"),
+        entry("TRANSITION_ID_GENERATE", "generate"),
+        entry("TRANSITION_ID_RESEND", "resend"),
+        entry("TRANSITION_ID_RESET_PASSWORD", "resetPassword"),
+        entry("TRANSITION_ID_STOP", "stop"),
+        entry("TRANSITION_ID_SUBMIT", "submit"),
+        entry("TRANSITION_ID_SUCCESS", "success"),
+        entry("TRANSITION_ID_TICKET_GRANTING_TICKET_INVALID", "invalid"),
+        entry("TRANSITION_ID_TICKET_GRANTING_TICKET_NOT_EXISTS", "notExists"),
+        entry("TRANSITION_ID_TICKET_GRANTING_TICKET_VALID", "valid"),
+        entry("VAR_ID_CREDENTIAL", "credential")
+    );
+
+    @Test
+    public void constantsUsedByTheWebflowKeepTheirValue() throws Exception {
+        final Map<String, String> missing = new TreeMap<>();
+        final Map<String, String> actual = new LinkedHashMap<>();
+
+        for (final String fieldName : EXPECTED_VALUES.keySet()) {
+            try {
+                final Field field = CasWebflowConstants.class.getField(fieldName);
+                actual.put(fieldName, String.valueOf(field.get(null)));
+            } catch (final NoSuchFieldException e) {
+                missing.put(fieldName, EXPECTED_VALUES.get(fieldName));
+            }
+        }
+
+        assertThat(missing).as("CasWebflowConstants fields used by the webflow configurers that CAS removed").isEmpty();
+
+        assertThat(actual)
+            .as(
+                "CasWebflowConstants values changed. These constants are inlined at compile time, so the webflow " +
+                "configurers still wire the old values and the module keeps compiling: review every use " +
+                "before updating this list."
+            )
+            .containsExactlyInAnyOrderEntriesOf(EXPECTED_VALUES);
+    }
+}

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/ConfigurationKeysTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/config/ConfigurationKeysTest.java
@@ -1,0 +1,267 @@
+package fr.gouv.vitamui.cas.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks that every configuration key this module ships still designates a property that something on the
+ * classpath declares.
+ *
+ * <p>CAS renames configuration properties freely between minor versions, and a key that no longer binds is simply
+ * ignored: the server starts, and the behaviour silently reverts to the default. The authoritative list of valid
+ * keys is the {@code spring-configuration-metadata.json} that CAS, Spring Boot and Spring Cloud ship inside their
+ * jars, so that is what this test reads.
+ *
+ * <p>Only the files that live in this module are covered. The production configuration is an Ansible template,
+ * {@code deployment/roles/vitamui/templates/cas-server/application.yml.j2}, and it holds keys that are not
+ * expressed here — it has to be reviewed by hand when CAS is upgraded.
+ */
+public class ConfigurationKeysTest {
+
+    /** Prefixes worth checking: everything else belongs to VitamUI or to the theme. */
+    private static final Set<String> CHECKED_PREFIXES = Set.of("cas", "spring", "server", "management", "logging");
+
+    private static final Pattern INDEX = Pattern.compile("\\[\\d+]");
+    private static final Pattern CAMEL_BOUNDARY = Pattern.compile("(?<!^)(?=[A-Z])");
+
+    /**
+     * Keys nothing declares, and that were already inert before the CAS 7.3.8 upgrade.
+     *
+     * <p>{@code spring.cloud.bus.enabled} guards against a spring-cloud-bus that is not on the classpath.
+     * {@code management.health.memoryHealthIndicator.enabled} names a health indicator Spring Boot does not have.
+     * {@code server.host} is not a Spring property at all — the address setting is {@code server.address}.
+     *
+     * <p>{@code management.monitor.endpoints.endpoint.defaults.access} is different: it is a CAS key that ended up
+     * nested under {@code management} in application-recette.yml, so it binds to nothing and the recette
+     * environment falls back to the {@code AUTHENTICATED} set in application.properties. Moving it under
+     * {@code cas} would restore what was meant — and open those endpoints — so the decision belongs to whoever
+     * owns that environment rather than to this upgrade.
+     *
+     * <p>They are recorded rather than removed so the test stays a faithful description of the files. Removing
+     * them is a separate cleanup.
+     */
+    private static final Set<String> KNOWN_INERT = Set.of(
+        "spring.cloud.bus.enabled",
+        "management.health.memoryHealthIndicator.enabled",
+        "server.host",
+        "management.monitor.endpoints.endpoint.defaults.access"
+    );
+
+    @Test
+    public void everyConfigurationKeyIsDeclaredBySomethingOnTheClasspath() throws Exception {
+        final Metadata metadata = Metadata.fromClasspath();
+        final TreeMap<String, String> unknown = new TreeMap<>();
+
+        for (final Path file : configurationFiles()) {
+            final Map<String, Integer> keys = file.toString().endsWith(".properties")
+                ? readProperties(file)
+                : readYaml(file);
+            keys.forEach((key, line) -> {
+                if (!CHECKED_PREFIXES.contains(key.split("\\.")[0])) {
+                    return;
+                }
+                if (KNOWN_INERT.contains(key) || metadata.declares(key)) {
+                    return;
+                }
+                unknown.put(file.getFileName() + ":" + line + "  " + key, key);
+            });
+        }
+
+        assertThat(unknown.keySet())
+            .as(
+                "Configuration keys nothing on the classpath declares. A key that does not bind is ignored in " +
+                "silence and the setting reverts to its default."
+            )
+            .isEmpty();
+    }
+
+    /**
+     * A key can be perfectly well declared and still be dead. Spring Boot keeps deprecated properties in the
+     * metadata, reports them at startup through PropertiesMigrationListener, and then ignores them. Checking that
+     * a key exists, which the test above does, does not catch that — the eight management.* keys this module
+     * carried into CAS 7.3.8 went unnoticed until the server was actually started.
+     */
+    @Test
+    public void noConfigurationKeyIsDeprecated() throws Exception {
+        final Metadata metadata = Metadata.fromClasspath();
+        final TreeMap<String, String> removed = new TreeMap<>();
+
+        for (final Path file : configurationFiles()) {
+            final Map<String, Integer> keys = file.toString().endsWith(".properties")
+                ? readProperties(file)
+                : readYaml(file);
+            keys.forEach((key, line) -> {
+                if (!CHECKED_PREFIXES.contains(key.split("\\.")[0])) {
+                    return;
+                }
+                final String replacement = metadata.removedReplacementFor(key);
+                if (replacement != null) {
+                    removed.put(file.getFileName() + ":" + line + "  " + key + "  ->  " + replacement, key);
+                }
+            });
+        }
+
+        assertThat(removed.keySet())
+            .as("Deprecated configuration keys: they parse, and then do nothing. Each line shows the replacement.")
+            .isEmpty();
+    }
+
+    private static List<Path> configurationFiles() throws IOException {
+        final List<Path> files = new ArrayList<>();
+        files.add(Path.of("src/main/resources/application.properties"));
+        try (var stream = Files.list(Path.of("src/main/config"))) {
+            stream.filter(p -> p.getFileName().toString().endsWith(".yml")).sorted().forEach(files::add);
+        }
+        return files;
+    }
+
+    private static Map<String, Integer> readProperties(final Path file) throws IOException {
+        final Map<String, Integer> keys = new LinkedHashMap<>();
+        final List<String> lines = Files.readAllLines(file);
+        final Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(file)) {
+            properties.load(in);
+        }
+        properties.stringPropertyNames().forEach(name -> keys.put(name, lineOf(lines, name)));
+        return keys;
+    }
+
+    private static int lineOf(final List<String> lines, final String key) {
+        for (int i = 0; i < lines.size(); i++) {
+            final String line = lines.get(i).trim();
+            if (!line.startsWith("#") && line.startsWith(key) && line.substring(key.length()).startsWith("=")) {
+                return i + 1;
+            }
+        }
+        return 0;
+    }
+
+    /** Flattens every document of a YAML file into dotted keys. Line numbers are not tracked here. */
+    private static Map<String, Integer> readYaml(final Path file) throws IOException {
+        final Map<String, Integer> keys = new LinkedHashMap<>();
+        try (InputStream in = Files.newInputStream(file)) {
+            for (final Object document : new Yaml().loadAll(in)) {
+                if (document instanceof Map<?, ?> map) {
+                    flatten("", map, keys);
+                }
+            }
+        }
+        return keys;
+    }
+
+    private static void flatten(final String prefix, final Map<?, ?> map, final Map<String, Integer> out) {
+        map.forEach((rawKey, value) -> {
+            final String key = prefix.isEmpty() ? String.valueOf(rawKey) : prefix + '.' + rawKey;
+            if (value instanceof Map<?, ?> nested) {
+                flatten(key, nested, out);
+            } else {
+                out.put(key, 0);
+            }
+        });
+    }
+
+    /** The union of every spring-configuration-metadata.json reachable on the classpath. */
+    private record Metadata(
+        Set<String> names,
+        Set<String> containers,
+        List<Pattern> templated,
+        Map<String, String> removed
+    ) {
+        static Metadata fromClasspath() throws IOException {
+            final Set<String> names = new TreeSet<>();
+            final Set<String> containers = new TreeSet<>();
+            final List<Pattern> templated = new ArrayList<>();
+            final Map<String, String> removed = new TreeMap<>();
+            final ObjectMapper mapper = new ObjectMapper();
+
+            final Resource[] resources = new PathMatchingResourcePatternResolver()
+                .getResources("classpath*:META-INF/spring-configuration-metadata.json");
+            for (final Resource resource : resources) {
+                final JsonNode root;
+                try (InputStream in = resource.getInputStream()) {
+                    root = mapper.readTree(in);
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                for (final JsonNode property : root.path("properties")) {
+                    final String name = property.path("name").asText();
+                    if (name.isEmpty()) {
+                        continue;
+                    }
+                    if (name.contains("[key]")) {
+                        templated.add(
+                            Pattern.compile('^' + Pattern.quote(normalise(name)).replace("[key]", "\\E[^.]+\\Q") + '$')
+                        );
+                        continue;
+                    }
+                    names.add(normalise(name));
+                    final JsonNode deprecation = property.path("deprecation");
+                    if (!deprecation.isMissingNode()) {
+                        // The level field is often absent, and Spring Boot still refuses the key when the
+                        // replacement has an incompatible type — which is how the management.* ones slipped
+                        // through. Any deprecation block is treated as a key to migrate.
+                        final String replacement = deprecation.path("replacement").asText();
+                        removed.put(normalise(name), replacement.isEmpty() ? "no replacement" : replacement);
+                    }
+                    final String type = property.path("type").asText();
+                    if (type.startsWith("java.util.Map") || type.startsWith("java.util.List")) {
+                        containers.add(normalise(name));
+                    }
+                }
+            }
+            return new Metadata(names, containers, templated, removed);
+        }
+
+        /** Replacement advertised for a key Spring Boot removed, or null when the key is still supported. */
+        String removedReplacementFor(final String key) {
+            return removed.get(normalise(key));
+        }
+
+        boolean declares(final String key) {
+            final String candidate = normalise(key);
+            if (names.contains(candidate)) {
+                return true;
+            }
+            if (templated.stream().anyMatch(pattern -> pattern.matcher(candidate).matches())) {
+                return true;
+            }
+            // Only Map- and List-typed properties may carry arbitrary keys underneath.
+            return containers.stream().anyMatch(container -> candidate.startsWith(container + '.'));
+        }
+
+        /** Spring's relaxed binding accepts camelCase and indices; the metadata is kebab-case without them. */
+        private static String normalise(final String key) {
+            final String withoutIndices = INDEX.matcher(key).replaceAll("");
+            final StringBuilder result = new StringBuilder();
+            final String[] segments = withoutIndices.split("\\.", -1);
+            for (int i = 0; i < segments.length; i++) {
+                if (i > 0) {
+                    result.append('.');
+                }
+                result.append(CAMEL_BOUNDARY.matcher(segments[i]).replaceAll("-").toLowerCase());
+            }
+            return result.toString();
+        }
+    }
+}

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/password/IamPasswordManagementServiceTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/password/IamPasswordManagementServiceTest.java
@@ -55,7 +55,7 @@ import org.apereo.cas.authentication.DefaultAuthentication;
 import org.apereo.cas.authentication.PreventedException;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
-import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
+import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.pm.PasswordChangeRequest;
 import org.apereo.cas.pm.PasswordManagementQuery;
 import org.junit.Before;
@@ -89,6 +89,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -126,8 +128,8 @@ public final class IamPasswordManagementServiceTest extends BaseWebflowActionTes
         identityProviderHelper = mock(IdentityProviderHelper.class);
         identityProviderDto = new IdentityProviderDto();
         identityProviderDto.setInternal(true);
-        PasswordManagementProperties passwordManagementProperties = new PasswordManagementProperties();
-        passwordManagementProperties.getCore().setPasswordPolicyPattern(encode(policyPattern));
+        CasConfigurationProperties casProperties = new CasConfigurationProperties();
+        casProperties.getAuthn().getPm().getCore().setPasswordPolicyPattern(encode(policyPattern));
         PasswordConfiguration passwordConfiguration = new PasswordConfiguration();
         passwordConfiguration.setCheckOccurrence(true);
         passwordConfiguration.setOccurrencesCharsNumber(4);
@@ -143,8 +145,7 @@ public final class IamPasswordManagementServiceTest extends BaseWebflowActionTes
         );
         final var utils = new Utils(null, 0, null, null, "");
         service = new IamPasswordManagementService(
-            passwordManagementProperties,
-            null,
+            casProperties,
             null,
             null,
             casApi,
@@ -402,6 +403,19 @@ public final class IamPasswordManagementServiceTest extends BaseWebflowActionTes
         assertThatThrownBy(() -> service.findEmail(getPasswordManagementQuery())).isInstanceOf(
             PreventedException.class
         );
+    }
+
+    /**
+     * CAS 7.3 calls findEmail from PasswordChangeAction with a query built from the username alone, to send a
+     * confirmation email that did not exist in 7.0. Without a customer id the user cannot be looked up, and
+     * letting that fail turned a successful password change into "password could not be changed" on screen.
+     */
+    @Test
+    public void testFindEmailWithoutCustomerIdReturnsNull() {
+        final var queryWithoutRecord = PasswordManagementQuery.builder().username(EMAIL).build();
+
+        assertNull(service.findEmail(queryWithoutRecord));
+        verify(casApi, never()).getUser(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/webflow/actions/TerminateApiSessionActionTest.java
+++ b/cas/cas-server/src/test/java/fr/gouv/vitamui/cas/webflow/actions/TerminateApiSessionActionTest.java
@@ -6,12 +6,13 @@ import fr.gouv.vitamui.cas.util.Utils;
 import fr.gouv.vitamui.iam.openapiclient.CasApi;
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.Authentication;
+import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.logout.LogoutProperties;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.logout.slo.SingleLogoutRequestContext;
-import org.apereo.cas.services.RegexRegisteredService;
+import org.apereo.cas.services.CasRegisteredService;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
@@ -19,7 +20,6 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
 import org.junit.Assert;
 import org.junit.Test;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.webflow.execution.Action;
@@ -47,7 +47,7 @@ public final class TerminateApiSessionActionTest extends BaseWebflowActionTest {
     public void testPerformGeneralLogout() throws Throwable {
         // Mocker ServicesManager
         final ServicesManager servicesManager = mock(ServicesManager.class);
-        RegexRegisteredService registeredService = new RegexRegisteredService();
+        CasRegisteredService registeredService = new CasRegisteredService();
         registeredService.setLogoutUrl(LOGOUT_URL);
         when(servicesManager.getAllServices()).thenReturn(List.of(registeredService));
 
@@ -65,6 +65,8 @@ public final class TerminateApiSessionActionTest extends BaseWebflowActionTest {
         final TicketRegistry ticketRegistry = mock(TicketRegistry.class);
         final Utils utils = mock(Utils.class);
         final CasApi casApi = mock(CasApi.class);
+        final ServiceFactory<WebApplicationService> webApplicationServiceFactory = mock(ServiceFactory.class);
+        when(webApplicationServiceFactory.createService(anyString())).thenReturn(mock(WebApplicationService.class));
 
         // Créer l'action avec les mocks
         final TestableTerminateApiSessionAction action = new TestableTerminateApiSessionAction(
@@ -73,13 +75,13 @@ public final class TerminateApiSessionActionTest extends BaseWebflowActionTest {
             warnCookie,
             casProperties.getLogout(),
             logoutManager,
-            mock(ConfigurableApplicationContext.class),
             utils,
             casApi,
             servicesManager,
             casProperties,
             frontChannelLogoutAction,
-            ticketRegistry
+            ticketRegistry,
+            webApplicationServiceFactory
         );
 
         // Mocker le TGT factice et le ST pour CAS 7
@@ -109,13 +111,13 @@ public final class TerminateApiSessionActionTest extends BaseWebflowActionTest {
             CasCookieBuilder warnCookie,
             LogoutProperties logoutProps,
             LogoutManager logoutManager,
-            ConfigurableApplicationContext ctx,
             Utils utils,
             CasApi casApi,
             ServicesManager servicesManager,
             CasConfigurationProperties casProperties,
             Action frontChannelLogoutAction,
-            TicketRegistry ticketRegistry
+            TicketRegistry ticketRegistry,
+            ServiceFactory<WebApplicationService> webApplicationServiceFactory
         ) {
             super(
                 cas,
@@ -123,14 +125,15 @@ public final class TerminateApiSessionActionTest extends BaseWebflowActionTest {
                 warnCookie,
                 logoutProps,
                 logoutManager,
-                ctx,
                 utils,
                 casApi,
                 servicesManager,
                 casProperties,
                 frontChannelLogoutAction,
                 ticketRegistry,
-                null
+                null,
+                null,
+                webApplicationServiceFactory
             );
         }
 

--- a/deployment/roles/vitamui/templates/cas-server/application.yml.j2
+++ b/deployment/roles/vitamui/templates/cas-server/application.yml.j2
@@ -83,6 +83,13 @@ cas.webflow.crypto:
   enabled: true
   encryption.key-size: 128
 cas.authn.pm.reset.crypto.enabled: true
+# CAS 7.3.5 turned encryption off by default for the session-replication cookies. Their value is then written
+# in clear as "<TST id>@<client ip>@<user agent>", and the semicolons of the user agent truncate the cookie at
+# the first one, per RFC 6265. CAS can no longer match the pinned user agent, drops the session, and therefore
+# cannot restore the pending OIDC authorization request: the login flow redirects to the client with no code
+# and loops. Encrypting the value keeps it opaque and free of semicolons.
+cas.authn.oauth.session-replication.cookie.crypto.enabled: true
+cas.authn.pac4j.core.session-replication.cookie.crypto.enabled: true
 
 ##
 # CAS Web Application Session Configuration
@@ -126,6 +133,10 @@ cas.authn.pm.reset.mail.attribute-name: email
 cas.authn.pm.reset.security-questions-enabled: false
 cas.authn.pm.reset.include-server-ip-address: false
 cas.authn.pm.reset.include-client-ip-address: false
+# CAS 7.3 implements this property, which 7.0 declared but ignored: password reset now routes through MFA using
+# any registered provider. With the simple SMS provider registered, accounts without a mobile number could no
+# longer reset their password at all.
+cas.authn.pm.reset.multifactor-authentication-enabled: false
 cas.authn.pm.core.auto-login: true
 
 # Used to sign/encrypt the password-reset link


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the CAS server to CAS 7.3.8 and Spring Boot 3.5.6.
  - Password changes during login now require the current password.
  - Actuator endpoints now use explicit access controls; health, metrics, and Prometheus remain unrestricted.
  - Enabled encrypted session-replication cookies to support OIDC login flow restoration.
  - Added German text for the current-password field.

- **Bug Fixes**
  - Password-reset flows no longer trigger multifactor authentication.
  - Password lookup safely handles accounts without a customer identifier.
  - Improved delegated authentication and logout compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->