### PR TITLE
Story #16344 : [Archive-search] Add the Archive Unit History tab.

### DIFF
--- a/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/rest/RestApi.java
+++ b/api/api-archive-search/archive-search-commons/src/main/java/fr/gouv/vitamui/archives/search/common/rest/RestApi.java
@@ -64,4 +64,7 @@ public class RestApi {
 
     public static final String PRESERVATION = "/preservation";
     public static final String PRESERVATION_OBJECT_GROUPS_COUNT = "/preservation/object-groups-count";
+
+    public static final String ARCHIVE_UNIT_LIFECYCLES = ARCHIVE_UNIT_INFO + "/unitlifecycles";
+    public static final String OBJECT_GROUP_LIFECYCLES = OBJECTGROUP + "/objectslifecycles";
 }

--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/rest/ArchivesSearchController.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/rest/ArchivesSearchController.java
@@ -60,6 +60,7 @@ import fr.gouv.vitamui.commons.api.dtos.VitamUiOntologyDto;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.rest.util.RestUtils;
+import fr.gouv.vitamui.commons.vitam.api.dto.LogbookLifeCycleResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.PersistentIdentifierResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.ResultsDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.VitamUISearchResponseDto;
@@ -251,6 +252,26 @@ public class ArchivesSearchController {
         SanityChecker.checkSecureParameter(id);
         LOGGER.debug("Find a ObjectGroup by id {} ", id);
         return archiveSearchService.findObjectById(id);
+    }
+
+    @GetMapping(RestApi.ARCHIVE_UNIT_LIFECYCLES + CommonConstants.PATH_ID)
+    @Secured(ServicesData.ARCHIVE_SEARCH_GET_ARCHIVE_SEARCH_ROLE)
+    public LogbookLifeCycleResponseDto findUnitLifeCyclesByUnitId(final @PathVariable("id") String id)
+        throws PreconditionFailedException, VitamClientException, InvalidParseOperationException {
+        ParameterChecker.checkParameter(MANDATORY_IDENTIFIER, id);
+        SanityChecker.checkSecureParameter(id);
+        LOGGER.debug("Find the unit lifecycle logbook for unit id {} ", id);
+        return archiveSearchService.findUnitLifeCyclesByUnitId(id);
+    }
+
+    @GetMapping(RestApi.OBJECT_GROUP_LIFECYCLES + CommonConstants.PATH_ID)
+    @Secured(ServicesData.ARCHIVE_SEARCH_GET_ARCHIVE_SEARCH_ROLE)
+    public LogbookLifeCycleResponseDto findObjectGroupLifeCyclesByUnitId(final @PathVariable("id") String id)
+        throws PreconditionFailedException, VitamClientException, InvalidParseOperationException {
+        ParameterChecker.checkParameter(MANDATORY_IDENTIFIER, id);
+        SanityChecker.checkSecureParameter(id);
+        LOGGER.debug("Find the object group lifecycle logbook for object group id {} ", id);
+        return archiveSearchService.findObjectGroupLifeCyclesByUnitId(id);
     }
 
     @PostMapping(RestApi.EXPORT_CSV_SEARCH_PATH)

--- a/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/service/ArchiveSearchService.java
+++ b/api/api-archive-search/archive-search/src/main/java/fr/gouv/vitamui/archives/search/server/service/ArchiveSearchService.java
@@ -72,6 +72,7 @@ import fr.gouv.vitamui.commons.api.dtos.TermsFacet;
 import fr.gouv.vitamui.commons.api.dtos.VitamUiOntologyDto;
 import fr.gouv.vitamui.commons.api.exception.BadRequestException;
 import fr.gouv.vitamui.commons.api.exception.InternalServerException;
+import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.exception.UnexpectedDataException;
 import fr.gouv.vitamui.commons.api.exception.UnexpectedSettingsException;
 import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
@@ -79,6 +80,7 @@ import fr.gouv.vitamui.commons.api.utils.OntologyServiceReader;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.access.PersistentIdentifierService;
 import fr.gouv.vitamui.commons.vitam.api.access.UnitCommonService;
+import fr.gouv.vitamui.commons.vitam.api.dto.LogbookLifeCycleResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.LogbookOperationsCommonResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.PersistentIdentifierResponseDto;
@@ -618,6 +620,36 @@ public class ArchiveSearchService {
             .collect(Collectors.toSet());
 
         return operationIds.stream().collect(Collectors.toMap(id -> id, existingOperationIds::contains));
+    }
+
+    /**
+     * Retrieve the lifecycle logbook of an archive unit.
+     *
+     * @param unitId the archive unit identifier
+     * @return the unit lifecycle logbook
+     */
+    public LogbookLifeCycleResponseDto findUnitLifeCyclesByUnitId(String unitId)
+        throws VitamClientException, PreconditionFailedException {
+        VitamContext vitamContext = externalParametersService.buildVitamContextFromExternalParam();
+        return VitamRestUtils.responseMapping(
+            logbookService.findUnitLifeCyclesByUnitId(unitId, vitamContext).toJsonNode(),
+            LogbookLifeCycleResponseDto.class
+        );
+    }
+
+    /**
+     * Retrieve the lifecycle logbook of an object group.
+     *
+     * @param objectGroupId the object group identifier
+     * @return the object group lifecycle logbook
+     */
+    public LogbookLifeCycleResponseDto findObjectGroupLifeCyclesByUnitId(String objectGroupId)
+        throws VitamClientException, PreconditionFailedException {
+        VitamContext vitamContext = externalParametersService.buildVitamContextFromExternalParam();
+        return VitamRestUtils.responseMapping(
+            logbookService.findObjectGroupLifeCyclesByUnitId(objectGroupId, vitamContext).toJsonNode(),
+            LogbookLifeCycleResponseDto.class
+        );
     }
 
     private JsonNode buildReassignmentDsl(JsonNode searchDsl, Long threshold) {

--- a/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/rest/ArchivesSearchControllerTest.java
+++ b/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/rest/ArchivesSearchControllerTest.java
@@ -51,6 +51,7 @@ import fr.gouv.vitamui.commons.api.dtos.SearchCriteriaEltDto;
 import fr.gouv.vitamui.commons.api.dtos.VitamUiOntologyDto;
 import fr.gouv.vitamui.commons.api.exception.PreconditionFailedException;
 import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
+import fr.gouv.vitamui.commons.vitam.api.dto.LogbookLifeCycleResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.PersistentIdentifierResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.ResultsDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.VitamUISearchResponseDto;
@@ -360,6 +361,42 @@ class ArchivesSearchControllerTest extends ApiArchiveSearchControllerTest<IdDto>
 
         // Then
         verify(archiveSearchService, times(1)).findObjectsByPersistentIdentifier(arkId);
+        assertEquals(response, expectedResponse);
+    }
+
+    @Test
+    void testFindUnitLifeCyclesByUnitId()
+        throws PreconditionFailedException, VitamClientException, InvalidParseOperationException {
+        // Given
+        final String unitId = "aeaqaaaaa4ecgoguawzpoam6kaj6m3yaaaca";
+        final LogbookLifeCycleResponseDto expectedResponse = new LogbookLifeCycleResponseDto();
+
+        // When
+        Mockito.when(archiveSearchService.findUnitLifeCyclesByUnitId(unitId)).thenReturn(expectedResponse);
+        final LogbookLifeCycleResponseDto response = archivesSearchController.findUnitLifeCyclesByUnitId(unitId);
+
+        // Then
+        verify(archiveSearchService, times(1)).findUnitLifeCyclesByUnitId(unitId);
+        assertEquals(response, expectedResponse);
+    }
+
+    @Test
+    void testFindObjectGroupLifeCyclesByUnitId()
+        throws PreconditionFailedException, VitamClientException, InvalidParseOperationException {
+        // Given
+        final String objectGroupId = "aebqaaaaacec2k2dac3ssam7lpe5k4qaaaba";
+        final LogbookLifeCycleResponseDto expectedResponse = new LogbookLifeCycleResponseDto();
+
+        // When
+        Mockito.when(archiveSearchService.findObjectGroupLifeCyclesByUnitId(objectGroupId)).thenReturn(
+            expectedResponse
+        );
+        final LogbookLifeCycleResponseDto response = archivesSearchController.findObjectGroupLifeCyclesByUnitId(
+            objectGroupId
+        );
+
+        // Then
+        verify(archiveSearchService, times(1)).findObjectGroupLifeCyclesByUnitId(objectGroupId);
         assertEquals(response, expectedResponse);
     }
 }

--- a/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/service/ArchiveSearchServiceTest.java
+++ b/api/api-archive-search/archive-search/src/test/java/fr/gouv/vitamui/archives/search/server/service/ArchiveSearchServiceTest.java
@@ -47,6 +47,7 @@ import fr.gouv.vitam.common.exception.VitamClientException;
 import fr.gouv.vitam.common.json.JsonHandler;
 import fr.gouv.vitam.common.model.RequestResponse;
 import fr.gouv.vitam.common.model.RequestResponseOK;
+import fr.gouv.vitam.common.model.logbook.LogbookLifecycle;
 import fr.gouv.vitam.common.model.logbook.LogbookOperation;
 import fr.gouv.vitamui.archives.search.common.dto.ReassignRequestDto;
 import fr.gouv.vitamui.archives.search.common.dto.ReassignmentMode;
@@ -60,6 +61,7 @@ import fr.gouv.vitamui.commons.api.utils.ArchiveSearchConsts;
 import fr.gouv.vitamui.commons.vitam.api.access.LogbookService;
 import fr.gouv.vitamui.commons.vitam.api.access.PersistentIdentifierService;
 import fr.gouv.vitamui.commons.vitam.api.access.UnitCommonService;
+import fr.gouv.vitamui.commons.vitam.api.dto.LogbookLifeCycleResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.PersistentIdentifierResponseDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.ResultsDto;
 import fr.gouv.vitamui.commons.vitam.api.dto.VitamUISearchResponseDto;
@@ -136,6 +138,8 @@ class ArchiveSearchServiceTest {
     public final String LOGBOOK_OPERATIONS_NON_INGEST_RESPONSE = "data/logbook_operations_non_ingest_response.json";
     public final String LOGBOOK_OPERATIONS_INGEST_RESPONSE = "data/logbook_operations_ingest_response.json";
     public final String LOGBOOK_OPERATIONS_EMPTY_RESPONSE = "data/logbook_operations_empty_response.json";
+    public final String LOGBOOK_UNIT_LIFECYCLE_RESPONSE = "data/logbook_unit_lifecycle_response.json";
+    public final String LOGBOOK_OBJECT_GROUP_LIFECYCLE_RESPONSE = "data/logbook_object_group_lifecycle_response.json";
 
     @BeforeEach
     public void setUp() {
@@ -196,6 +200,18 @@ class ArchiveSearchServiceTest {
             objectMapper.readValue(ByteStreams.toByteArray(inputStream), JsonNode.class)
         );
         return (RequestResponse<LogbookOperation>) (RequestResponse<?>) response;
+    }
+
+    @SuppressWarnings("unchecked")
+    private RequestResponse<LogbookLifecycle> responseFromFileLifecycle(String filename) throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        InputStream inputStream = ArchiveSearchServiceTest.class.getClassLoader().getResourceAsStream(filename);
+        assertThat(inputStream).isNotNull();
+        RequestResponse<JsonNode> response = RequestResponseOK.getFromJsonNode(
+            objectMapper.readValue(ByteStreams.toByteArray(inputStream), JsonNode.class)
+        );
+        return (RequestResponse<LogbookLifecycle>) (RequestResponse<?>) response;
     }
 
     @Test
@@ -833,5 +849,39 @@ class ArchiveSearchServiceTest {
         searchCriteria.setPageNumber(pageNumber);
         searchCriteria.setSize(size);
         return searchCriteria;
+    }
+
+    @Test
+    void shouldReturnUnitLifeCyclesWhenFindUnitLifeCyclesByUnitId() throws Exception {
+        // Given
+        String unitId = "aeaqaaaaa4ecgoguawzpoam6kaj6m3yaaaca";
+        when(logbookService.findUnitLifeCyclesByUnitId(eq(unitId), eq(defaultVitamContext))).thenReturn(
+            responseFromFileLifecycle(LOGBOOK_UNIT_LIFECYCLE_RESPONSE)
+        );
+
+        // When
+        LogbookLifeCycleResponseDto response = archiveSearchService.findUnitLifeCyclesByUnitId(unitId);
+
+        // Then
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().getFirst().getEvents()).hasSize(1);
+        assertThat(response.getResults().getFirst().getEvents().getFirst().getEvType()).isEqualTo("LFC.LFC_CREATION");
+    }
+
+    @Test
+    void shouldReturnObjectGroupLifeCyclesWhenFindObjectGroupLifeCyclesByUnitId() throws Exception {
+        // Given
+        String objectGroupId = "aebqaaaaacec2k2dac3ssam7lpe5k4qaaaba";
+        when(logbookService.findObjectGroupLifeCyclesByUnitId(eq(objectGroupId), eq(defaultVitamContext))).thenReturn(
+            responseFromFileLifecycle(LOGBOOK_OBJECT_GROUP_LIFECYCLE_RESPONSE)
+        );
+
+        // When
+        LogbookLifeCycleResponseDto response = archiveSearchService.findObjectGroupLifeCyclesByUnitId(objectGroupId);
+
+        // Then
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().getFirst().getEvents()).hasSize(1);
+        assertThat(response.getResults().getFirst().getEvents().getFirst().getEvType()).isEqualTo("LFC.LFC_CREATION");
     }
 }

--- a/api/api-archive-search/archive-search/src/test/resources/data/logbook_object_group_lifecycle_response.json
+++ b/api/api-archive-search/archive-search/src/test/resources/data/logbook_object_group_lifecycle_response.json
@@ -1,0 +1,36 @@
+{
+  "$hits": {
+    "total": 1,
+    "offset": 0,
+    "limit": 1,
+    "size": 1
+  },
+  "$results": [
+    {
+      "_id": "aebqaaaaacec2k2dac3ssam7lpe5k4qaaaba",
+      "_tenant": 1,
+      "_v": 0,
+      "evId": "aedqaaaaa6ecgoguawzpoam6kaj6pvqaaaaq",
+      "evType": "LFC.LFC_CREATION",
+      "evTypeProc": "INGEST",
+      "evDateTime": "2026-07-24T12:16:04.180",
+      "outcome": "OK",
+      "outDetail": "LFC.LFC_CREATION.OK",
+      "outMessg": "Succès de l'alimentation du journal du cycle de vie",
+      "events": [
+        {
+          "evId": "aedqaaaaa6ecgoguawzpoam6kaj6pvqaaaaq",
+          "evParentId": null,
+          "evType": "LFC.LFC_CREATION",
+          "evTypeProc": "INGEST",
+          "evDateTime": "2026-07-24T12:16:04.180",
+          "outcome": "OK",
+          "outDetail": "LFC.LFC_CREATION.OK",
+          "outMessg": "Succès de l'alimentation du journal du cycle de vie"
+        }
+      ]
+    }
+  ],
+  "$facetResults": [],
+  "$context": {}
+}

--- a/api/api-archive-search/archive-search/src/test/resources/data/logbook_unit_lifecycle_response.json
+++ b/api/api-archive-search/archive-search/src/test/resources/data/logbook_unit_lifecycle_response.json
@@ -1,0 +1,36 @@
+{
+  "$hits": {
+    "total": 1,
+    "offset": 0,
+    "limit": 1,
+    "size": 1
+  },
+  "$results": [
+    {
+      "_id": "aeaqaaaaa4ecgoguawzpoam6kaj6m3yaaaca",
+      "_tenant": 1,
+      "_v": 0,
+      "evId": "aedqaaaaa6ecgoguawzpoam6kaj6pvqaaaaq",
+      "evType": "LFC.LFC_CREATION",
+      "evTypeProc": "INGEST",
+      "evDateTime": "2026-07-24T12:16:04.180",
+      "outcome": "OK",
+      "outDetail": "LFC.LFC_CREATION.OK",
+      "outMessg": "Succès de l'alimentation du journal du cycle de vie",
+      "events": [
+        {
+          "evId": "aedqaaaaa6ecgoguawzpoam6kaj6pvqaaaaq",
+          "evParentId": null,
+          "evType": "LFC.LFC_CREATION",
+          "evTypeProc": "INGEST",
+          "evDateTime": "2026-07-24T12:16:04.180",
+          "outcome": "OK",
+          "outDetail": "LFC.LFC_CREATION.OK",
+          "outMessg": "Succès de l'alimentation du journal du cycle de vie"
+        }
+      ]
+    }
+  ],
+  "$facetResults": [],
+  "$context": {}
+}

--- a/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/dto/LogbookLifecycleDto.java
+++ b/commons/commons-vitam/src/main/java/fr/gouv/vitamui/commons/vitam/api/dto/LogbookLifecycleDto.java
@@ -37,9 +37,15 @@
 package fr.gouv.vitamui.commons.vitam.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.util.List;
 
+@Getter
+@Setter
+@ToString(callSuper = true)
 public class LogbookLifecycleDto extends LogbookEventDto {
 
     @JsonProperty("_id")

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.html
@@ -51,5 +51,9 @@
     <mat-tab label="{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.TABS.OBJECTS' | translate }}">
       <app-archive-unit-objects-details-tab [archiveUnit]="archiveUnit"> </app-archive-unit-objects-details-tab>
     </mat-tab>
+
+    <mat-tab label="{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.TABS.HISTORY' | translate }}">
+      <app-archive-unit-history-tab [archiveUnit]="archiveUnit"> </app-archive-unit-history-tab>
+    </mat-tab>
   </mat-tab-group>
 </div>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.spec.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.spec.ts
@@ -227,13 +227,13 @@ describe('ArchivePreviewComponent', () => {
   });
 
   describe('DOM', () => {
-    it('should have 4 mat-tab', () => {
+    it('should have 5 mat-tab', () => {
       // When
       const nativeElement = fixture.nativeElement;
       const matTabElements = nativeElement.querySelectorAll('mat-tab');
 
       // Then
-      expect(matTabElements.length).toEqual(4);
+      expect(matTabElements.length).toEqual(5);
     });
 
     it('should have 1 mat-tab-group', () => {

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-preview.component.ts
@@ -113,19 +113,9 @@ export class ArchivePreviewComponent implements OnChanges, OnInit, AfterViewInit
   }
 
   selectedTabChangeEvent($event: MatTabChangeEvent) {
-    switch ($event.index) {
-      case 0:
-        this.isPanelextended = false;
-        this.backToNormalLateralPanel.emit();
-        break;
-      case 1:
-      case 2:
-      case 3:
-        this.isPanelextended = true;
-        this.showExtendedLateralPanel.emit();
-        break;
-    }
+    this.isPanelextended = $event.index !== 0;
     this.selectedIndex = $event.index;
+    (this.isPanelextended ? this.showExtendedLateralPanel : this.backToNormalLateralPanel).emit();
   }
 
   @HostListener('window:beforeunload', ['$event'])

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-history-tab.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-history-tab.component.html
@@ -1,0 +1,112 @@
+<div class="archive-unit-history-tab">
+  <h5 class="history-title">{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.TITLE' | translate }}</h5>
+
+  @if (loading()) {
+    <mat-progress-spinner mode="indeterminate" diameter="32"></mat-progress-spinner>
+  }
+
+  @if (!loading() && !operationGroups().length) {
+    <p class="no-history">{{ 'COMMON.HISTORY.NO_HISTORY' | translate }}</p>
+  }
+
+  @if (!loading() && operationGroups().length) {
+    <div class="vitamui-table">
+      <div class="vitamui-table-head">
+        <div class="col-4 d-flex align-items-center hgap-2">
+          {{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.OPERATION_COLUMN' | translate }}
+
+          <button
+            class="vitamui-filter-button"
+            [vitamuiCommonTableFilter]="operationTypeFilterTemplate"
+            #operationTypeFilterTrigger="vitamuiCommonTableFilter"
+            [class.active]="operationTypeFilter().length > 0"
+          >
+            <i class="material-icons vitamui-row-icon">filter_list</i>
+          </button>
+        </div>
+        <div class="col-7 d-flex align-items-start">
+          {{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.EVENT_COLUMN' | translate }}
+        </div>
+        <div class="col d-flex align-items-center hgap-2">
+          {{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.JOURNAL_COLUMN' | translate }}
+
+          <button
+            class="vitamui-filter-button"
+            [vitamuiCommonTableFilter]="journalFilterTemplate"
+            #journalFilterTrigger="vitamuiCommonTableFilter"
+            [class.active]="originFilter().length > 0"
+          >
+            <i class="material-icons vitamui-row-icon">filter_list</i>
+          </button>
+        </div>
+      </div>
+
+      <div class="vitamui-table-rows mt-4">
+        @for (group of filteredOperationGroups(); track group.evIdProc; let lastGroup = $last) {
+          <div class="d-flex no-hover">
+            <div class="col-4 operation-group-column">
+              <span class="text normal bold">
+                <vitamui-common-event-type-label [key]="group.evTypeProc"></vitamui-common-event-type-label>
+              </span>
+              <div class="operation-id-row">
+                <span
+                  class="text medium operation-id"
+                  [vitamuiTooltip]="'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.ACCESS_OPERATIONS_LOG' | translate"
+                  [outline]="true"
+                  vitamuiTooltipClass="secondary"
+                >
+                  @if (getOperationLogbookUrl(group.evIdProc)) {
+                    <a [href]="getOperationLogbookUrl(group.evIdProc)" target="_blank" rel="noopener">{{ group.evIdProc }}</a>
+                  } @else {
+                    {{ group.evIdProc }}
+                  }
+                </span>
+                <button
+                  type="button"
+                  class="btn btn-circle link primary xsmall d-inline-block ml-1"
+                  [vitamuiTooltip]="'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.COPY' | translate"
+                  [outline]="true"
+                  vitamuiTooltipClass="secondary"
+                  (click)="copyToClipboard(group.evIdProc)"
+                >
+                  <i class="vitamui-icon vitamui-icon-content-copy"></i>
+                </button>
+              </div>
+            </div>
+            <div class="col-8 event-column">
+              @for (event of group.events; track event.evId; let firstEvent = $first; let lastEvent = $last) {
+                <app-lifecycle-event-node
+                  [event]="event"
+                  [isFirstInList]="firstEvent"
+                  [isLastInList]="lastEvent"
+                  [bridgeToNextRow]="lastEvent && !lastGroup"
+                ></app-lifecycle-event-node>
+              }
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
+</div>
+
+<ng-template #operationTypeFilterTemplate>
+  <vitamui-common-table-filter [(filter)]="operationTypeFilter">
+    @for (operationType of availableOperationTypes(); track operationType) {
+      <vitamui-common-table-filter-option [value]="operationType">
+        <vitamui-common-event-type-label [key]="operationType"></vitamui-common-event-type-label>
+      </vitamui-common-table-filter-option>
+    }
+  </vitamui-common-table-filter>
+</ng-template>
+
+<ng-template #journalFilterTemplate>
+  <vitamui-common-table-filter [(filter)]="originFilter">
+    <vitamui-common-table-filter-option value="UA">
+      {{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.JOURNAL_UNIT' | translate }}
+    </vitamui-common-table-filter-option>
+    <vitamui-common-table-filter-option value="GOT">
+      {{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.JOURNAL_OBJECT_GROUP' | translate }}
+    </vitamui-common-table-filter-option>
+  </vitamui-common-table-filter>
+</ng-template>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-history-tab.component.scss
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-history-tab.component.scss
@@ -1,0 +1,45 @@
+.history-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--vitamui-primary);
+  padding: 5px 0;
+  margin-bottom: 8px;
+}
+
+.no-history {
+  color: var(--vitamui-grey-600);
+}
+
+.operation-group-column {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--vitamui-grey-900);
+}
+
+.operation-id-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  min-width: 0;
+}
+
+.operation-id {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 330px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  a {
+    color: var(--vitamui-secondary);
+  }
+}
+
+.event-column {
+  min-width: 0;
+}

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-history-tab.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-history-tab.component.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Component, computed, effect, inject, input, signal } from '@angular/core';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { catchError, of } from 'rxjs';
+import type { Unit } from 'vitamui-library';
+import { AccessContract, AccessContractService, ApplicationId, ApplicationService, SnackBarService } from 'vitamui-library';
+import { ArchiveUnitLifecycleHistoryService } from './archive-unit-lifecycle-history.service';
+import { LifecycleOrigin, OperationLifecycleGroup } from './archive-unit-lifecycle-history.model';
+
+@Component({
+  selector: 'app-archive-unit-history-tab',
+  templateUrl: './archive-unit-history-tab.component.html',
+  styleUrls: ['./archive-unit-history-tab.component.scss'],
+  standalone: false,
+})
+export class ArchiveUnitHistoryTabComponent {
+  private route = inject(ActivatedRoute);
+  private accessContractService = inject(AccessContractService);
+  private applicationService = inject(ApplicationService);
+  private lifecycleHistoryService = inject(ArchiveUnitLifecycleHistoryService);
+  private clipboard = inject(Clipboard);
+  private snackBarService = inject(SnackBarService);
+
+  archiveUnit = input<Unit>();
+
+  originFilter = signal<LifecycleOrigin[]>([]);
+  operationTypeFilter = signal<string[]>([]);
+
+  private readonly tenantIdentifier = +this.route.snapshot.params['tenantIdentifier'];
+
+  private readonly logError = (e: unknown) => {
+    console.error(e);
+    return of(undefined);
+  };
+
+  private readonly logbookOperationAppUrl = toSignal(
+    this.applicationService
+      .getUrl$({ appId: ApplicationId.LOGBOOK_OPERATION_APP, tenantIdentifier: this.tenantIdentifier })
+      .pipe(catchError(this.logError)),
+  );
+
+  private readonly accessContract = toSignal(this.accessContractService.currentAccessContract$.pipe(catchError(this.logError)));
+
+  private readonly historyResource = rxResource<OperationLifecycleGroup[], { archiveUnit: Unit; accessContract: AccessContract }>({
+    params: () => {
+      const archiveUnit = this.archiveUnit();
+      const accessContract = this.accessContract();
+      return archiveUnit && accessContract ? { archiveUnit, accessContract } : undefined;
+    },
+    stream: ({ params }) =>
+      this.lifecycleHistoryService.getConsolidatedHistory(
+        params.archiveUnit['#id'],
+        params.archiveUnit['#object'] || null,
+        params.accessContract.id,
+        this.tenantIdentifier,
+      ),
+  });
+
+  loading = computed(() => this.historyResource.isLoading());
+
+  operationGroups = computed(() => (this.historyResource.hasValue() ? this.historyResource.value() : []));
+
+  availableOperationTypes = computed(() => Array.from(new Set(this.operationGroups().map((group) => group.evTypeProc))).sort());
+
+  filteredOperationGroups = computed(() => {
+    const operationTypeFilter = this.operationTypeFilter();
+    const originFilter = this.originFilter();
+    return this.operationGroups()
+      .filter((group) => !operationTypeFilter.length || operationTypeFilter.includes(group.evTypeProc))
+      .map((group) => ({
+        ...group,
+        events: group.events.filter((event) => !originFilter.length || originFilter.includes(event.origin)),
+      }))
+      .filter((group) => group.events.length > 0);
+  });
+
+  constructor() {
+    effect(() => {
+      const error = this.historyResource.error();
+      if (error) {
+        console.error(error);
+        this.snackBarService.open({ message: 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.HISTORY.LOAD_ERROR', duration: 10_000 });
+      }
+    });
+  }
+
+  getOperationLogbookUrl(evIdProc: string): string {
+    const logbookOperationAppUrl = this.logbookOperationAppUrl();
+    return logbookOperationAppUrl ? `${logbookOperationAppUrl}?guid=${evIdProc}` : null;
+  }
+
+  copyToClipboard(text: string): void {
+    this.clipboard.copy(text);
+  }
+}

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-lifecycle-history.model.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-lifecycle-history.model.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2020)
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
  * and the signatories of the "VITAM - Accord du Contributeur" agreement.
  *
  * contact@programmevitam.fr
@@ -34,72 +34,38 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-package fr.gouv.vitamui.commons.vitam.api.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import fr.gouv.vitamui.commons.api.domain.IdDto;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+/** Which lifecycle logbook (unit or object group) a raw event was fetched from. */
+export type LifecycleOrigin = 'UA' | 'GOT';
 
-import java.io.Serializable;
+/**
+ * One event (or sub-event) of the consolidated unit/object-group lifecycle history, rebuilt into a tree
+ * from the flat `evParentId` references returned by Vitam.
+ */
+export interface ConsolidatedLifecycleEvent {
+  evId: string;
+  evParentId: string;
+  evType: string;
+  evTypeProc: string;
+  evIdProc: string;
+  evDateTime: string;
+  outcome: string;
+  outDetail: string;
+  outMessg: string;
+  origin: LifecycleOrigin;
+  /** Parsed JSON content of evDetData, or null if evDetData is empty or not valid JSON. */
+  parsedDetail: unknown;
+  /** Raw evDetData content, kept as a fallback when it cannot be parsed as JSON. */
+  rawDetail: string;
+  hasDetail: boolean;
+  children: ConsolidatedLifecycleEvent[];
+}
 
-@Getter
-@Setter
-@ToString
-public class LogbookEventDto extends IdDto implements Serializable {
-
-    @JsonProperty("evId")
-    private String evId;
-
-    @JsonProperty("evIdReq")
-    private String evIdReq;
-
-    @JsonProperty("evParentId")
-    private String evParentId;
-
-    @JsonProperty("evIdProc")
-    private String evIdProc;
-
-    @JsonProperty("evType")
-    private String evType;
-
-    @JsonProperty("evTypeProc")
-    private String evTypeProc;
-
-    @JsonProperty("evDateTime")
-    private String evDateTime;
-
-    @JsonProperty("outcome")
-    private String outcome;
-
-    @JsonProperty("outDetail")
-    private String outDetail;
-
-    @JsonProperty("outMessg")
-    private String outMessg;
-
-    @JsonProperty("evDetData")
-    private String evDetData;
-
-    @JsonProperty("obId")
-    private String obId;
-
-    @JsonProperty("obIdReq")
-    private String obIdReq;
-
-    @JsonProperty("evIdAppSession")
-    private String evIdAppSession;
-
-    @JsonProperty("agId")
-    private String agId;
-
-    @JsonProperty("agIdApp")
-    private String agIdApp;
-
-    @JsonProperty("agIdExt")
-    private String agIdExt;
-
-    @JsonProperty("rightsStatementIdentifier")
-    private String rightsStatementIdentifier;
+/** One operation (identified by evIdProc/evTypeProc) grouping the lifecycle events it triggered. */
+export interface OperationLifecycleGroup {
+  evTypeProc: string;
+  evIdProc: string;
+  /** Date used to sort operations, taken from their most recent triggering event. */
+  date: string;
+  events: ConsolidatedLifecycleEvent[];
 }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-lifecycle-history.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/archive-unit-lifecycle-history.service.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { HttpHeaders } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, forkJoin, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import type { ApiEvent } from 'vitamui-library';
+import { VitamuiHttpHeaders } from 'vitamui-library';
+import { ArchiveApiService } from '../../../core/api/archive-api.service';
+import { ConsolidatedLifecycleEvent, LifecycleOrigin, OperationLifecycleGroup } from './archive-unit-lifecycle-history.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ArchiveUnitLifecycleHistoryService {
+  private archiveApiService = inject(ArchiveApiService);
+
+  getConsolidatedHistory(
+    unitId: string,
+    objectGroupId: string | null,
+    accessContract: string,
+    tenantIdentifier: number,
+  ): Observable<OperationLifecycleGroup[]> {
+    const headers = new HttpHeaders()
+      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
+      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
+
+    const unitEvents$ = this.fetchLifecycleEvents(this.archiveApiService.getUnitLifecycles(unitId, headers), 'UA');
+    const objectGroupEvents$ = objectGroupId
+      ? this.fetchLifecycleEvents(this.archiveApiService.getObjectGroupLifecycles(objectGroupId, headers), 'GOT')
+      : of([] as (ApiEvent & { origin: LifecycleOrigin })[]);
+
+    return forkJoin([unitEvents$, objectGroupEvents$]).pipe(
+      map(([unitEvents, objectGroupEvents]) => buildConsolidatedHistory([...unitEvents, ...objectGroupEvents])),
+    );
+  }
+
+  private fetchLifecycleEvents(
+    response$: Observable<{ $results: ApiEvent[] }>,
+    origin: LifecycleOrigin,
+  ): Observable<(ApiEvent & { origin: LifecycleOrigin })[]> {
+    return response$.pipe(
+      map((response) => (response?.$results?.length ? response.$results[0].events || [] : [])),
+      map((events) => events.map((event) => ({ ...event, origin }))),
+    );
+  }
+}
+
+/**
+ * Builds the consolidated, 4-level lifecycle history from the flat unit and object-group event arrays.
+ *
+ * Level 1 (returned groups) is derived from evIdProc/evTypeProc; levels 2+ are rebuilt from the
+ * evParentId references within the merged flat list. Nodes are keyed by origin+evId so that a UA
+ * event and a GOT event never collide even if they happen to share the same evId GUID.
+ */
+export function buildConsolidatedHistory(rawEvents: (ApiEvent & { origin: LifecycleOrigin })[]): OperationLifecycleGroup[] {
+  const nodesById = new Map<string, ConsolidatedLifecycleEvent>();
+  const roots: ConsolidatedLifecycleEvent[] = [];
+  const nodeKey = (origin: LifecycleOrigin, evId: string) => `${origin}#${evId}`;
+
+  rawEvents.forEach((rawEvent) => {
+    nodesById.set(nodeKey(rawEvent.origin, rawEvent.evId), toConsolidatedEvent(rawEvent));
+  });
+
+  rawEvents.forEach((rawEvent) => {
+    const node = nodesById.get(nodeKey(rawEvent.origin, rawEvent.evId));
+    const parent = rawEvent.evParentId ? nodesById.get(nodeKey(rawEvent.origin, rawEvent.evParentId)) : null;
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+
+  const groupsByOperation = new Map<string, OperationLifecycleGroup>();
+  roots.forEach((root) => {
+    const key = root.evIdProc || root.evTypeProc;
+    let group = groupsByOperation.get(key);
+    if (!group) {
+      group = { evTypeProc: root.evTypeProc, evIdProc: root.evIdProc, date: root.evDateTime, events: [] };
+      groupsByOperation.set(key, group);
+    }
+    const mostRecentEventDate = findMostRecentEventDate(root);
+    if (mostRecentEventDate > group.date) {
+      group.date = mostRecentEventDate;
+    }
+    group.events.push(root);
+  });
+
+  const groups = Array.from(groupsByOperation.values());
+  groups.forEach((group) => sortEventsByDate(group.events));
+  return groups.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+}
+
+function toConsolidatedEvent(rawEvent: ApiEvent & { origin: LifecycleOrigin }): ConsolidatedLifecycleEvent {
+  const parsedDetail = parseDetail(rawEvent.evDetData);
+  return {
+    evId: rawEvent.evId,
+    evParentId: rawEvent.evParentId,
+    evType: rawEvent.evType,
+    evTypeProc: rawEvent.evTypeProc,
+    evIdProc: rawEvent.evIdProc,
+    evDateTime: rawEvent.evDateTime as unknown as string,
+    outcome: rawEvent.outcome,
+    outDetail: rawEvent.outDetail,
+    outMessg: rawEvent.outMessg,
+    origin: rawEvent.origin,
+    parsedDetail,
+    rawDetail: rawEvent.evDetData,
+    hasDetail: !!rawEvent.evDetData,
+    children: [],
+  };
+}
+
+function parseDetail(evDetData: string): unknown {
+  if (!evDetData) {
+    return null;
+  }
+  try {
+    return JSON.parse(evDetData);
+  } catch {
+    return null;
+  }
+}
+
+function findMostRecentEventDate(event: ConsolidatedLifecycleEvent): string {
+  return event.children.reduce((mostRecent, child) => {
+    const childMostRecent = findMostRecentEventDate(child);
+    return childMostRecent > mostRecent ? childMostRecent : mostRecent;
+  }, event.evDateTime);
+}
+
+function sortEventsByDate(events: ConsolidatedLifecycleEvent[]): void {
+  events.sort((a, b) => (a.evDateTime < b.evDateTime ? -1 : a.evDateTime > b.evDateTime ? 1 : 0));
+  events.forEach((event) => sortEventsByDate(event.children));
+}

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.html
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.html
@@ -1,0 +1,52 @@
+<div
+  class="lifecycle-event-item"
+  [class.event-error]="isKo()"
+  [class.event-warning]="isWarning()"
+  [class.no-line]="suppressLine()"
+  [class.no-incoming-line]="isFirstInList()"
+  [class.bridge-row]="bridgeRow()"
+  [class.has-visible-children]="hasVisibleChildren()"
+>
+  <div class="lifecycle-event">
+    <div class="lifecycle-event-main">
+      <div class="lifecycle-event-date">{{ event().evDateTime | dateTime: 'dd/MM/yyyy - HH:mm:ss' }}</div>
+
+      <div class="lifecycle-event-title">
+        @if (event().children.length) {
+          <button type="button" class="lifecycle-event-chevron" (click)="toggleChildren()" [attr.aria-expanded]="childrenExpanded()">
+            <i class="material-icons">{{ childrenExpanded() ? 'expand_more' : 'chevron_right' }}</i>
+          </button>
+        }
+        <vitamui-common-event-type-label [key]="event().evType"></vitamui-common-event-type-label>
+      </div>
+
+      @if (isWarning() || isKo()) {
+        <div class="lifecycle-event-message">{{ event().outMessg }}</div>
+      }
+
+      @if (hasMeaningfulDetail()) {
+        <button type="button" class="lifecycle-event-detail-toggle" (click)="toggleDetail()">
+          <i class="material-icons">{{ detailExpanded() ? 'expand_more' : 'chevron_right' }}</i>
+          <span>{{ 'ARCHIVE_SEARCH.ARCHIVE_UNIT_PREVIEW.FIELDS.SHOW_HIDE_DETAIL' | translate }}</span>
+        </button>
+        @if (detailExpanded()) {
+          <div class="lifecycle-event-details">{{ detailText() }}</div>
+        }
+      }
+    </div>
+
+    <div class="text medium col-1">{{ event().origin }}</div>
+  </div>
+
+  @if (childrenExpanded()) {
+    <div class="lifecycle-event-children">
+      @for (child of event().children; track child.evId; let lastChild = $last) {
+        <app-lifecycle-event-node
+          [event]="child"
+          [isLastInList]="lastChild"
+          [bridgeToNextRow]="lastChild && childBridgeToNextRow()"
+        ></app-lifecycle-event-node>
+      }
+    </div>
+  }
+</div>

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.scss
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.scss
@@ -1,0 +1,188 @@
+.lifecycle-event-item {
+  overflow: hidden;
+  position: relative;
+  padding: 0 0 16px 35px;
+  left: 8px;
+  font-size: 12px;
+  border-color: var(--vitamui-primary);
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 7px;
+    top: 9px;
+    width: 0;
+    height: 100%;
+    border-color: var(--vitamui-primary);
+    border-style: solid;
+    border-width: 1px 0 0 1px;
+  }
+
+  &.no-line::before {
+    border-width: 0 0 0 0;
+  }
+
+  &.bridge-row {
+    overflow: visible;
+
+    &::before {
+      height: calc(100% + 1.9rem);
+    }
+  }
+
+  // trailing gap is handed off to the last child instead (see .lifecycle-event-children)
+  &.has-visible-children {
+    padding-bottom: 0;
+  }
+
+  // direct-child combinator: avoids also matching a nested child's own title
+  &.event-warning > .lifecycle-event .lifecycle-event-title::before {
+    background: var(--vitamui-orange);
+    border-color: var(--vitamui-orange);
+  }
+
+  &.event-error > .lifecycle-event .lifecycle-event-title::before {
+    background: var(--vitamui-red);
+    border-color: var(--vitamui-red);
+  }
+
+  &.no-incoming-line > .lifecycle-event .lifecycle-event-date::after,
+  &.no-incoming-line > .lifecycle-event .lifecycle-event-title::after {
+    border-width: 0 0 0 0;
+  }
+
+  &.no-incoming-line::before {
+    top: 22px;
+  }
+
+  // cancels the item's own indent so nested dots stay on the shared timeline column
+  .lifecycle-event-children & {
+    left: 0;
+  }
+}
+
+.lifecycle-event {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.lifecycle-event-date {
+  position: relative;
+  color: var(--vitamui-grey-600);
+  font-weight: 400;
+
+  // first half of the incoming line, continued by .lifecycle-event-title below
+  &::after {
+    content: '';
+    position: absolute;
+    left: -28px;
+    top: 0;
+    width: 0;
+    height: 100%;
+    border-color: var(--vitamui-primary);
+    border-style: solid;
+    border-width: 1px 0 0 1px;
+  }
+}
+
+.lifecycle-event-title {
+  position: relative;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--vitamui-grey-900);
+
+  // the timeline dot; z-index needed or the ::after line paints over it
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: 1;
+    left: -35px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    background: var(--vitamui-white);
+    border: 2px solid var(--vitamui-primary);
+    border-radius: 50%;
+  }
+
+  // second half of the incoming line, down to the dot's vertical center
+  &::after {
+    content: '';
+    position: absolute;
+    left: -28px;
+    top: 0;
+    width: 0;
+    height: 50%;
+    border-color: var(--vitamui-primary);
+    border-style: solid;
+    border-width: 0 0 0 1px;
+  }
+}
+
+.lifecycle-event-chevron {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-right: 2px;
+  margin-left: -4px;
+  cursor: pointer;
+  color: var(--vitamui-grey-900);
+
+  i {
+    font-size: 20px;
+  }
+}
+
+.lifecycle-event-message {
+  font-weight: 400;
+}
+
+.event-warning .lifecycle-event-message {
+  color: var(--vitamui-orange);
+}
+
+.event-error .lifecycle-event-message {
+  color: var(--vitamui-red);
+}
+
+.lifecycle-event-detail-toggle {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-top: 2px;
+  margin-left: -4px;
+  color: var(--vitamui-secondary);
+  cursor: pointer;
+  font-size: 12px;
+
+  span {
+    text-decoration: underline;
+  }
+
+  i {
+    font-size: 18px;
+  }
+}
+
+.lifecycle-event-details {
+  color: var(--vitamui-grey-900);
+  font-weight: 400;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  padding-right: 8px;
+  margin-top: 4px;
+}
+
+.lifecycle-event-children {
+  margin-top: 8px;
+  margin-left: -35px;
+}

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.spec.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
+ * and the signatories of the "VITAM - Accord du Contributeur" agreement.
+ *
+ * contact@programmevitam.fr
+ *
+ * This software is a computer program whose purpose is to implement
+ * implement a digital archiving front-office system for the secure and
+ * efficient high volumetry VITAM solution.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+import { NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LifecycleEventNodeComponent } from './lifecycle-event-node.component';
+import { ConsolidatedLifecycleEvent } from '../archive-unit-lifecycle-history.model';
+
+@Pipe({
+  name: 'dateTime',
+  standalone: false,
+})
+class DateTimeStubPipe implements PipeTransform {
+  transform(value: string = ''): string {
+    return value;
+  }
+}
+
+@Pipe({
+  name: 'translate',
+  standalone: false,
+})
+class TranslateStubPipe implements PipeTransform {
+  transform(value: string = ''): string {
+    return value;
+  }
+}
+
+function event(partial: Partial<ConsolidatedLifecycleEvent>): ConsolidatedLifecycleEvent {
+  return {
+    evId: 'ev1',
+    evParentId: null,
+    evType: 'LFC.LFC_CREATION',
+    evTypeProc: 'INGEST',
+    evIdProc: 'op1',
+    evDateTime: '2026-07-24T12:16:04.167',
+    outcome: 'OK',
+    outDetail: 'LFC.LFC_CREATION.OK',
+    outMessg: 'Succès',
+    origin: 'UA',
+    parsedDetail: null,
+    rawDetail: null,
+    hasDetail: false,
+    children: [],
+    ...partial,
+  };
+}
+
+describe('LifecycleEventNodeComponent', () => {
+  let fixture: ComponentFixture<LifecycleEventNodeComponent>;
+  let component: LifecycleEventNodeComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LifecycleEventNodeComponent, DateTimeStubPipe, TranslateStubPipe],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LifecycleEventNodeComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should not flag OK events as warning or error', () => {
+    fixture.componentRef.setInput('event', event({ outcome: 'OK' }));
+    expect(component.isWarning()).toBe(false);
+    expect(component.isKo()).toBe(false);
+  });
+
+  it('should flag WARNING events', () => {
+    fixture.componentRef.setInput('event', event({ outcome: 'WARNING' }));
+    expect(component.isWarning()).toBe(true);
+    expect(component.isKo()).toBe(false);
+  });
+
+  it('should flag KO and FATAL events as errors', () => {
+    fixture.componentRef.setInput('event', event({ outcome: 'KO' }));
+    expect(component.isKo()).toBe(true);
+
+    fixture.componentRef.setInput('event', event({ outcome: 'FATAL' }));
+    expect(component.isKo()).toBe(true);
+  });
+
+  it('should start collapsed', () => {
+    fixture.componentRef.setInput('event', event({ children: [event({ evId: 'child' })] }));
+    expect(component.childrenExpanded()).toBe(false);
+    expect(component.detailExpanded()).toBe(false);
+  });
+
+  describe('hasMeaningfulDetail', () => {
+    it('should be false when the event has no detail at all', () => {
+      fixture.componentRef.setInput('event', event({ hasDetail: false, rawDetail: null, parsedDetail: null }));
+      expect(component.hasMeaningfulDetail()).toBe(false);
+    });
+
+    it('should be false when the parsed detail is an empty object', () => {
+      fixture.componentRef.setInput('event', event({ hasDetail: true, rawDetail: '{}', parsedDetail: {} }));
+      expect(component.detailText()).toEqual('{}');
+      expect(component.hasMeaningfulDetail()).toBe(false);
+    });
+
+    it('should be true when the parsed detail has content', () => {
+      fixture.componentRef.setInput(
+        'event',
+        event({ hasDetail: true, rawDetail: '{"Algorithm":"SHA-512"}', parsedDetail: { Algorithm: 'SHA-512' } }),
+      );
+      expect(component.hasMeaningfulDetail()).toBe(true);
+    });
+
+    it('should be true when evDetData could not be parsed as JSON but is not empty', () => {
+      fixture.componentRef.setInput(
+        'event',
+        event({ hasDetail: true, rawDetail: 'diff:{"- Size":"","+ Size":7702}} => conforme', parsedDetail: null }),
+      );
+      expect(component.hasMeaningfulDetail()).toBe(true);
+    });
+  });
+});

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2020)
+/*
+ * Copyright French Prime minister Office/SGMAP/DINSIC/Vitam Program (2019-2022)
  * and the signatories of the "VITAM - Accord du Contributeur" agreement.
  *
  * contact@programmevitam.fr
@@ -34,72 +34,48 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-package fr.gouv.vitamui.commons.vitam.api.dto;
+import { Component, computed, input, signal } from '@angular/core';
+import type { ConsolidatedLifecycleEvent } from '../archive-unit-lifecycle-history.model';
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import fr.gouv.vitamui.commons.api.domain.IdDto;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+@Component({
+  selector: 'app-lifecycle-event-node',
+  templateUrl: './lifecycle-event-node.component.html',
+  styleUrls: ['./lifecycle-event-node.component.scss'],
+  standalone: false,
+})
+export class LifecycleEventNodeComponent {
+  event = input<ConsolidatedLifecycleEvent>();
+  isLastInList = input(false);
+  isFirstInList = input(false);
+  bridgeToNextRow = input(false);
 
-import java.io.Serializable;
+  childrenExpanded = signal(false);
+  detailExpanded = signal(false);
 
-@Getter
-@Setter
-@ToString
-public class LogbookEventDto extends IdDto implements Serializable {
+  hasVisibleChildren = computed(() => this.childrenExpanded() && !!this.event().children?.length);
 
-    @JsonProperty("evId")
-    private String evId;
+  suppressLine = computed(() => this.isLastInList() && !this.hasVisibleChildren() && !this.bridgeToNextRow());
 
-    @JsonProperty("evIdReq")
-    private String evIdReq;
+  bridgeRow = computed(() => this.bridgeToNextRow() && !this.hasVisibleChildren());
 
-    @JsonProperty("evParentId")
-    private String evParentId;
+  childBridgeToNextRow = computed(() => this.isLastInList() && this.bridgeToNextRow());
 
-    @JsonProperty("evIdProc")
-    private String evIdProc;
+  isWarning = computed(() => this.event().outcome === 'WARNING');
 
-    @JsonProperty("evType")
-    private String evType;
+  isKo = computed(() => this.event().outcome === 'KO' || this.event().outcome === 'FATAL');
 
-    @JsonProperty("evTypeProc")
-    private String evTypeProc;
+  detailText = computed(() => {
+    const event = this.event();
+    return event.parsedDetail !== null && event.parsedDetail !== undefined ? JSON.stringify(event.parsedDetail) : event.rawDetail;
+  });
 
-    @JsonProperty("evDateTime")
-    private String evDateTime;
+  hasMeaningfulDetail = computed(() => this.event().hasDetail && this.detailText() !== '{}');
 
-    @JsonProperty("outcome")
-    private String outcome;
+  toggleChildren(): void {
+    this.childrenExpanded.update((expanded) => !expanded);
+  }
 
-    @JsonProperty("outDetail")
-    private String outDetail;
-
-    @JsonProperty("outMessg")
-    private String outMessg;
-
-    @JsonProperty("evDetData")
-    private String evDetData;
-
-    @JsonProperty("obId")
-    private String obId;
-
-    @JsonProperty("obIdReq")
-    private String obIdReq;
-
-    @JsonProperty("evIdAppSession")
-    private String evIdAppSession;
-
-    @JsonProperty("agId")
-    private String agId;
-
-    @JsonProperty("agIdApp")
-    private String agIdApp;
-
-    @JsonProperty("agIdExt")
-    private String agIdExt;
-
-    @JsonProperty("rightsStatementIdentifier")
-    private String rightsStatementIdentifier;
+  toggleDetail(): void {
+    this.detailExpanded.update((expanded) => !expanded);
+  }
 }

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive.module.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive.module.ts
@@ -52,9 +52,11 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTreeModule } from '@angular/material/tree';
-import { AgenciesModule, VitamUICommonModule, VitamUILibraryModule } from 'vitamui-library';
+import { AgenciesModule, DiscussionIconComponent, VitamUICommonModule, VitamUILibraryModule } from 'vitamui-library';
 import { ArchivePreviewComponent } from './archive-preview/archive-preview.component';
 import { ArchiveUnitDescriptionTabComponent } from './archive-preview/archive-unit-description-tab/archive-unit-description-tab.component';
+import { ArchiveUnitHistoryTabComponent } from './archive-preview/archive-unit-history-tab/archive-unit-history-tab.component';
+import { LifecycleEventNodeComponent } from './archive-preview/archive-unit-history-tab/lifecycle-event-node/lifecycle-event-node.component';
 import { ArchiveUnitInformationTabComponent } from './archive-preview/archive-unit-information-tab/archive-unit-information-tab.component';
 import { ArchiveUnitObjectsDetailsTabComponent } from './archive-preview/archive-unit-objects-details-tab/archive-unit-objects-details-tab.component';
 import { ArchiveUnitRulesDetailsTabComponent } from './archive-preview/archive-unit-rules-details-tab/archive-unit-rules-details-tab.component';
@@ -119,6 +121,7 @@ import { TranslatePipe } from '@ngx-translate/core';
     VitamUILibraryModule,
     MatTableModule,
     TranslatePipe,
+    DiscussionIconComponent,
   ],
   declarations: [
     AddManagementRulesComponent,
@@ -128,6 +131,7 @@ import { TranslatePipe } from '@ngx-translate/core';
     ArchiveSearchComponent,
     ArchiveSearchRulesFacetsComponent,
     ArchiveUnitDescriptionTabComponent,
+    ArchiveUnitHistoryTabComponent,
     ArchiveUnitInformationTabComponent,
     ArchiveUnitObjectsDetailsTabComponent,
     ArchiveUnitRulesComponent,
@@ -141,6 +145,7 @@ import { TranslatePipe } from '@ngx-translate/core';
     DipRequestCreateComponent,
     FilingHoldingSchemeComponent,
     LeavesTreeComponent,
+    LifecycleEventNodeComponent,
     ManagementRulesComponent,
     SearchAccessRulesFacetsComponent,
     SearchAppraisalRulesFacetsComponent,

--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive.service.ts
@@ -106,7 +106,7 @@ export class ArchiveService extends SearchService<any> implements SearchArchiveU
   }
 
   public static fetchTitle(title: string, titleInLanguages: any) {
-    return title ? title : titleInLanguages ? (titleInLanguages.fr ? titleInLanguages.fr : titleInLanguages.en) : titleInLanguages.en;
+    return title ?? titleInLanguages?.fr ?? titleInLanguages?.en;
   }
 
   public static fetchAuTitle(unit: any) {

--- a/ui/ui-frontend/projects/archive-search/src/app/core/api/archive-api.service.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/core/api/archive-api.service.ts
@@ -38,6 +38,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
+import type { ApiEvent } from 'vitamui-library';
 import {
   ApiUnitObject,
   ArchiveUnit,
@@ -294,5 +295,25 @@ export class ArchiveApiService extends PaginatedHttpClient<any> {
    */
   countObjectGroups(criteriaDto: SearchCriteriaDto, headers?: HttpHeaders): Observable<number> {
     return this.http.post<number>(`${this.apiUrl}/preservation/object-groups-count`, criteriaDto, { headers });
+  }
+
+  /**
+   * Gets the lifecycle logbook of an archive unit.
+   *
+   * @param unitId the archive unit id.
+   * @param headers optionnal headers.
+   */
+  getUnitLifecycles(unitId: string, headers?: HttpHeaders): Observable<{ $results: ApiEvent[] }> {
+    return this.http.get<{ $results: ApiEvent[] }>(`${this.apiUrl}/archiveunit/unitlifecycles/${unitId}`, { headers });
+  }
+
+  /**
+   * Gets the lifecycle logbook of an object group.
+   *
+   * @param objectGroupId the object group id.
+   * @param headers optionnal headers.
+   */
+  getObjectGroupLifecycles(objectGroupId: string, headers?: HttpHeaders): Observable<{ $results: ApiEvent[] }> {
+    return this.http.get<{ $results: ApiEvent[] }>(`${this.apiUrl}/object/objectslifecycles/${objectGroupId}`, { headers });
   }
 }

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/logbook/api-event.interface.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/models/logbook/api-event.interface.ts
@@ -41,6 +41,7 @@ export interface ApiEvent extends Id {
   obIdIn?: string;
   evId: string;
   evIdReq: string;
+  evIdProc: string;
   evParentId: string;
   evType: string;
   evTypeProc: string;

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/en.json
@@ -2370,6 +2370,9 @@
     "CHECK_HEADER.KO": "Failed general check of transfer slip",
     "STP_IMPORT_INGEST_CONTRACT.PROFILE_NOT_FOUND.KO": "Failed to import entry contract: archive profile not found",
     "LFC.UNIT_DETACHMENT": "Modification of the archival unit tree",
+    "LFC.UNIT_DETACHMENT.OK": "Archival unit detachment succeeded",
+    "LFC.UNIT_ATTACHMENT": "Archival unit attachment",
+    "LFC.UNIT_ATTACHMENT.OK": "Archival unit attachment succeeded",
     "ELIMINATION_ACTION_REPORT_GENERATION.WARNING": "Warning when generating the final disposal report for archival units",
     "LFC.CHECK_UNIT_SCHEMA.CONSISTENCY": "Checking the consistency between the Start date and End date fields",
     "OG_OBJECTS_FORMAT_CHECK.UNKNOWN.KO": "Failed to identify formats: the format of the object (s) cannot be identified",
@@ -3190,7 +3193,9 @@
     "CHECK_DATAOBJECTPACKAGE.CHECK_MANIFEST_OBJECTNUMBER.INVALID_URI.KO": "At least one object declares a URI to which a file does not correspond or declares a URI already used by another object",
     "LFC.CHECK_ARCHIVE_UNIT_PROFILE.INVALID_AU_PROFILE.KO": "Failed to verify compliance with archival unit profiles: archival unit profile not compliant",
     "LFC.CHECK_OBJECT_SIZE.CHECK_SIZE": "Checking the size of a binary file",
+    "LFC.CHECK_OBJECT_SIZE.CHECK_SIZE.OK": "Binary file size check succeeded",
     "LFC.CHECK_OBJECT_SIZE": "Checking File Size",
+    "LFC.CHECK_OBJECT_SIZE.OK": "File size check succeeded",
     "CHECK_OBJECT_SIZE.CHECK_SIZE": "Checking the size of a binary file",
     "CHECK_OBJECT_SIZE.KO": "Failed to check the size of a binary object",
     "CHECK_OBJECT_SIZE.OK": "Success of checking the size of a binary object",
@@ -3874,6 +3879,10 @@
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_UNITS.KO": "Archive units originating agency reassignment process failed",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_UNITS.WARNING": "Warning during archive units originating agency reassignment process",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_UNITS.FATAL": "Technical error during archive units originating agency reassignment process",
+    "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_OBJECT_GROUPS": "Object groups originating agency reassignment process",
+    "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_OBJECT_GROUPS.OK": "Object groups originating agencies reassignment process succeeded",
+    "LFC.DELETE_GOT_VERSIONS_ACTION": "Deletion of object group versions",
+    "LFC.DELETE_GOT_VERSIONS_ACTION.OK": "Object group versions deletion succeeded",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_CHILD_UNITS": "Inherited archive units originating agencies reassignment process",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_CHILD_UNITS.STARTED": "Inherited archive units originating agencies reassignment process started",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_CHILD_UNITS.STARTED.OK": "Inherited archive units originating agencies reassignment process start succeeded",
@@ -4063,12 +4072,27 @@
         "USAGE": "Usage",
         "USAGE_VERSION": "Usage version",
         "PHYSICAL_ID": "Physical object identifier",
-        "PhysicalDimensions": "PHYSICAL CHARACTERISTICS"
+        "PhysicalDimensions": "PHYSICAL CHARACTERISTICS",
+        "SHOW_HIDE_DETAIL": "Show/Hide detail"
       },
       "TABS": {
-        "INFORMATIONS": "Informations",
+        "INFORMATIONS": "Information",
         "OBJECTS": "Objects",
-        "RULES": "Rules"
+        "RULES": "Rules",
+        "HISTORY": "History"
+      },
+      "HISTORY": {
+        "TITLE": "Archival unit and object group lifecycle logbooks",
+        "OPERATION_COLUMN": "Operation",
+        "EVENT_COLUMN": "Event",
+        "JOURNAL_COLUMN": "Logbook",
+        "JOURNAL_UNIT": "Archival unit lifecycle",
+        "JOURNAL_OBJECT_GROUP": "Object group lifecycle",
+        "OUTCOME_OK": "Success",
+        "OUTCOME_WARNING": "Warning",
+        "OUTCOME_KO": "Failure",
+        "ACCESS_OPERATIONS_LOG": "Go to the operations logbook",
+        "LOAD_ERROR": "An error occurred while loading the archival unit history."
       }
     },
     "ARCHIVE_UNIT_RULES_DETAILS": {

--- a/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
+++ b/ui/ui-frontend/projects/vitamui-library/src/assets/shared-i18n/fr.json
@@ -2369,6 +2369,9 @@
     "CHECK_HEADER.KO": "Échec de la vérification générale du bordereau de transfert",
     "STP_IMPORT_INGEST_CONTRACT.PROFILE_NOT_FOUND.KO": "Échec de l'import du contrat d'entrée : profil d'archivage non trouvé",
     "LFC.UNIT_DETACHMENT": "Modification d'arborescence de l'unité archivistique",
+    "LFC.UNIT_DETACHMENT.OK": "Succès du détachement de l'unité archivistique",
+    "LFC.UNIT_ATTACHMENT": "Rattachement de l'unité archivistique",
+    "LFC.UNIT_ATTACHMENT.OK": "Succès du rattachement de l'unité archivistique",
     "ELIMINATION_ACTION_REPORT_GENERATION.WARNING": "Avertissement lors de la de génération du rapport d'élimination définitive des unités archivistiques",
     "LFC.CHECK_UNIT_SCHEMA.CONSISTENCY": "Vérification de la cohérence entre les champs Date de début et Date de fin",
     "OG_OBJECTS_FORMAT_CHECK.UNKNOWN.KO": "Échec de l'identification des formats : le format de ou des objet(s) ne peut pas être identifié",
@@ -3190,7 +3193,9 @@
     "CHECK_DATAOBJECTPACKAGE.CHECK_MANIFEST_OBJECTNUMBER.INVALID_URI.KO": "Au moins un objet déclare une URI à laquelle ne correspond pas de fichier ou déclare une URI déjà utilisée par un autre objet",
     "LFC.CHECK_ARCHIVE_UNIT_PROFILE.INVALID_AU_PROFILE.KO": "Échec de la vérification de la conformité aux profils d'unité archivistique : profil d'unité archivistique non conforme",
     "LFC.CHECK_OBJECT_SIZE.CHECK_SIZE": "Vérification de la taille d'un fichier binaire",
+    "LFC.CHECK_OBJECT_SIZE.CHECK_SIZE.OK": "Succès de la vérification de la taille du fichier binaire",
     "LFC.CHECK_OBJECT_SIZE": "Vérification de la taille des fichiers",
+    "LFC.CHECK_OBJECT_SIZE.OK": "Succès de la vérification de la taille des fichiers",
     "CHECK_OBJECT_SIZE.CHECK_SIZE": "Vérification de la taille d'un fichier binaire",
     "CHECK_OBJECT_SIZE.OK": "Succès de la vérification de la taille des fichiers",
     "CHECK_OBJECT_SIZE.KO": "Échec de la vérification de la taille des fichiers",
@@ -3874,6 +3879,10 @@
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_UNITS.KO": "Échec du processus de réattribution du service producteur des unités archivistiques",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_UNITS.WARNING": "Avertissement lors du processus de réattribution du service producteur des unités archivistiques",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_UNITS.FATAL": "Erreur technique lors du processus de réattribution du service producteur des unités archivistiques",
+    "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_OBJECT_GROUPS": "Processus de réattribution du service producteur des groupes d'objets",
+    "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_OBJECT_GROUPS.OK": "Succès du processus de réattribution des services producteurs des groupes d'objets",
+    "LFC.DELETE_GOT_VERSIONS_ACTION": "Suppression des versions des groupes d'objets",
+    "LFC.DELETE_GOT_VERSIONS_ACTION.OK": "Succès de la suppression des versions des groupes d'objets",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_CHILD_UNITS": "Processus de réattribution des services producteurs des unités archivistiques héritières",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_CHILD_UNITS.STARTED": "Début du processus de réattribution des services producteurs des unités archivistiques héritières",
     "LFC.ORIGINATING_AGENCY_REASSIGNMENT_UPDATE_CHILD_UNITS.STARTED.OK": "Succès du début du processus de réattribution des services producteurs des unités archivistiques héritières",
@@ -4063,12 +4072,27 @@
         "USAGE": "Usage",
         "USAGE_VERSION": "Version d'usage",
         "PHYSICAL_ID": "Identifiant de l'objet physique",
-        "PhysicalDimensions": "CARACTÉRISTIQUES PHYSIQUES"
+        "PhysicalDimensions": "CARACTÉRISTIQUES PHYSIQUES",
+        "SHOW_HIDE_DETAIL": "Voir/Masquer le détail"
       },
       "TABS": {
         "INFORMATIONS": "Informations",
         "OBJECTS": "Objets",
-        "RULES": "Règles"
+        "RULES": "Règles",
+        "HISTORY": "Historique"
+      },
+      "HISTORY": {
+        "TITLE": "Journaux du cycle de vie de l'unité archivistique et du groupe d'objets techniques",
+        "OPERATION_COLUMN": "Opération",
+        "EVENT_COLUMN": "Événement",
+        "JOURNAL_COLUMN": "Journal",
+        "JOURNAL_UNIT": "Cycle de vie de l'unité archivistique",
+        "JOURNAL_OBJECT_GROUP": "Cycle de vie du groupe d'objets",
+        "OUTCOME_OK": "Succès",
+        "OUTCOME_WARNING": "Avertissement",
+        "OUTCOME_KO": "Échec",
+        "ACCESS_OPERATIONS_LOG": "Accéder au journal des opérations",
+        "LOAD_ERROR": "Une erreur est survenue lors du chargement de l'historique de l'unité archivistique."
       }
     },
     "ARCHIVE_UNIT_RULES_DETAILS": {


### PR DESCRIPTION
-  US #16344 - Afficher les journaux du cycle de vie d'une unité archivistique et de son GOT.
-  US #16713 - Ajouter des filtres et un lien interAPP dans l’onglet Historique de l’unité archivistique


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a History tab to archive unit previews.
  - View grouped lifecycle events from archive units and object groups with filters, expandable details, status indicators, and logbook links.
  - Added REST access to archive unit and object group lifecycle data.
  - Added copying of operation IDs and English and French history labels.
  - Added support for displaying event process identifiers and additional lifecycle event types.

- **Bug Fixes**
  - Prevented errors when archive titles have no language-specific value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->