### PR TITLE
Bug #16793: [Users] - Fix affichage historique (regression logbook.service post-migration Angular 21)

### DIFF
--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.spec.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.spec.ts
@@ -145,15 +145,4 @@ describe('CustomerPreviewComponent', () => {
   it('should create', () => {
     expect(testhost).toBeTruthy();
   });
-
-  it('should call window.open', () => {
-    const openSpy = vi.spyOn(window, 'open');
-    openSpy.mockImplementation(() => null as any);
-    testhost.component.openPopup();
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://dev.vitamui.com/identity/customer/11',
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-  });
 });

--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/customer-preview.component.ts
@@ -38,7 +38,6 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, inject } fro
 import { Subscription } from 'rxjs';
 
 import type { Customer } from 'vitamui-library';
-import { StartupService } from 'vitamui-library';
 import { CustomerService } from '../../core/customer.service';
 
 @Component({
@@ -49,7 +48,6 @@ import { CustomerService } from '../../core/customer.service';
 })
 export class CustomerPreviewComponent implements OnInit, OnDestroy {
   private customerService = inject(CustomerService);
-  private startupService = inject(StartupService);
 
   @Input() customer: Customer;
   @Input() isPopup: boolean;
@@ -63,15 +61,6 @@ export class CustomerPreviewComponent implements OnInit, OnDestroy {
     this.customerUpdatedSub = this.customerService.updated.subscribe((updatedCustomer: Customer) => {
       this.customer = updatedCustomer;
     });
-  }
-
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/customer/' + this.customer.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
   }
 
   emitClose() {

--- a/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-operation-history-tab/owner-operation-history-tab.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-operation-history-tab/owner-operation-history-tab.component.ts
@@ -35,7 +35,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
-import { AuthService, IEvent, LogbookService } from 'vitamui-library';
+import { AuthService, HistoryEvent, LogbookService } from 'vitamui-library';
 
 const EVENT_LIMIT = 100;
 @Component({
@@ -51,9 +51,8 @@ export class OwnerOperationHistoryTabComponent implements OnChanges {
   @Input() id: string;
   @Input() identifier: string;
   @Input() externalParamId: string;
-  @Input() filter: (event: any) => boolean;
 
-  events: IEvent[] = [];
+  events: HistoryEvent[] = [];
   loading = false;
 
   ngOnChanges(changes: SimpleChanges) {
@@ -73,7 +72,7 @@ export class OwnerOperationHistoryTabComponent implements OnChanges {
     this.logbookService.listHistoryForOwner(this.id, this.identifier, this.externalParamId, tenantIdentifier).subscribe(
       (results) => {
         this.loading = false;
-        this.events = results.filter((event) => (this.filter ? this.filter(event) : true)).slice(0, EVENT_LIMIT);
+        this.events = results.slice(0, EVENT_LIMIT);
       },
       () => (this.loading = false),
     );

--- a/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/owner-preview/owner-preview.component.ts
@@ -34,10 +34,9 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import type { Owner, Tenant } from 'vitamui-library';
-import { StartupService } from 'vitamui-library';
 
 @Component({
   selector: 'app-owner-preview',
@@ -46,34 +45,12 @@ import { StartupService } from 'vitamui-library';
   standalone: false,
 })
 export class OwnerPreviewComponent {
-  private startupService = inject(StartupService);
-
   @Input() owner: Owner;
   @Input() tenant: Tenant;
   @Input() isPopup: boolean;
   @Output() previewClose = new EventEmitter();
 
-  openPopup() {
-    const url = this.tenant ? '/customer/tenant/' + this.tenant.id : '/customer/owner/' + this.owner.id;
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + url,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
-
   emitClose() {
     this.previewClose.emit();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail &&
-      (event.outDetail.includes('EXT_VITAMUI_UPDATE_OWNER') ||
-        event.outDetail.includes('EXT_VITAMUI_CREATE_OWNER') ||
-        event.outDetail.includes('EXT_VITAMUI_CREATE_TENANT') ||
-        event.outDetail.includes('EXT_VITAMUI_UPDATE_TENANT'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/group/group-preview/group-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/group/group-preview/group-preview.component.ts
@@ -37,7 +37,7 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, inject } from '@angular/core';
 import { Subscription } from 'rxjs';
 import type { Group } from 'vitamui-library';
-import { AuthService, isLevelAllowed, StartupService } from 'vitamui-library';
+import { AuthService, isLevelAllowed } from 'vitamui-library';
 
 import { GroupService } from '../group.service';
 
@@ -50,7 +50,6 @@ import { GroupService } from '../group.service';
 export class GroupPreviewComponent implements OnInit, OnDestroy, OnChanges {
   private groupService = inject(GroupService);
   private authService = inject(AuthService);
-  private startupService = inject(StartupService);
 
   @Input() isPopup: boolean;
 
@@ -86,14 +85,6 @@ export class GroupPreviewComponent implements OnInit, OnDestroy, OnChanges {
       }
     }
   }
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/group/' + this.group.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
 
   levelNotAllowed(): boolean {
     if (this.group) {
@@ -108,11 +99,5 @@ export class GroupPreviewComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy(): void {
     this.groupUpdateSub.unsubscribe();
-  }
-
-  filterEvents(event: any): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_CREATE_GROUP') || event.outDetail.includes('EXT_VITAMUI_UPDATE_GROUP'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/hierarchy/hierarchy-detail/hierarchy-detail.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/hierarchy/hierarchy-detail/hierarchy-detail.component.ts
@@ -37,8 +37,8 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, inject } from '@angular/core';
 
 import { Subscription } from 'rxjs';
-import type { Event, Profile } from 'vitamui-library';
-import { AuthService, isLevelAllowed, StartupService } from 'vitamui-library';
+import type { Profile } from 'vitamui-library';
+import { AuthService, isLevelAllowed } from 'vitamui-library';
 import { HierarchyService } from '../hierarchy.service';
 
 @Component({
@@ -50,7 +50,6 @@ import { HierarchyService } from '../hierarchy.service';
 export class HierarchyDetailComponent implements OnInit, OnDestroy {
   private hierarchyService = inject(HierarchyService);
   private authService = inject(AuthService);
-  private startupService = inject(StartupService);
 
   @Input()
   set id(id: string) {
@@ -75,15 +74,6 @@ export class HierarchyDetailComponent implements OnInit, OnDestroy {
     this.profileUpdateSub.unsubscribe();
   }
 
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/profile-hierarchy/' + this.profile.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
-
   emitClose() {
     this.previewClose.emit();
   }
@@ -93,11 +83,5 @@ export class HierarchyDetailComponent implements OnInit, OnDestroy {
       return !isLevelAllowed(this.authService.user, this.profile.level);
     }
     return false;
-  }
-
-  filterEvents(event: Event): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_CREATE_PROFILE') || event.outDetail.includes('EXT_VITAMUI_UPDATE_PROFILE'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/profile/profile-detail/profile-detail.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/profile/profile-detail/profile-detail.component.ts
@@ -36,8 +36,8 @@
  */
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, inject } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { AuthService, isLevelAllowed, StartupService } from 'vitamui-library';
-import type { Event, Profile } from 'vitamui-library';
+import { AuthService, isLevelAllowed } from 'vitamui-library';
+import type { Profile } from 'vitamui-library';
 
 import { ProfileService } from '../profile.service';
 
@@ -50,7 +50,6 @@ import { ProfileService } from '../profile.service';
 export class ProfileDetailComponent implements OnInit, OnDestroy {
   private rngProfileService = inject(ProfileService);
   private authService = inject(AuthService);
-  private startupService = inject(StartupService);
 
   @Input()
   set id(id: string) {
@@ -73,15 +72,6 @@ export class ProfileDetailComponent implements OnInit, OnDestroy {
     });
   }
 
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/profile/' + this.profile.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
-
   levelNotAllowed(): boolean {
     if (this.profile) {
       return !isLevelAllowed(this.authService.user, this.profile.level);
@@ -95,11 +85,5 @@ export class ProfileDetailComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.profileUpdateSub.unsubscribe();
-  }
-
-  filterEvents(event: Event): boolean {
-    return (
-      event.outDetail && (event.outDetail.includes('EXT_VITAMUI_CREATE_PROFILE') || event.outDetail.includes('EXT_VITAMUI_UPDATE_PROFILE'))
-    );
   }
 }

--- a/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-preview.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/user/user-preview/user-preview.component.ts
@@ -133,15 +133,6 @@ export class UserPreviewComponent implements OnDestroy, OnInit {
     this.userUpdatedSub.unsubscribe();
   }
 
-  openPopup() {
-    window.open(
-      this.startupService.getConfigStringValue('UI_URL') + '/user/' + this.user.id,
-      'detailPopup',
-      'width=584, height=713, resizable=no, location=no',
-    );
-    this.emitClose();
-  }
-
   updateStatus(status: string) {
     let dialogToOpen;
     if (status === 'ENABLED') {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/logbook-api.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/api/logbook-api.service.ts
@@ -34,14 +34,13 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { BASE_URL } from '../injection-tokens';
 import { ApiEvent } from '../models/logbook/api-event.interface';
-import { IEvent } from '../models/logbook/event.interface';
-import { VitamSelectQuery } from '../models/vitam/vitam-select-query.interface';
+import { HistoryEvent, IEvent } from '../models/logbook/event.interface';
 import { VitamResponse } from '../models/vitam/vitam-response.interface';
 import { PaginatedApi } from '../paginated-api.interface';
 import { PageRequest } from '../vitamui-table/page-request.model';
@@ -125,50 +124,14 @@ export class LogbookApiService implements PaginatedApi<IEvent> {
     return userIdentifier;
   }
 
-  findUnitLifeCyclesByUnitId(unitId: string, headers?: HttpHeaders): Observable<{ $hits: any; $results: IEvent[] }> {
-    return this.http
-      .get<{ $hits: any; $results: ApiEvent[] }>(this.apiUrl + '/unitlifecycles/' + unitId, { headers })
-      .pipe(map((response) => ({ $hits: response.$hits, $results: response.$results.map(LogbookApiService.toEvent) })));
-  }
-
-  findObjectGroupLifeCyclesByUnitId(objectId: string, headers?: HttpHeaders): Observable<{ $hits: any; $results: IEvent[] }> {
-    return this.http
-      .get<{ $hits: any; $results: ApiEvent[] }>(this.apiUrl + '/objectslifecycles/' + objectId, { headers })
-      .pipe(map((response) => ({ $hits: response.$hits, $results: response.$results.map(LogbookApiService.toEvent) })));
-  }
-
   findOperationById(operationId: string, headers?: HttpHeaders): Observable<{ $results: any[] }> {
     return this.http.get<{ $results: any[] }>(this.apiUrl + '/operations/' + operationId, { headers });
   }
 
-  findOperations(obId: string, obIdReq: string, headers?: HttpHeaders): Observable<{ $results: IEvent[] }> {
-    const params = new HttpParams().set('obId', obId).set('obIdReq', obIdReq);
-
+  findOperationByIdAndCollectionName(id: string, resourcePath: string, headers?: HttpHeaders): Observable<HistoryEvent[]> {
     return this.http
-      .get<{ $results: ApiEvent[] }>(this.apiUrl + '/operations/', { params, headers })
-      .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
-  }
-
-  findOperationByIdAndCollectionName(id: string, resourcePath: string, headers?: HttpHeaders): Observable<{ $results: IEvent[] }> {
-    return this.http
-      .get<{ $results: ApiEvent[] }>(this.baseUrl + '/' + resourcePath + '/' + id + '/history', { headers })
-      .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
-  }
-
-  findOperationsBySelectQuery(
-    selectQuery: VitamSelectQuery,
-    vitamTenantIdentifier?: number,
-    headers?: HttpHeaders,
-  ): Observable<{ $results: IEvent[] }> {
-    let params = new HttpParams();
-
-    if (vitamTenantIdentifier) {
-      params = params.append('vitamTenantIdentifier', vitamTenantIdentifier.toString());
-    }
-
-    return this.http
-      .post<{ $results: ApiEvent[] }>(this.apiUrl + '/operations', selectQuery, { headers, params })
-      .pipe(map((response) => ({ $results: response.$results.map(LogbookApiService.toEvent) })));
+      .get<HistoryEvent[]>(this.baseUrl + '/' + resourcePath + '/' + id + '/history', { headers })
+      .pipe(map((events) => events.map((event) => ({ ...event, parsedData: JSON.parse(event.data) }))));
   }
 
   downloadManifest(id: string, headers?: HttpHeaders): Observable<HttpResponse<Blob>> {

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/logbook.service.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/logbook/logbook.service.ts
@@ -40,127 +40,36 @@ import { forkJoin, Observable, of, throwError } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { LogbookApiService } from '../api/logbook-api.service';
 import { SnackBarService } from '../components/snack-bar/snack-bar.service';
-import { Logger } from '../logger/logger';
-import { IEvent } from '../models/logbook/event.interface';
-import { VitamSelectQuery } from '../models/vitam/vitam-select-query.interface';
+import { HistoryEvent, IEvent } from '../models/logbook/event.interface';
 import { VitamuiHttpHeaders } from '../vitamui-http-headers.enum';
 
 @Injectable({
   providedIn: 'root',
 })
 export class LogbookService {
-  private logger = inject(Logger);
   private logbookApi = inject(LogbookApiService);
   private snackBarService = inject(SnackBarService);
 
-  protected extractEvents(response: { $results: IEvent[] }): IEvent[] {
-    if (response && response.$results) {
-      if (response.$results.length > 1) {
-        this.logger.warn(this, 'WARN: multiple results in history');
-      }
-      if (response.$results.length > 0) {
-        return response.$results[0].events;
-      }
-    }
-
-    return [];
-  }
-
-  listOperationsEvents(identifier: string, obIdReq: string, tenantIdentifier: number, accessContract: string): Observable<IEvent[]> {
-    const headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
-      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-
-    return this.logbookApi.findOperations(identifier, obIdReq, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) => response.$results.reduce(flattenChildEvents, []).sort(sortEventByDate)),
-    );
-  }
-
-  listUnitEvents(unitId: string, accessContract: string, tenantIdentifier: number): Observable<IEvent[]> {
-    const headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
-      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-
-    return this.logbookApi.findUnitLifeCyclesByUnitId(unitId, headers).pipe(
-      catchError(() => of({ $hits: null, $results: [] })),
-      map((response) => this.extractEvents(response).sort(sortEventByDate)),
-    );
-  }
-
-  listObjectEvents(objectId: string, accessContract: string, tenantIdentifier: number): Observable<IEvent[]> {
-    const headers = new HttpHeaders()
-      .set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString())
-      .set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-    return this.logbookApi.findObjectGroupLifeCyclesByUnitId(objectId, headers).pipe(
-      catchError(() => of({ $hits: null, $results: [] })),
-      map((response) => this.extractEvents(response).sort(sortEventByDate)),
-    );
-  }
-
-  listOperationByIdAndCollectionName(identifier: string, collectionName: string, tenantIdentifier: number): Observable<IEvent[]> {
+  listOperationByIdAndCollectionName(id: string, collectionName: string, tenantIdentifier: number): Observable<HistoryEvent[]> {
     const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(identifier, collectionName, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) =>
-        response.$results
-          .reduce(flattenChildEvents, [])
-          .filter((e) => e.obIdReq.toLowerCase() === collectionName.toLowerCase())
-          .sort(sortEventByDate),
-      ),
+    return this.logbookApi.findOperationByIdAndCollectionName(id, collectionName, headers).pipe(
+      catchError(() => of([] as HistoryEvent[])),
+      map((response) => response.sort(sortEventByDate)),
     );
   }
 
-  listOperationByResourcePathIdAndCollectionName(
-    resourcePath: string,
-    identifier: string,
-    collectionName: string,
-    tenantIdentifier: number,
-  ): Observable<IEvent[]> {
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(identifier, resourcePath, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) =>
-        response.$results
-          .reduce(flattenChildEvents, [])
-          .filter((e) => e.obIdReq === collectionName)
-          .sort(sortEventByDate),
-      ),
-    );
-  }
-
-  listOperationByResourcePathIdAndCollectionNameWithCustomFilter(
-    resourcePath: string,
-    identifier: string,
-    tenantIdentifier: number,
-    filterPredicate: (event: IEvent) => boolean,
-  ): Observable<IEvent[]> {
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(identifier, resourcePath, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) => response.$results.reduce(flattenChildEvents, []).filter(filterPredicate).sort(sortEventByDate)),
-    );
-  }
-
-  listOperationByIdentifierAndCollectionName(
+  private listOperationByIdentifierAndCollectionName(
     id: string,
     identifier: string,
     collectionName: string,
     tenantIdentifier: number,
-  ): Observable<IEvent[]> {
-    const headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    return this.logbookApi.findOperationByIdAndCollectionName(id, collectionName, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) =>
-        response.$results
-          .reduce(flattenChildEvents, [])
-          .filter((e) => e.obIdReq === collectionName && e.obId === identifier)
-          .sort(sortEventByDate),
-      ),
+  ): Observable<HistoryEvent[]> {
+    return this.listOperationByIdAndCollectionName(id, collectionName, tenantIdentifier).pipe(
+      map((response) => response.filter((e) => e.obId === identifier)),
     );
   }
 
-  listHistoryForOwner(id: string, identifier: string, externalParamId: string, tenantIdentifier: number): Observable<IEvent[]> {
+  listHistoryForOwner(id: string, identifier: string, externalParamId: string, tenantIdentifier: number): Observable<HistoryEvent[]> {
     const ownerEventsObservable = this.listOperationByIdentifierAndCollectionName(id, identifier, 'owners', tenantIdentifier);
     const tenantEventsObservable = this.listOperationByIdAndCollectionName(externalParamId, 'tenants', tenantIdentifier);
 
@@ -171,19 +80,8 @@ export class LogbookService {
     );
   }
 
-  listHistoryForProfileArchive(id: string, externalParamId: string, tenantIdentifier: number): Observable<IEvent[]> {
-    const profileEventsObservable = this.listOperationByIdAndCollectionName(id, 'profiles', tenantIdentifier);
-    const archiveParamEventsObservable = this.listOperationByIdAndCollectionName(externalParamId, 'archiveparams', tenantIdentifier);
-
-    return forkJoin([profileEventsObservable, archiveParamEventsObservable]).pipe(
-      map((results) => {
-        return results[0].concat(results[1]).sort(sortEventByDate);
-      }),
-    );
-  }
-
-  listHistoryOperations(collectionsMap: Map<string, string>, tenantIdentifier: number): Observable<IEvent[]> {
-    const observables: Observable<IEvent[]>[] = [];
+  listHistoryOperations(collectionsMap: Map<string, string>, tenantIdentifier: number): Observable<HistoryEvent[]> {
+    const observables: Observable<HistoryEvent[]>[] = [];
     collectionsMap.forEach((value, key) => {
       const result = this.listOperationByIdAndCollectionName(key, value, tenantIdentifier);
       observables.push(result);
@@ -191,31 +89,12 @@ export class LogbookService {
 
     return forkJoin(observables).pipe(
       map((results) => {
-        let events: IEvent[] = [];
+        let events: HistoryEvent[] = [];
 
         results.forEach((event) => {
           events = events.concat(event);
         });
         return events.sort(sortEventByDate);
-      }),
-    );
-  }
-
-  listOperationsBySelectQuery(
-    query: VitamSelectQuery,
-    tenantIdentifier: number,
-    accessContract?: string,
-    vitamTenantIdentifier?: number,
-  ): Observable<IEvent[]> {
-    let headers = new HttpHeaders().set(VitamuiHttpHeaders.X_TENANT_ID, tenantIdentifier.toString());
-    if (accessContract) {
-      headers = headers.set(VitamuiHttpHeaders.X_ACCESS_CONTRACT_ID, accessContract);
-    }
-
-    return this.logbookApi.findOperationsBySelectQuery(query, vitamTenantIdentifier, headers).pipe(
-      catchError(() => of({ $results: [] as IEvent[] })),
-      map((response) => {
-        return response.$results.reduce(flattenChildEvents, []).sort(sortEventByDate);
       }),
     );
   }
@@ -247,10 +126,6 @@ export class LogbookService {
       this.snackBarService.startDownload(response);
     });
   }
-}
-
-function flattenChildEvents(acc: IEvent[], current: IEvent): IEvent[] {
-  return acc.concat(current.events);
 }
 
 export function sortEventByDate(ev1: IEvent, ev2: IEvent): number {


### PR DESCRIPTION
 L'onglet « Historique » n'affichait aucune donnée pour aucune entité (utilisateurs, groupes, profils, owners, agencies, contexts, rules, contracts, etc.), alors que les API backend correspondantes répondaient correctement en 200 avec les événements attendus.

Le commit (« Bug #14926: Secure *.findHistoryById methods », 2026-05-06) a modifié les endpoints backend d'historique (`/{resourcePath}/{id}/history`) pour retourner un tableau JSON à plat d'objets `HistoryEventDto` simplifiés, et avait correctement mis à jour les services Angular en conséquence.

Plus tard le même jour, le commit (« Story #16279: Migration Angular from 19  to 21 — karma→Vitest ») — réalisé lors d'un merge/rebase — a accidentellement fait revenir `logbook.service.ts` et `logbook-api.service.ts` à leur état d'avant le correctif, qui s'attend à l'ancien format natif VITAM `{ $results: [...] }` avec des noms de champs  préfixés `ev*`.