### PR TITLE
Bug #16789: add preservation roles to the default archive administrator profile

### DIFF
--- a/api/api-iam/iam/src/main/resources/dev/customer-init.yml
+++ b/api/api-iam/iam/src/main/resources/dev/customer-init.yml
@@ -248,6 +248,8 @@ customer-init:
         - ROLE_GET_ARCHIVE_PROFILES_UNIT
         - ROLE_GET_FILLING_PLAN_ACCESS
         - ROLE_ORIGINATING_AGENCY_REASSIGNMENT
+        - ROLE_GET_PRESERVATION_SCENARIOS
+        - ROLE_LAUNCH_PRESERVATION
 
     - name: Consultation
       description: Profil pour la recherche et consultation des archives dans Vitam sans mises à jour des règles, sans export DIP et sans élimination

--- a/deployment/roles/vitamui/files/customer-init.yml
+++ b/deployment/roles/vitamui/files/customer-init.yml
@@ -235,6 +235,8 @@ customer-init:
         - ROLE_GET_ARCHIVE_PROFILES_UNIT
         - ROLE_GET_FILLING_PLAN_ACCESS
         - ROLE_ORIGINATING_AGENCY_REASSIGNMENT
+        - ROLE_GET_PRESERVATION_SCENARIOS
+        - ROLE_LAUNCH_PRESERVATION
 
     - name: Consultation
       description: Profil pour la recherche et consultation des archives dans Vitam sans mises à jour des règles, sans export DIP et sans élimination


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The “Archiviste administrateur” profile can now view preservation scenarios.
  - The profile can also launch preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->