### PR TITLE
Bug #16805: [Preservation] – The “Possible Actions” column takes up all the available space.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/preservation/preservation-group/preservation-scenario-list/preservation-scenario-list.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/preservation/preservation-group/preservation-scenario-list/preservation-scenario-list.component.html
@@ -25,7 +25,7 @@
         </span>
       </th>
 
-      <th>
+      <th class="possible-actions">
         <span class="no-wrap">
           {{ 'PRESERVATION.SCENARIO.TABLE.HEADER.POSSIBLE_ACTIONS' | translate }}
           <vitamui-order-by-button
@@ -64,7 +64,9 @@
       >
         <td>{{ preservationScenario.Identifier }}</td>
         <td>{{ preservationScenario.Name }}</td>
-        <td>{{ formatPossibleActions(preservationScenario.ActionList) }}</td>
+        <td class="possible-actions">
+          <div vitamuiCommonEllipsis>{{ formatPossibleActions(preservationScenario.ActionList) }}</div>
+        </td>
         <td>{{ preservationScenario.CreationDate | dateTime: 'dd/MM/yyyy' | empty }}</td>
         <td class="delete-button">
           <button class="btn btn-circle primary" (click)="$event.stopPropagation(); deletePreservationScenarioDialog(preservationScenario)">

--- a/ui/ui-frontend/projects/referential/src/app/preservation/preservation-group/preservation-scenario-list/preservation-scenario-list.component.scss
+++ b/ui/ui-frontend/projects/referential/src/app/preservation/preservation-group/preservation-scenario-list/preservation-scenario-list.component.scss
@@ -1,3 +1,8 @@
 tr:not(:hover) .delete-button button {
   visibility: hidden;
 }
+
+th.possible-actions,
+td.possible-actions {
+  max-width: 400px;
+}

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/ellipsis/ellipsis.directive.module.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/ellipsis/ellipsis.directive.module.ts
@@ -36,10 +36,11 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { CommonTooltipModule } from '../../components/common-tooltip/common-tooltip.module';
 import { EllipsisDirective } from './ellipsis.directive';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, CommonTooltipModule],
   declarations: [EllipsisDirective],
   exports: [EllipsisDirective],
 })

--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/ellipsis/ellipsis.directive.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/ellipsis/ellipsis.directive.ts
@@ -34,51 +34,108 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-import { AfterViewInit, Directive, ElementRef, HostBinding, HostListener, inject, input, OnInit, Renderer2 } from '@angular/core';
+import {
+  AfterViewInit,
+  ComponentRef,
+  Directive,
+  ElementRef,
+  HostBinding,
+  HostListener,
+  inject,
+  input,
+  OnDestroy,
+  OnInit,
+  Renderer2,
+} from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { ConnectedPosition, Overlay, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { CommonTooltipComponent } from '../../components/common-tooltip/common-tooltip.component';
+
+const ELLIPSIS_TOOLTIP_POSITION: ConnectedPosition = {
+  originX: 'start',
+  originY: 'bottom',
+  overlayX: 'start',
+  overlayY: 'top',
+};
 
 @Directive({
   selector: '[vitamuiCommonEllipsis]',
   standalone: false,
 })
-export class EllipsisDirective implements OnInit, AfterViewInit {
+export class EllipsisDirective implements OnInit, AfterViewInit, OnDestroy {
   private renderer = inject(Renderer2);
   private elementRef = inject(ElementRef);
+  private overlay = inject(Overlay);
+  private overlayPositionBuilder = inject(OverlayPositionBuilder);
 
   isToolTipOnMouseEnter = input(false, { transform: coerceBooleanProperty });
   vitamuiCommonEllipsisLines = input(1);
   breakAll = input(false, { transform: coerceBooleanProperty });
 
-  domElement: any;
+  domElement: HTMLElement;
+
+  private isTruncated = false;
+  private overlayRef: OverlayRef;
+  private tooltipRef: ComponentRef<CommonTooltipComponent>;
 
   ngOnInit(): void {
     this.domElement = this.elementRef.nativeElement;
-    this.renderer.addClass(this.elementRef.nativeElement, 'text-ellipsis');
-    if (this.breakAll()) this.renderer.addClass(this.elementRef.nativeElement, 'break-all');
-    this.setToolTip();
+    this.renderer.addClass(this.domElement, 'text-ellipsis');
+    if (this.breakAll()) this.renderer.addClass(this.domElement, 'break-all');
+    this.checkTruncation();
   }
 
   ngAfterViewInit(): void {
     this.renderer.setProperty(this.domElement, 'scrollTop', 1);
-    this.setToolTip();
+    this.checkTruncation();
+  }
+
+  ngOnDestroy(): void {
+    this.closeTooltip();
+    this.overlayRef?.dispose();
   }
 
   @HostListener('window:resize')
-  setToolTip() {
-    this.domElement.offsetHeight < this.domElement.scrollHeight
-      ? this.renderer.setAttribute(this.domElement, 'title', this.domElement.textContent)
-      : this.renderer.removeAttribute(this.domElement, 'title');
+  checkTruncation() {
+    this.isTruncated = this.domElement.offsetHeight < this.domElement.scrollHeight;
+    if (!this.isTruncated) this.closeTooltip();
   }
 
   @HostListener('mouseenter')
-  setToolTipOnMouseEnter() {
-    if (this.isToolTipOnMouseEnter()) {
-      this.setToolTip();
-    }
+  onMouseEnter() {
+    if (this.isToolTipOnMouseEnter()) this.checkTruncation();
+    if (this.isTruncated) this.openTooltip();
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.closeTooltip();
   }
 
   @HostBinding('style.-webkit-line-clamp')
   get lineClamp() {
     return this.vitamuiCommonEllipsisLines() > 1 ? this.vitamuiCommonEllipsisLines() : null;
+  }
+
+  private openTooltip() {
+    if (!this.overlayRef) this.createOverlayRef();
+    if (!this.overlayRef.hasAttached()) {
+      this.tooltipRef = this.overlayRef.attach(new ComponentPortal(CommonTooltipComponent));
+      this.tooltipRef.instance.text = this.domElement.textContent;
+      this.tooltipRef.instance.position = 'BOTTOM';
+    }
+  }
+
+  private closeTooltip() {
+    if (this.overlayRef?.hasAttached()) this.overlayRef.detach();
+  }
+
+  private createOverlayRef() {
+    const positionStrategy = this.overlayPositionBuilder
+      .flexibleConnectedTo(this.elementRef)
+      .withPositions([ELLIPSIS_TOOLTIP_POSITION])
+      .withPush(false);
+    this.overlayRef = this.overlay.create({ positionStrategy, scrollStrategy: this.overlay.scrollStrategies.reposition() });
   }
 }


### PR DESCRIPTION
Problème d'affichage dans l'app préservation: "la colonne des actions possibles prend toute la place".
 
 ==> il faudrait tronquer les actions et au survol avoir la liste complète

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readability of the “Possible actions” column by truncating long content with an ellipsis.
  * Added a hover tooltip displaying the full list of possible actions when content is truncated.
  * Applied a consistent maximum width of 400px to the column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->