### PR TITLE
Bug #16800: [Access contract] – Brief display of the “This field is required” message after selecting a CSV file.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/file-selector/file-selector.component.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/components/file-selector/file-selector.component.ts
@@ -176,10 +176,9 @@ export class FileSelectorComponent extends AbstractFormInputDirective implements
   }
 
   async handleFilesSelection(files: FileList | File[]) {
-    this.control.markAsTouched();
-
+    // We mark the control as touched only AFTER the value has been set
     await this.updateFiles(files);
-
+    this.control.markAsTouched();
     this.resetInput();
   }
 


### PR DESCRIPTION
Fix: moved markAsTouched() to run after updateFiles() resolves, so the control's touched state is only set once its value already reflects the selected files.