### PR TITLE
Bug #16799: [Access contract/Entry contract] – the "Importer" button re-enabled while the pop-in was still animating closed, letting a second /import request fire.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/shared/import-dialog/import-dialog.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/shared/import-dialog/import-dialog.component.ts
@@ -37,7 +37,7 @@
 import { Component, inject, OnDestroy } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ApplicationId, FileTypes, FileValidationErrors, FileValidatorFunction, SnackBarService } from 'vitamui-library';
-import { finalize, firstValueFrom, Subject } from 'rxjs';
+import { firstValueFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ImportDialogParam, ReferentialTypes } from './import-dialog-param.interface';
 import { FormControl, Validators } from '@angular/forms';
@@ -74,7 +74,6 @@ export class ImportDialogComponent implements OnDestroy {
     this.referentialImportService
       .importReferential(this.dialogParams.referential, this.fileControl.value[0])
       .pipe(takeUntil(this.destroy))
-      .pipe(finalize(() => (this.isLoading = false)))
       .subscribe({
         next: () => {
           this.snackBarService.open({
@@ -91,6 +90,7 @@ export class ImportDialogComponent implements OnDestroy {
           this.dialogRef.close({ successfulImport: true });
         },
         error: (_) => {
+          this.isLoading = false;
           let showSnackbar = true;
           if (showSnackbar && this.dialogParams.errorMessage) {
             this.snackBarService.open({


### PR DESCRIPTION
Correction : suppression du reset dans finalize() et réinitialisation de isLoading uniquement dans le callback d’erreur.

En cas de succès, la boîte de dialogue se ferme, donc le bouton reste correctement désactivé jusqu’à sa fermeture. En cas d’erreur, le bouton est correctement réactivé afin de permettre à l’utilisateur de réessayer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Updated the import dialog’s loading indicator behavior. After a successful import, the dialog continues displaying its loading state instead of immediately resetting it.
  - If an import fails, the loading indicator is cleared so the error can be addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->