### PR TITLE
Bug #16813: [Audit] – The “X” button used to close the “Launch Chaining Audit” action is misaligned.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/audit/audit.component.html
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit.component.html
@@ -16,7 +16,7 @@
           <button class="btn primary" (click)="openCreateAuditDialog()">
             <span>{{ 'AUDIT.HOME.START_AUDIT' | translate }}</span>
           </button>
-          <vitamui-menu-button icon="vitamui-icon-more-horiz">
+          <vitamui-menu-button [overlayPos]="'end'" [icon]="'vitamui-icon-more-horiz'">
             <button mat-menu-item (click)="openCreateChainAuditDialog()">
               {{ 'AUDIT.HOME.SECONDARY_ACTIONS.START_CHAIN_AUDIT' | translate }}
             </button>


### PR DESCRIPTION
le bouton « CROIX » permettant de la fermer l'action Lancer l'audit de chaînage est positionné de manière décalée.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the audit menu button to use the correct icon binding.
  - Positioned the menu overlay at the end of the button for improved alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->