### PR TITLE
Bug #16815: [Preservation] – Scenario list displaying only the title.

### DIFF
--- a/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/preservation-dialog/preservation-dialog.component.ts
+++ b/ui/ui-frontend/projects/archive-search/src/app/archive/archive-search/additional-actions-search/preservation-dialog/preservation-dialog.component.ts
@@ -96,7 +96,7 @@ export class PreservationDialogComponent {
 
   private scenarios = toSignal(this.preservationScenariosService.list(), { initialValue: [] as PreservationScenario[] });
   scenarioOptions = computed<VitamuiSelectOptions>(() => ({
-    options: this.scenarios().map((scenario) => ({ key: scenario.Identifier, label: scenario.Name })),
+    options: this.scenarios().map((scenario) => ({ key: scenario.Identifier, label: `${scenario.Identifier} - ${scenario.Name}` })),
   }));
 
   objectGroupsCount = toSignal(


### PR DESCRIPTION
Dans la pop-in, quand je sélectionne un scénario de préservation, la liste ne remonte que l'intitulé des scénarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Preservation scenario options now display both the scenario identifier and name for easier recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->