### PR TITLE
Bug #16816: [Collect] The “Update” button remains enabled after uploading an unsupported file format (PDF).

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.html
@@ -14,12 +14,11 @@
           <mat-spinner class="vitamui-spinner large"></mat-spinner>
         </div>
       } @else {
-        <vitamui-file-selector [extensions]="['.csv', '.jsonl']" [multiple]="false" (filesChanged)="handleFiles($event)">
-        </vitamui-file-selector>
+        <vitamui-file-selector [extensions]="['.csv', '.jsonl']" [multiple]="false" [formControl]="fileControl"> </vitamui-file-selector>
       }
     </mat-dialog-content>
     <mat-dialog-actions>
-      <button (click)="updateUnitsMetadata()" [disabled]="!fileToUpload || isLoadingData" class="btn primary" type="button">
+      <button (click)="updateUnitsMetadata()" [disabled]="fileControl.invalid || isLoadingData" class="btn primary" type="button">
         {{ 'COLLECT.UPDATE_UNITS_METADATA.UPDATE_CONFIRM' | translate }}
       </button>
       <button (click)="onCancel()" class="btn cancel link" [disabled]="isLoadingData" type="button">

--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.ts
@@ -35,6 +35,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 import { Component, OnDestroy, TemplateRef, ViewChild, inject } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Subscription, throwError } from 'rxjs';
 import { Logger, SnackBarService, Transaction, VitamErrorDetails } from 'vitamui-library';
@@ -60,7 +61,7 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
 
   isLoadingData = false;
 
-  fileToUpload: File = undefined;
+  fileControl: FormControl<File[]> = new FormControl([], [Validators.required]);
   errorsDetails: VitamErrorDetails[];
   errorMessage: string;
 
@@ -74,6 +75,7 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
   }
 
   updateUnitsMetadata() {
+    const fileToUpload = this.fileControl.value[0];
     this.isLoadingData = true;
     this.snackBarService.open({
       message: 'COLLECT.UPDATE_UNITS_METADATA.WAIT_MESSAGE',
@@ -81,7 +83,7 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
     });
 
     this.subscriptions = this.archiveCollectService
-      .updateUnitsMetadataByCsvFile(this.fileToUpload, this.fileToUpload.name, this.data.selectedTransaction.id)
+      .updateUnitsMetadataByCsvFile(fileToUpload, fileToUpload.name, this.data.selectedTransaction.id)
       .subscribe({
         next: () => {
           this.isLoadingData = false;
@@ -112,9 +114,5 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
   onConfirmAction() {
     this.dialogRefToClose.close(true);
     this.dialogRef.close(true);
-  }
-
-  handleFiles(files: File[]) {
-    this.fileToUpload = files?.length ? files[0] : undefined;
   }
 }


### PR DESCRIPTION
Le bouton Mettre à jour est cliquable malgré le format de fichier non valide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file selection validation in the update metadata dialog.
  * The confirm action is now enabled only when a file has been selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->