### PR TITLE
Bug #16825: [Chain audit] 404 error when downloading the report of a failed chaining audit.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.spec.ts
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.spec.ts
@@ -91,4 +91,24 @@ describe('AuditPreviewComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should report no report for a chain audit without a successful reporting sub-event', () => {
+    fixture.componentRef.setInput('audit', {
+      type: 'TRACEABILITY_CHAIN_AUDIT',
+      events: [{ type: 'STP_PREPARE_TRACEABILITY_CHAIN_AUDIT', outcome: 'KO', outDetail: 'STP_PREPARE_TRACEABILITY_CHAIN_AUDIT.KO' }],
+    });
+    fixture.detectChanges();
+
+    expect(component.hasReport()).toBe(false);
+  });
+
+  it('should report a report for a chain audit with a successful reporting sub-event, even when the audit is KO', () => {
+    fixture.componentRef.setInput('audit', {
+      type: 'TRACEABILITY_CHAIN_AUDIT',
+      events: [{ type: 'TRACEABILITY_CHAIN_AUDIT_REPORTING', outcome: 'OK', outDetail: 'TRACEABILITY_CHAIN_AUDIT_REPORTING.OK' }],
+    });
+    fixture.detectChanges();
+
+    expect(component.hasReport()).toBe(true);
+  });
 });

--- a/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/audit/audit-preview/audit-preview.component.ts
@@ -77,9 +77,14 @@ export class AuditPreviewComponent implements OnInit {
 
   accessContractId: string;
   hasReport: Signal<boolean> = computed(() => {
-    if (this.audit().type === 'EVIDENCE_AUDIT') {
+    const audit = this.audit();
+    if (audit.type === 'EVIDENCE_AUDIT') {
       // Evidence audit may not have a report if "data" has "No report generated" in it.
-      return !this.audit().events.some((e) => /No report generated/i.test(e.data));
+      return !audit.events.some((e) => /No report generated/i.test(e.data));
+    }
+    if (audit.type === AuditOperation.TRACEABILITY_CHAIN_AUDIT) {
+      // Chain audit report only exists once the reporting sub-step has completed successfully.
+      return audit.events.some((e) => /REPORTING$/i.test(e.type) && e.outcome === 'OK');
     }
     return true;
   });

--- a/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-download.service.ts
+++ b/ui/ui-frontend/projects/referential/src/app/logbook-operation/logbook-download.service.ts
@@ -239,6 +239,10 @@ export class LogbookDownloadService extends SearchService<IEvent> {
       // Evidence audit may not have a report if "data" has "No report generated" in it.
       return !event.events.some((e) => /No report generated/i.test(e.data));
     }
+    if (['TRACEABILITY_CHAIN_AUDIT'].includes(event.type)) {
+      // Chain audit report only exists once the reporting sub-step has completed successfully.
+      return event.events.some((e) => /REPORTING$/i.test(e.type) && e.outcome === 'OK');
+    }
     return true;
   }
 }


### PR DESCRIPTION
pour un TRACEABILITY_CHAIN_AUDIT (audit de chaînage), le bouton « Télécharger le rapport » était toujours affiché/actif une fois l'opération terminée — y compris pour les statuts KO où le rapport n'avait en
  réalité jamais été généré/stocké (par exemple quand le workflow échouait avant d'atteindre sa sous-étape TRACEABILITY_CHAIN_AUDIT_REPORTING). La requête de téléchargement tombait alors sur le module AccessExternalModule de
  VITAM, qui renvoyait le 404 constaté dans le ticket.

  Correctif (en suivant le pattern déjà existant du Fix #14961 / commit 511535122, qui fait la même chose pour EVIDENCE_AUDIT) : le bouton n'est désormais affiché/actif que lorsqu'un sous-événement
  TRACEABILITY_CHAIN_AUDIT_REPORTING réussi est présent — quel que soit le statut global (OK, WARNING ou KO). Un audit de chaînage KO dont l'étape de reporting a bien abouti (cas courant : anomalies détectées et rapportées)
  affiche donc toujours un bouton fonctionnel, tandis qu'un audit KO ayant échoué avant même l'étape de reporting ne propose plus un bouton qui renvoie un 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit previews now show a report only when traceability chain audit reporting completes successfully.
  * Report downloads now apply the same success criteria for traceability chain audits.
  * Audits with failed preparation or unsuccessful outcomes no longer appear to have an available report.

* **Tests**
  * Added coverage for successful and unsuccessful traceability chain audit reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->