### PR TITLE
Bug #16662: [Organisation] Missing snackbar when downloading the SSO IdP/SP metadata file.

### DIFF
--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.spec.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.spec.ts
@@ -40,7 +40,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { of, Subject } from 'rxjs';
 
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { BASE_URL, OtpState } from 'vitamui-library';
+import { BASE_URL, OtpState, SnackBarService } from 'vitamui-library';
 import type { Customer, IdentityProvider } from 'vitamui-library';
 import { VitamUICommonTestModule } from 'vitamui-library/testing';
 import { IdentityProviderService } from './identity-provider.service';
@@ -161,6 +161,7 @@ describe('SsoTabComponent', () => {
         ProviderApiService,
         { provide: BASE_URL, useValue: '/fake-api' },
         { provide: MatDialog, useValue: matDialogSpy },
+        { provide: SnackBarService, useValue: { notifyDownloadStarted: vi.fn().mockName('SnackBarService.notifyDownloadStarted') } },
         {
           provide: IdentityProviderService,
           useValue: {

--- a/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.ts
+++ b/ui/ui-frontend/projects/identity/src/app/customer/customer-preview/sso-tab/sso-tab.component.ts
@@ -39,7 +39,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
 
 import type { Customer, IdentityProvider } from 'vitamui-library';
-import { DownloadUtils } from 'vitamui-library';
+import { DownloadUtils, SnackBarService } from 'vitamui-library';
 import { IdentityProviderCreateComponent } from './identity-provider-create/identity-provider-create.component';
 import { IdentityProviderService } from './identity-provider.service';
 import { ProviderApiService } from './provider-api.service';
@@ -54,6 +54,7 @@ export class SsoTabComponent implements OnDestroy, OnInit {
   dialog = inject(MatDialog);
   private identityProviderService = inject(IdentityProviderService);
   private providerApi = inject(ProviderApiService);
+  private snackBarService = inject(SnackBarService);
 
   providers: IdentityProvider[];
   panel1Position = 'current';
@@ -129,7 +130,10 @@ export class SsoTabComponent implements OnDestroy, OnInit {
   }
 
   downloadFile(url: string): void {
-    this.providerApi.getFileByUrl(url).subscribe((response: any) => DownloadUtils.loadFromBlob(response, response.body.type));
+    this.providerApi.getFileByUrl(url).subscribe((response: any) => {
+      DownloadUtils.loadFromBlob(response, response.body.type);
+      this.snackBarService.notifyDownloadStarted();
+    });
   }
 
   private refreshAvailableDomains() {


### PR DESCRIPTION
[Orga]Absence du snackbar lors du téléchargement du fichier Métadonnées SSO IDP/SP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Experience**
  - Added a notification confirming that identity provider metadata downloads have started.
  - Download behavior remains unchanged while providing clearer feedback during the download process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->