### PR TITLE
Bug #16831: [Collect] The "Terminer" button remains enabled after uploading an unsupported JSLT file or after removing the selected file.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.html
@@ -621,6 +621,7 @@
               [maxSizeInBytes]="10 * 1024"
               [directoryMode]="false"
               [extensions]="['.jslt']"
+              [formControl]="jsltFileControl"
               (filesChanged)="handleJsltFile($event)"
             >
             </vitamui-file-selector>
@@ -628,7 +629,7 @@
         </mat-dialog-content>
         <mat-dialog-actions>
           <div>
-            <button (click)="validateAndCreateProject()" class="btn primary" type="button">
+            <button (click)="validateAndCreateProject()" [disabled]="jsltFileControl.invalid" class="btn primary" type="button">
               {{ 'COMMON.SUBMIT' | translate }}
             </button>
             <button (click)="onClose()" class="btn cancel link" type="button">

--- a/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/projects/create-project/create-project.component.ts
@@ -131,6 +131,7 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
   errorMessage: string;
   schemaOptions: ItemNode<SchemaElement>[];
   filesToUploadControl: FormControl<File[]> = new FormControl([], [Validators.required]);
+  jsltFileControl: FormControl<File[]> = new FormControl([], [Validators.required]);
   zipFileStatus$: Observable<ZipFileStatus>;
   units: Unit[];
   compressedZip: Blob;
@@ -293,6 +294,8 @@ export class CreateProjectComponent implements OnInit, AfterViewChecked {
         this.logger.error('Error reading JSLT file:', error);
         this.isLoading = false;
       }
+    } else {
+      this.projectForm.get('transformationRules').setValue(null);
     }
   }
 


### PR DESCRIPTION
[Collect]Le bouton « Terminer » reste cliquable à l'étape d'import JSLT (Extension non autorisée / Fichier supprimé)