### PR TITLE
Bug #16836: [Search] The information tooltip remains displayed after selecting a preservation scenario.

### DIFF
--- a/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/ellipsis/ellipsis.directive.ts
+++ b/ui/ui-frontend/projects/vitamui-library/src/app/modules/directives/ellipsis/ellipsis.directive.ts
@@ -78,6 +78,7 @@ export class EllipsisDirective implements OnInit, AfterViewInit, OnDestroy {
   private isTruncated = false;
   private overlayRef: OverlayRef;
   private tooltipRef: ComponentRef<CommonTooltipComponent>;
+  private isConnectedInterval: ReturnType<typeof setInterval>;
 
   ngOnInit(): void {
     this.domElement = this.elementRef.nativeElement;
@@ -109,6 +110,7 @@ export class EllipsisDirective implements OnInit, AfterViewInit, OnDestroy {
   }
 
   @HostListener('mouseleave')
+  @HostListener('click')
   onMouseLeave() {
     this.closeTooltip();
   }
@@ -124,10 +126,15 @@ export class EllipsisDirective implements OnInit, AfterViewInit, OnDestroy {
       this.tooltipRef = this.overlayRef.attach(new ComponentPortal(CommonTooltipComponent));
       this.tooltipRef.instance.text = this.domElement.textContent;
       this.tooltipRef.instance.position = 'BOTTOM';
+
+      this.isConnectedInterval = setInterval(() => {
+        if (!this.domElement.isConnected) this.closeTooltip();
+      }, 100);
     }
   }
 
   private closeTooltip() {
+    clearInterval(this.isConnectedInterval);
     if (this.overlayRef?.hasAttached()) this.overlayRef.detach();
   }
 


### PR DESCRIPTION
Le tooltip reste affiché après le clic sur le scénario et gêne l’utilisation de l’interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now close automatically when their associated element is removed from the page.
  * Clicking the element closes its open tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->