### PR TITLE
Bug #14841: [Ontology] The ontology import action is enabled for all tenants instead of being restricted to Tenant 1.

### DIFF
--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology.component.spec.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology.component.spec.ts
@@ -40,7 +40,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { InjectorModule, LoggerModule, SchemaService, SecurityService } from 'vitamui-library';
+import { InjectorModule, LoggerModule, SchemaService, SecurityService, StartupService } from 'vitamui-library';
 import { VitamUICommonTestModule } from 'vitamui-library/testing';
 
 import { OntologyComponent } from './ontology.component';
@@ -83,6 +83,7 @@ describe('OntologyComponent', () => {
       providers: [
         { provide: OntologyService, useValue: {} },
         { provide: SchemaService, useValue: {} },
+        { provide: StartupService, useValue: { getConfigStringValue: (_param: string) => '' } },
         {
           provide: SecurityService,
           useValue: {

--- a/ui/ui-frontend/projects/referential/src/app/ontology/ontology.component.ts
+++ b/ui/ui-frontend/projects/referential/src/app/ontology/ontology.component.ts
@@ -49,6 +49,7 @@ import {
   SchemaService,
   SecurityService,
   SidenavPage,
+  StartupService,
 } from 'vitamui-library';
 import { ImportDialogParam, ReferentialTypes } from '../shared/import-dialog/import-dialog-param.interface';
 import { ImportDialogComponent } from '../shared/import-dialog/import-dialog.component';
@@ -70,6 +71,7 @@ export class OntologyComponent extends SidenavPage<Ontology | SchemaElement> imp
   private securityService = inject(SecurityService);
   private ontologyService = inject(OntologyService);
   private schemaService = inject(SchemaService);
+  private startupService = inject(StartupService);
 
   private previousTab: string | null = null;
   private subscription: Subscription;
@@ -77,6 +79,7 @@ export class OntologyComponent extends SidenavPage<Ontology | SchemaElement> imp
   search = '';
   filters: string;
   tenantId: number;
+  vitamAdminTenant: number;
   canImportOntology: boolean;
   canImportSchema: boolean;
   canCreateVocabulary: boolean;
@@ -91,8 +94,8 @@ export class OntologyComponent extends SidenavPage<Ontology | SchemaElement> imp
   }
 
   ngOnInit(): void {
+    this.vitamAdminTenant = +this.startupService.getConfigStringValue('VITAM_ADMIN_TENANT');
     this.initializeTenantId();
-    this.initializePermissions();
     this.subscribeToTenantChanges();
 
     this.subscription = this.route.queryParams.subscribe((params) => {
@@ -107,6 +110,7 @@ export class OntologyComponent extends SidenavPage<Ontology | SchemaElement> imp
   private initializeTenantId(): void {
     this.route.params.subscribe((params) => {
       this.tenantId = +params['tenantIdentifier'];
+      this.initializePermissions();
     });
   }
 
@@ -116,7 +120,9 @@ export class OntologyComponent extends SidenavPage<Ontology | SchemaElement> imp
 
   private initializePermissions(): void {
     this.canImportSchema = this.securityService.hasRole(ApplicationId.ONTOLOGY_APP, Role.ROLE_IMPORT_SCHEMAS, this.tenantId);
-    this.canImportOntology = this.securityService.hasRole(ApplicationId.ONTOLOGY_APP, Role.ROLE_IMPORT_ONTOLOGIES, this.tenantId);
+    this.canImportOntology =
+      this.securityService.hasRole(ApplicationId.ONTOLOGY_APP, Role.ROLE_IMPORT_ONTOLOGIES, this.tenantId) &&
+      this.tenantId === this.vitamAdminTenant;
     this.canCreateVocabulary = this.securityService.hasRole(ApplicationId.ONTOLOGY_APP, Role.ROLE_CREATE_ONTOLOGIES, this.tenantId);
   }
 


### PR DESCRIPTION
le profil gestion dans les tenants métiers doit permettre de mettre à jour les extensions du schéma mais pas de mettre à jour les vocabulaires de l'ontologie.

Cette mise à jour n'est possible que sur le tenant 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ontology import access is now restricted to the configured administration tenant.
  * Permissions are evaluated after the tenant context is initialized, improving access-control accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->