### PR TITLE
Bug #16819: [Collect] The “The operation is in progress...” notification remains displayed when an error occurs with an invalid CSV.

### DIFF
--- a/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.ts
+++ b/ui/ui-frontend/projects/collect/src/app/collect/archive-search-collect/update-units-metadata/update-units-metadata.component.ts
@@ -77,7 +77,7 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
   updateUnitsMetadata() {
     const fileToUpload = this.fileControl.value[0];
     this.isLoadingData = true;
-    this.snackBarService.open({
+    const waitSnackBarRef = this.snackBarService.open({
       message: 'COLLECT.UPDATE_UNITS_METADATA.WAIT_MESSAGE',
       duration: 100_000,
     });
@@ -96,6 +96,7 @@ export class UpdateUnitsMetadataComponent implements OnDestroy {
         error: (error: any) => {
           this.isLoadingData = false;
           this.dialogRef.close(true);
+          waitSnackBarRef.then((snackBarRef) => snackBarRef.dismiss());
           this.logger.error('Error message :', error);
           return throwError(error);
         },


### PR DESCRIPTION
La notification « L'opération est en cours... » reste affichée en cas d'erreur sur un CSV invalide